### PR TITLE
ci: add container and binary release workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,97 @@
+name: Docker images
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.component }} image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: backend
+            image: tokenhub-backend
+            context: .
+            dockerfile: backend/Dockerfile
+            cache_scope: tokenhub-backend
+            description: TokenHub API gateway backend
+          - component: frontend
+            image: tokenhub-frontend
+            context: frontend
+            dockerfile: frontend/Dockerfile
+            cache_scope: tokenhub-frontend
+            description: TokenHub administration console
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=TokenHub ${{ matrix.component }}
+            org.opencontainers.image.description=${{ matrix.description }}
+            org.opencontainers.image.licenses=Apache-2.0
+
+      - name: Build and publish image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          pull: true
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.cache_scope }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.cache_scope }}
+          provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || 'false' }}
+          sbom: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker images
 on:
   push:
     branches:
-      - main
+      - "**"
     tags:
       - "v*"
   pull_request:
@@ -24,6 +24,8 @@ jobs:
     name: Build ${{ matrix.component }} image
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      PUBLISH_IMAGE: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
     permissions:
       contents: read
       packages: write
@@ -55,7 +57,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GitHub Container Registry
-        if: github.event_name != 'pull_request'
+        if: env.PUBLISH_IMAGE == 'true'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -88,10 +90,10 @@ jobs:
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           pull: true
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ env.PUBLISH_IMAGE == 'true' }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.cache_scope }}
           cache-to: type=gha,mode=max,scope=${{ matrix.cache_scope }}
