### PR TITLE
fix(auth): protect the last platform admin

### DIFF
--- a/backend/internal/server/store.go
+++ b/backend/internal/server/store.go
@@ -2240,6 +2240,7 @@ func (s *GormStore) UpdateAdminUser(id string, patch AdminUser, password string)
 	if err := s.db.First(&user, "id = ?", id).Error; err != nil {
 		return AdminUser{}, notFound(err, "admin_user_not_found", "Admin user not found")
 	}
+	wasActivePlatformAdmin := activePlatformAdmin(user)
 	if patch.Username != "" {
 		var count int64
 		if err := s.db.Model(&AdminUser{}).Where("id <> ? AND username = ?", id, patch.Username).Count(&count).Error; err != nil {
@@ -2273,6 +2274,11 @@ func (s *GormStore) UpdateAdminUser(id string, patch AdminUser, password string)
 	if password != "" {
 		user.PasswordHash = HashSecret(password)
 	}
+	if wasActivePlatformAdmin && !activePlatformAdmin(user) {
+		if err := ensureAnotherActivePlatformAdmin(s.db, user.ID); err != nil {
+			return AdminUser{}, err
+		}
+	}
 	user.UpdatedAt = time.Now().UTC()
 	if err := s.db.Save(&user).Error; err != nil {
 		return AdminUser{}, err
@@ -2289,12 +2295,10 @@ func (s *GormStore) DeleteAdminUser(id string) error {
 		if err := tx.First(&user, "id = ?", id).Error; err != nil {
 			return notFound(err, "admin_user_not_found", "Admin user not found")
 		}
-		var activeUsers int64
-		if err := tx.Model(&AdminUser{}).Where("status = ?", StatusActive).Count(&activeUsers).Error; err != nil {
-			return err
-		}
-		if activeUsers <= 1 && user.Status == StatusActive {
-			return NewHTTPError(400, "last_admin_user", "Cannot delete the last active admin user")
+		if activePlatformAdmin(user) {
+			if err := ensureAnotherActivePlatformAdmin(tx, user.ID); err != nil {
+				return err
+			}
 		}
 		if err := tx.Where("user_id = ?", id).Delete(&AdminSession{}).Error; err != nil {
 			return err
@@ -2304,6 +2308,24 @@ func (s *GormStore) DeleteAdminUser(id string) error {
 		}
 		return tx.Delete(&user).Error
 	})
+}
+
+func activePlatformAdmin(user AdminUser) bool {
+	role := strings.ToLower(strings.TrimSpace(user.Role))
+	return user.Status == StatusActive && (role == "admin" || role == "system_admin")
+}
+
+func ensureAnotherActivePlatformAdmin(db *gorm.DB, excludedUserID string) error {
+	var count int64
+	if err := db.Model(&AdminUser{}).
+		Where("id <> ? AND status = ? AND lower(role) IN ?", excludedUserID, StatusActive, []string{"admin", "system_admin"}).
+		Count(&count).Error; err != nil {
+		return err
+	}
+	if count == 0 {
+		return NewHTTPError(400, "last_admin_user", "Cannot remove, disable, or demote the last active platform administrator")
+	}
+	return nil
 }
 
 func (s *GormStore) CreateAdminPasswordResetToken(userID string, createdBy string, ttl time.Duration) (string, AdminPasswordResetToken, error) {

--- a/backend/internal/server/store_test.go
+++ b/backend/internal/server/store_test.go
@@ -1,0 +1,65 @@
+package server
+
+import "testing"
+
+func TestDeleteAdminUserProtectsLastActivePlatformAdmin(t *testing.T) {
+	store := NewMemoryStore()
+	admin := createTestAdminUser(t, store, "only-admin", "admin")
+	member := createTestAdminUser(t, store, "member", "user")
+
+	if err := store.DeleteAdminUser(admin.ID); AsHTTPError(err).Code != "last_admin_user" {
+		t.Fatalf("expected last admin deletion to be rejected, got %v", err)
+	}
+	if err := store.DeleteAdminUser(member.ID); err != nil {
+		t.Fatalf("expected ordinary user deletion to remain allowed, got %v", err)
+	}
+}
+
+func TestUpdateAdminUserProtectsLastActivePlatformAdmin(t *testing.T) {
+	tests := []struct {
+		name  string
+		patch AdminUser
+	}{
+		{name: "disable", patch: AdminUser{Status: StatusDisabled}},
+		{name: "demote", patch: AdminUser{Role: "user"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewMemoryStore()
+			admin := createTestAdminUser(t, store, "only-admin-"+tt.name, "system_admin")
+			createTestAdminUser(t, store, "member-"+tt.name, "user")
+
+			if _, err := store.UpdateAdminUser(admin.ID, tt.patch, ""); AsHTTPError(err).Code != "last_admin_user" {
+				t.Fatalf("expected last admin update to be rejected, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAdminUserChangesAllowedWhenAnotherAdminRemains(t *testing.T) {
+	store := NewMemoryStore()
+	first := createTestAdminUser(t, store, "first-admin", "admin")
+	createTestAdminUser(t, store, "second-admin", "system_admin")
+
+	updated, err := store.UpdateAdminUser(first.ID, AdminUser{Role: "user"}, "")
+	if err != nil {
+		t.Fatalf("expected demotion with another active admin to succeed, got %v", err)
+	}
+	if updated.Role != "user" {
+		t.Fatalf("expected demoted user role, got %q", updated.Role)
+	}
+}
+
+func createTestAdminUser(t *testing.T, store *GormStore, username string, role string) AdminUser {
+	t.Helper()
+	user, err := store.CreateAdminUser(AdminUser{
+		Username: username,
+		Email:    username + "@example.com",
+		Role:     role,
+		Status:   StatusActive,
+	}, "test-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return user
+}


### PR DESCRIPTION
## What changed

- prevent deletion of the last active `admin` or `system_admin` account
- apply the same invariant when an administrator is disabled or demoted
- keep ordinary-user deletion unchanged
- add focused store tests for delete, disable, demote, and multi-admin cases

## Why

The previous deletion guard counted every active user. If an ordinary user existed, the only platform administrator could be deleted. Updates also had no equivalent guard, so the final administrator could be disabled or demoted.

## Impact

TokenHub now preserves at least one active platform administrator while still allowing administrator changes when another active administrator remains.

## Validation

- focused `go test` coverage for the new invariant
- `go vet ./...`
- `git diff --check`
