### PR TITLE
修复: 放宽 CORS 允许头并增加流式响应显式状态码，提升第三方工具兼容性

### DIFF
--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -330,6 +330,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("cache-control", "no-cache")
 		w.Header().Set("x-request-id", routed.Call.RequestID)
 		s.writeRouteHeaders(w, routed.Call, route, 1)
+		w.WriteHeader(http.StatusOK)
 		usage, err := adapter.ChatStream(leaseCtx, route.Provider, route.ProviderModel, req, w)
 		if leaseErr := coordinationLeaseError(leaseCtx); leaseErr != nil {
 			err = leaseErr
@@ -6486,7 +6487,18 @@ func (s *Server) cors(next http.Handler) http.Handler {
 		}
 
 		w.Header().Set("access-control-allow-methods", "GET,POST,PATCH,DELETE,OPTIONS")
-		w.Header().Set("access-control-allow-headers", "authorization,content-type")
+		allowHeaders := "authorization,content-type"
+		if reqHeaders := r.Header.Get("access-control-request-headers"); reqHeaders != "" {
+			seen := map[string]bool{"authorization": true, "content-type": true}
+			for _, h := range strings.Split(reqHeaders, ",") {
+				h = strings.ToLower(strings.TrimSpace(h))
+				if h != "" && !seen[h] {
+					allowHeaders += "," + h
+					seen[h] = true
+				}
+			}
+		}
+		w.Header().Set("access-control-allow-headers", allowHeaders)
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -330,7 +330,10 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("cache-control", "no-cache")
 		w.Header().Set("x-request-id", routed.Call.RequestID)
 		s.writeRouteHeaders(w, routed.Call, route, 1)
-		w.WriteHeader(http.StatusOK)
+w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
 		usage, err := adapter.ChatStream(leaseCtx, route.Provider, route.ProviderModel, req, w)
 		if leaseErr := coordinationLeaseError(leaseCtx); leaseErr != nil {
 			err = leaseErr


### PR DESCRIPTION
## 概述

  修复 #19：WorkBuddy 等第三方 AI 工具通过 TokenHub 代理后发送消息无响应返回的问题。

  ## 根因分析

  经过 HTTP 协议测试和公开资料交叉验证，定位到两个原因：

  1. **CORS 预检拦截**：WorkBuddy 在请求中额外携带 `api-key` 等自定义头，
     浏览器检测到非简单头后自动发起 OPTIONS 预检。TokenHub 硬编码只允许
     `authorization,content-type` 两个头，`api-key` 不在允许列表中，
     CORS 检查失败导致真实 POST 请求被浏览器拦截，客户端表现为空响应。

  2. **流式状态码隐式发送**：流式路径未显式调用 `WriteHeader(200)`，
     部分客户端在解析 SSE 时对隐式状态码处理不佳。

  ## 修复内容

  1. CORS 中间件改为读取客户端 `Access-Control-Request-Headers` 的值，
     与默认头合并后动态回显，同时去重避免重复值

  2. 流式 SSE 响应在数据写入前显式调用 `w.WriteHeader(http.StatusOK)`

  ## 验证

  - [x] `go build ./cmd/tokenhub` 编译通过
  - [x] CORS 预检测试：OPTIONS 请求携带 `api-key` 头，响应正确允许
  - [x] CORS 预检测试：标准请求头不受影响
  - [x] 简单 POST 请求不受影响
  - [x] 流式 SSE 响应状态码和 Content-Type 正确

  Closes #19