-          provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || 'false' }}
-          sbom: ${{ github.event_name != 'pull_request' }}
+          provenance: ${{ env.PUBLISH_IMAGE == 'true' && 'mode=max' || 'false' }}
+          sbom: ${{ env.PUBLISH_IMAGE == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,10 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v7.0.1
         with:
           name: tokenhub-binaries
-          path: dist/*
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/checksums.txt
           if-no-files-found: error
           retention-days: 7
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Binary release
 on:
   push:
     branches:
-      - main
+      - "**"
     tags:
       - "v*"
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Binary release
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    name: Build binary snapshot
+    if: github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
+
+      - name: Build snapshot with GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser
+          version: v2.17.0
+          args: release --snapshot --clean
+
+      - name: Upload snapshot artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v7.0.1
+        with:
+          name: tokenhub-binaries
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Publish binary release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
+
+      - name: Publish release with GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser
+          version: v2.17.0
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,59 @@
+version: 2
+
+project_name: tokenhub
+
+builds:
+  - id: tokenhub
+    dir: backend
+    main: ./cmd/tokenhub
+    binary: tokenhub
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -buildid=
+    env:
+      - CGO_ENABLED=1
+      - >-
+        {{- if and (eq .Os "linux") (eq .Arch "amd64") }}CC=zig cc -target x86_64-linux-musl{{- end }}
+        {{- if and (eq .Os "linux") (eq .Arch "arm64") }}CC=zig cc -target aarch64-linux-musl{{- end }}
+        {{- if and (eq .Os "windows") (eq .Arch "amd64") }}CC=zig cc -target x86_64-windows-gnu{{- end }}
+    targets:
+      - linux_amd64_v1
+      - linux_arm64_v8.0
+      - windows_amd64_v1
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+archives:
+  - ids:
+      - tokenhub
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+    files:
+      - LICENSE
+      - README.md
+      - README.zh-CN.md
+      - README.ja.md
+      - src: data/model-catalog.yaml
+        dst: data
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+
+release:
+  prerelease: auto

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,9 +7,7 @@ RUN npm ci
 FROM node:22-alpine AS builder
 
 WORKDIR /app
-ARG NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
 ARG NEXT_PUBLIC_APP_NAME=TokenHub
-ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
 ENV NEXT_PUBLIC_APP_NAME=$NEXT_PUBLIC_APP_NAME
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .

--- a/frontend/app/(console)/layout.tsx
+++ b/frontend/app/(console)/layout.tsx
@@ -1,5 +1,8 @@
 import { AdminConsole } from "@/features/admin/shell/admin-console";
+import { runtimeAPIBaseURL } from "@/lib/runtime-config";
+
+export const dynamic = "force-dynamic";
 
 export default function ConsoleLayout() {
-  return <AdminConsole />;
+  return <AdminConsole defaultBaseURL={runtimeAPIBaseURL()} />;
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,8 @@
 import { AdminConsole } from "@/features/admin/shell/admin-console";
+import { runtimeAPIBaseURL } from "@/lib/runtime-config";
+
+export const dynamic = "force-dynamic";
 
 export default function LoginPage() {
-  return <AdminConsole />;
+  return <AdminConsole defaultBaseURL={runtimeAPIBaseURL()} />;
 }

--- a/frontend/features/admin/core/types.tsx
+++ b/frontend/features/admin/core/types.tsx
@@ -624,9 +624,6 @@ export type ConfirmState<T> = {
 
 export type SettingsTabKey = "settings" | "role-configs" | "identity-providers";
 
-export const defaultBaseURL =
-  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
-
 export const sessionStorageKey = "tokenhub.admin.session";
 
 export const oauthBaseURLStorageKey = "tokenhub.admin.oauth.base_url";

--- a/frontend/features/admin/shell/admin-console.tsx
+++ b/frontend/features/admin/shell/admin-console.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { type LoadedData, loadPlanForView, mergeLoadedData } from "../core/data-loading";
 import { allNavGroupTitles, canAccessView, defaultViewForRole, rememberRecentView, standaloneViewMeta } from "../core/navigation";
 import { clearOAuthLoginResult, clearPendingOAuthBaseURL, clearProviderAccountOAuthResultFromLocation, clearSavedSession, forwardOAuthAuthorizationResponse, hasPendingProviderAccountOAuthResult, isOAuthAuthorizationResponse, readOAuthLoginResult, readPendingOAuthBaseURL, readProviderAccountOAuthResultFromLocation, readSavedSession, savePendingProviderAccountOAuthResult, saveSession } from "../core/session";
-import { type AdminResource, type AdminUser, type AlertDelivery, type AlertEvent, type APIKey, type AppData, type ApprovalRequest, type AuditEvent, authExpiredEventName, type ConfirmState, defaultBaseURL, languageStorageKey, type LoginIdentityProvider, type ModalState, type Model, type ModelRoute, notificationChannelTypes, type Provider, type ProviderCatalogEntry, type ProviderResource, type ReportExportHistoryItem, type RequestLog, type ResourceAction, type ResourceConfig, type SettingsTabKey, type SQLiteBackup, type ToolbarAction, type UsageBreakdown, type UsagePoint, type ViewKey, viewRoutes } from "../core/types";
+import { type AdminResource, type AdminUser, type AlertDelivery, type AlertEvent, type APIKey, type AppData, type ApprovalRequest, type AuditEvent, authExpiredEventName, type ConfirmState, languageStorageKey, type LoginIdentityProvider, type ModalState, type Model, type ModelRoute, notificationChannelTypes, type Provider, type ProviderCatalogEntry, type ProviderResource, type ReportExportHistoryItem, type RequestLog, type ResourceAction, type ResourceConfig, type SettingsTabKey, type SQLiteBackup, type ToolbarAction, type UsageBreakdown, type UsagePoint, type ViewKey, viewRoutes } from "../core/types";
 import { emptyData, emptySummary, filterByModelCategory, filterRows } from "../domain/catalog";
 import { projectSelectOptions, rowTitle, stringifyForm } from "../domain/entities";
 import { uniqueUIID, viewFromPath } from "../domain/formatting";
@@ -31,7 +31,7 @@ import { ProviderUpsertModal } from "../views/provider-editor";
 import { EditModal, SettingsView, usePagination } from "../views/settings-table";
 import { BillingView, UsageView } from "../views/usage-billing";
 
-export function AdminConsole() {
+export function AdminConsole({ defaultBaseURL }: { defaultBaseURL: string }) {
   const pathname = usePathname();
   const router = useRouter();
   const routeView = viewFromPath(pathname);

--- a/frontend/lib/runtime-config.ts
+++ b/frontend/lib/runtime-config.ts
@@ -1,0 +1,8 @@
+import "server-only";
+
+const defaultAPIBaseURL = "http://localhost:8080";
+const runtimeAPIBaseURLEnv = "NEXT_PUBLIC_API_BASE_URL";
+
+export function runtimeAPIBaseURL() {
+  return process.env[runtimeAPIBaseURLEnv]?.trim() || defaultAPIBaseURL;
+}


### PR DESCRIPTION
## Summary

Add first-party GitHub Actions for repeatable multi-architecture container builds and downloadable backend binaries. Pull requests validate both artifact types, while trusted branch and tag events publish images and releases.

## Related Issue

N/A

## Changes

- Add a Buildx matrix workflow for the backend and frontend images on Linux amd64 and arm64.
- Publish OCI-tagged images to GHCR on `main`, `v*` tags, and manual runs, with cache reuse, SBOMs, and provenance attestations.
- Add a GoReleaser snapshot and release workflow for Linux amd64/arm64 and Windows amd64 backend binaries.
- Package the model catalog, license, multilingual READMEs, and checksums with binary releases.
- Pin every third-party GitHub Action to an immutable commit.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [x] Deployment or configuration

## Verification

- [x] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [ ] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- No Go files changed. `go test ./...` and `go vet ./...` passed from `backend/`.
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -color .github/workflows/docker.yml` passed for the Docker workflow.
- Fork Actions run [29977468423](https://github.com/ca-x/TokenHub/actions/runs/29977468423) passed the backend and frontend Docker builds for Linux amd64 and arm64 at commit `8bde582`.
- Fork Actions run [29977468452](https://github.com/ca-x/TokenHub/actions/runs/29977468452) passed the GoReleaser snapshot build and artifact upload at commit `8bde582`.
- Frontend verification stopped at `npm run typecheck` because the base checkout references the missing `frontend/scripts/check-source-lines.mjs`; `npm run build` therefore did not run.
- SDK smoke tests were not applicable because this change does not alter API behavior and no compatible backend credentials were configured.
- Docker and Docker Compose are unavailable in the local environment, so Compose rendering was skipped; the image builds were verified by the successful fork Actions run above.
- `git diff --check` passed before commit.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: None.
- Security or credential-handling impact: Release credentials remain in GitHub's scoped `GITHUB_TOKEN`; registry login and publishing are skipped for pull requests. Third-party actions are pinned to immutable commits.
- Database, environment, or deployment impact: No database or runtime environment changes. Merges to `main` and `v*` tags publish backend and frontend images to GHCR; `v*` tags also create binary GitHub releases.
- Rollout and rollback considerations: Merging enables CI immediately. Reverting the commit disables future builds; already published packages or release assets can be removed separately if required.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
