### PR TITLE
fix(i18n): localize native required-field validation message

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -680,6 +680,7 @@ let activeLanguage: AppLanguage = "en";
 
 const translations: Record<Exclude<AppLanguage, "zh-CN">, Record<string, string>> = {
   en: {
+    "请填写此字段": "Please fill out this field",
     "总览": "Overview",
     "网关概览": "Gateway Overview",
     "开始使用": "Get Started",
@@ -1809,6 +1810,7 @@ const translations: Record<Exclude<AppLanguage, "zh-CN">, Record<string, string>
     "点击启用 API Key": "Click to enable API Key",
     },
   ja: {
+    "请填写此字段": "このフィールドを入力してください",
     "总览": "概要",
     "网关概览": "ゲートウェイ概要",
     "开始使用": "はじめに",
@@ -2939,6 +2941,22 @@ function tx(value: string | undefined | null) {
   if (!value) return "";
   if (activeLanguage === "zh-CN") return value;
   return translations[activeLanguage][value] ?? translateGeneratedText(value, activeLanguage) ?? value;
+}
+
+// Localize the browser's native constraint-validation bubble (e.g. the required-field
+// message) so it follows the app language instead of the browser locale.
+function handleRequiredFieldInvalid(event: {
+  currentTarget: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+}) {
+  const el = event.currentTarget;
+  el.setCustomValidity(el.validity.valueMissing ? tx("请填写此字段") : "");
+}
+
+// Clear any custom validity message once the user edits the field, so re-validation works.
+function clearCustomValidity(event: {
+  currentTarget: HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+}) {
+  event.currentTarget.setCustomValidity("");
 }
 
 function translateGeneratedText(value: string, language: Exclude<AppLanguage, "zh-CN">) {
@@ -14350,7 +14368,7 @@ function ProviderInlineField({
     return (
       <label className="field" data-field-key={field.key}>
         <span>{tx(field.label)}</span>
-        <select value={value} onChange={(event) => onChange(event.target.value)} required={field.required}>
+        <select value={value} onChange={(event) => { clearCustomValidity(event); onChange(event.target.value); }} onInvalid={handleRequiredFieldInvalid} required={field.required}>
           <option value="">{tx("请选择")}</option>
           {options.map((option) => (
             <option key={option.value} value={option.value}>{tx(option.label)}</option>
@@ -14370,7 +14388,8 @@ function ProviderInlineField({
           data-lpignore={autoComplete === "off" || autoComplete === "new-password" ? "true" : undefined}
           name={inputName}
           value={value}
-          onChange={(event) => onChange(event.target.value)}
+          onChange={(event) => { clearCustomValidity(event); onChange(event.target.value); }}
+          onInvalid={handleRequiredFieldInvalid}
           placeholder={tx(field.placeholder)}
           required={field.required}
         />
@@ -14405,7 +14424,8 @@ function ProviderInlineField({
         name={inputName}
         value={value}
         type={field.type === "number" ? "number" : field.type === "password" ? "password" : "text"}
-        onChange={(event) => onChange(event.target.value)}
+        onChange={(event) => { clearCustomValidity(event); onChange(event.target.value); }}
+        onInvalid={handleRequiredFieldInvalid}
         placeholder={tx(field.placeholder)}
         required={field.required}
       />
@@ -14640,7 +14660,7 @@ function FieldInput({
     return (
       <label className="field" data-field-key={field.key}>
         <span>{tx(field.label)}</span>
-        <select value={value} onChange={(event) => onChange(event.target.value)} required={field.required} disabled={readOnly}>
+        <select value={value} onChange={(event) => { clearCustomValidity(event); onChange(event.target.value); }} onInvalid={handleRequiredFieldInvalid} required={field.required} disabled={readOnly}>
           <option value="">{tx("请选择")}</option>
           {options.map((option) => (
             <option key={option.value} value={option.value}>{tx(option.label)}</option>
@@ -14660,7 +14680,8 @@ function FieldInput({
           data-lpignore={autoComplete === "off" || autoComplete === "new-password" ? "true" : undefined}
           name={inputName}
           value={value}
-          onChange={(event) => onChange(event.target.value)}
+          onChange={(event) => { clearCustomValidity(event); onChange(event.target.value); }}
+          onInvalid={handleRequiredFieldInvalid}
           placeholder={tx(field.placeholder)}
           required={field.required}
           readOnly={readOnly}
@@ -14710,7 +14731,8 @@ function FieldInput({
         name={inputName}
         value={value}
         type={field.type === "number" ? "number" : field.type === "password" ? "password" : "text"}
-        onChange={(event) => onChange(event.target.value)}
+        onChange={(event) => { clearCustomValidity(event); onChange(event.target.value); }}
+        onInvalid={handleRequiredFieldInvalid}
         placeholder={tx(field.placeholder)}
         required={field.required}
         readOnly={readOnly}


### PR DESCRIPTION
## Problem

In the **Model Catalog** creation form (and other resource forms), leaving a required field empty and clicking **Save** shows the browser's native validation bubble in **Chinese** (`请填写此字段`) even when the app language is set to English or Japanese.

The forms use the HTML `required` attribute, so the validation message is rendered by the browser in the **browser locale**, completely independent of the app's i18n (`tx()` / `activeLanguage`). Switching the app to English does not change it.

## Fix

Localize the native constraint-validation bubble so it follows the **app language**:

- Add an `onInvalid` handler that overrides the `valueMissing` message with the app-language string via `tx("请填写此字段")`. It only overrides the required/empty case, leaving other constraints (e.g. `number`) to their defaults.
- Clear the custom validity on change so re-validation works after the user types.
- Wired into the shared `FieldInput` and `ProviderInlineField` components (select / textarea / input), which cover the Model Catalog and all resource/provider forms.
- Added the `请填写此字段` translation key for `en` (`Please fill out this field`) and `ja` (`このフィールドを入力してください`).

## Testing

- Frontend production build (`next build`, which type-checks) passes.
- Verified via Docker: switch app language to English/日本語, leave a required Model Catalog field empty, click Save → bubble now shows the message in the selected language.

## Notes

Scope is limited to the two shared field components. A few hand-written `<input required>` (e.g. the login form) don't use these components and are out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)