### PR TITLE
fix(ui): hide group-title text in collapsed sidebar to stop icon clipping

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -386,6 +386,10 @@ button {
   display: none;
 }
 
+.sidebar.collapsed .nav-title span {
+  display: none;
+}
+
 .nav {
   display: grid;
   gap: 4px;


### PR DESCRIPTION
## Problem

When the left sidebar is collapsed, it should show only each menu's icon, centered in the rail. Instead the nav icons are pushed to the right edge and their left half is clipped.

## Root cause

In collapsed mode, nav-item labels (`.nav-item span`) and the group-title chevron (`.nav-title svg`) are hidden, but the **group-title text span was only made `color: transparent`** — it kept `display: block` and its full width:

```css
.sidebar.collapsed .nav-title {
  color: transparent;   /* invisible, but the text still occupies width */
  ...
}
.sidebar.collapsed .nav-title svg { display: none; }   /* chevron hidden */
.sidebar.collapsed .nav-item span { display: none; }   /* item labels hidden */
/* group-title span was never hidden */
```

Measured in the collapsed state:

| Element | Width | Note |
| --- | --- | --- |
| sidebar rail | 76px | correct collapsed width |
| group-title span "Platform Workspace" | **90px**, `display:block` | transparent but still laid out |
| `.nav` / `.nav-item` row | **90px** (left 18 → right 108) | stretched by the title text |
| icon svg | at x 54–71 | jammed against the 76px edge |

The 90px transparent title text stretches the auto-sized grid column of `.sidebar-nav-scroll`, making every `.nav-item` row 90px — wider than the 76px rail. With `overflow: hidden` on the sidebar the overflow is clipped, and since items center their icon within the 90px row, the icons land against the right edge with the left half cut off.

## Fix

Hide the group-title text in collapsed mode too:

```css
.sidebar.collapsed .nav-title span {
  display: none;
}
```

## Verification

Rebuilt the frontend and collapsed the sidebar. The nav row shrinks **90px → 39px** and icons render centered in the rail (svg at x 29–46). Before/after confirmed visually.