### PR TITLE
fix(docker): serve public/ static assets in frontend runner image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,6 +25,7 @@ ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
 ENV NEXT_PUBLIC_APP_NAME=$NEXT_PUBLIC_APP_NAME
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/next.config.ts ./next.config.ts
 EXPOSE 3000


### PR DESCRIPTION
## Problem

The sidebar / login logo `/brand/tokenhub-logo.png` renders as a **broken image** in the Docker-deployed frontend.

## Root cause

`frontend/public/brand/tokenhub-logo.png` exists and is a valid PNG, but the **runner stage of `frontend/Dockerfile` never copies `public/`** into the final image:

```dockerfile
COPY --from=builder /app/package.json ./package.json
COPY --from=builder /app/.next ./.next
COPY --from=builder /app/node_modules ./node_modules
COPY --from=builder /app/next.config.ts ./next.config.ts
```

`next start` serves static files from `public/`. With that directory absent, requests for `/brand/tokenhub-logo.png` (and any other public asset) fall through to the App Router catch-all `app/[...view]/page.tsx`, which returns the HTML shell:

```
$ curl -I http://localhost:3000/brand/tokenhub-logo.png
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8   # <- HTML, not the PNG
```

The browser receives HTML where it expects an image → broken image icon.

## Fix

Copy `public/` into the runner stage:

```dockerfile
COPY --from=builder /app/public ./public
```

## Verification

Rebuilt the frontend image via Docker Compose:

```
$ curl -I http://localhost:3000/brand/tokenhub-logo.png
HTTP/1.1 200 OK
Content-Type: image/png
Content-Length: 184441
```

Logo renders correctly on the login page. This also fixes any other asset placed under `public/`.