### PR TITLE
docs: add optional agent development workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,17 @@ npm run test:security-policy
 
 Start the full local development stack from the repository root with `./start.sh`. Start the containerized stack with the commands documented in `docs/deployment.md`.
 
+## Optional development workflows
+
+TokenHub provides two optional AI-agent workflows:
+
+| Workflow | Intended use | Instructions |
+| --- | --- | --- |
+| `fast-dev` | Small, well-scoped, low-risk changes that do not alter public APIs, persistence, authentication or authorization, deployment, or cross-component behavior | [docs/development/workflows/fast-dev.md](docs/development/workflows/fast-dev.md) |
+| `feature-dev` | Important features, user-visible behavior, cross-component changes, public API or data-model changes, security-sensitive work, deployment changes, broad refactors, or work that needs an architectural decision | [docs/development/workflows/feature-dev.md](docs/development/workflows/feature-dev.md) |
+
+Use a workflow only when the user explicitly names it; otherwise follow the normal repository guidance. Read only the selected workflow before editing. If `fast-dev` no longer fits, ask before switching to `feature-dev`. Workflow selection never authorizes commits, pushes, pull requests, merges, or other external writes.
+
 ## Change guidelines
 
 - Keep changes focused and preserve unrelated work in the checkout.

--- a/README.ja.md
+++ b/README.ja.md
@@ -131,6 +131,17 @@ npm install
 npm run test:deepseek
 ```
 
+## オプションの AI Agent 開発ワークフロー
+
+TokenHub には、AI Agent がリポジトリを変更する際に選択できる 2 つのワークフローがあります。
+
+| ワークフロー | 適用範囲 |
+| --- | --- |
+| [`fast-dev`](docs/development/workflows/fast-dev.md) | 範囲が明確でリスクの低い局所的な変更 |
+| [`feature-dev`](docs/development/workflows/feature-dev.md) | 重要な機能、ユーザーに見える変更、コンポーネント横断の変更、公開 API やデータモデルの変更、セキュリティに関わる作業、デプロイ変更、アーキテクチャ上の判断 |
+
+依頼でワークフロー名を明示すると有効になります（例: `この変更では fast-dev を使用してください。`）。指定がなければ通常のリポジトリガイドに従います。切り替え前には確認が必要で、ワークフローの選択は Git や Pull Request の操作を許可するものではありません。詳細は [AGENTS.md](AGENTS.md#optional-development-workflows) を参照してください。
+
 ## ドキュメント
 
 - [ドキュメントホーム](docs/ja/README.md)

--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ npm install
 npm run test:deepseek
 ```
 
+## Optional AI Agent Development Workflows
+
+TokenHub provides two opt-in workflows for AI-assisted changes:
+
+| Workflow | Choose it for |
+| --- | --- |
+| [`fast-dev`](docs/development/workflows/fast-dev.md) | Small, well-scoped, low-risk changes |
+| [`feature-dev`](docs/development/workflows/feature-dev.md) | Important features, user-visible or cross-component changes, public API or data-model changes, security-sensitive work, deployment changes, or architectural decisions |
+
+Activate one by naming it in the request, such as `Use fast-dev for this change.` Without an explicit selection, the agent follows the normal repository guidance. The agent asks before switching workflows, and workflow selection does not authorize Git or pull-request actions. See [AGENTS.md](AGENTS.md#optional-development-workflows).
+
 ## Documentation
 
 - [Documentation home](docs/README.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -131,6 +131,17 @@ npm install
 npm run test:deepseek
 ```
 
+## 可选的 AI Agent 开发工作流
+
+TokenHub 为 AI Agent 修改仓库提供两套可选工作流：
+
+| 工作流 | 适用范围 |
+| --- | --- |
+| [`fast-dev`](docs/development/workflows/fast-dev.md) | 范围明确、风险较低的局部修改 |
+| [`feature-dev`](docs/development/workflows/feature-dev.md) | 重要功能、用户可见或跨组件修改、公共 API 或数据模型修改、安全敏感修改、部署修改或架构决策 |
+
+在请求中指定工作流即可启用，例如 `本次修改使用 fast-dev。` 未指定时，Agent 按仓库常规指引执行。切换工作流前需要确认，选择工作流也不代表允许 Git 或 Pull Request 操作。Agent 规则见 [AGENTS.md](AGENTS.md#optional-development-workflows)。
+
 ## 文档
 
 - [文档首页](docs/zh-CN/README.md)

--- a/docs/development/workflows/fast-dev.md
+++ b/docs/development/workflows/fast-dev.md
@@ -1,0 +1,26 @@
+# Fast Dev Workflow
+
+Use `fast-dev` only when the user explicitly selects it. It is intended for small, well-scoped, low-risk changes.
+
+Read this file and `AGENTS.md` before editing. Do not load `feature-dev` at the same time.
+
+## Scope
+
+The change must preserve public APIs, persistence, authentication and authorization, security boundaries, deployment behavior, and backend/frontend contracts. It must not introduce a broad refactor, architectural decision, or new user-visible capability.
+
+If the change exceeds this boundary, stop and ask whether to switch to `feature-dev`; never switch automatically.
+
+## Steps
+
+1. Inspect `git status`, preserve unrelated changes, and read the target code, adjacent tests, and relevant documentation.
+2. State the intended scope in one sentence, then make the smallest necessary change. Add a focused regression test when behavior changes.
+3. Run the applicable checks from `AGENTS.md`:
+   - documentation: `git diff --check` and link, command, and path verification;
+   - backend: formatting, focused tests, `go test ./...`, and `go vet ./...`;
+   - frontend: `npm ci`, `npm run typecheck`, and `npm run build`;
+   - visible UI: browser verification of affected states and viewports;
+   - deployment or SDK: the relevant repository checks when their required environment is available.
+4. After validation, spawn a fresh review subagent that did not participate in implementation. Give it the final diff and validation results, and require it to remain read-only. Fix accepted findings and rerun affected checks; use at most two rounds. If review subagents are unavailable, report that limitation instead of substituting self-review.
+5. Report changes, checks, skipped validation, review results, and remaining risk.
+
+Do not commit runtime artifacts or incidental generated files. Commit, push, or create a pull request only when separately requested.

--- a/docs/development/workflows/feature-dev.md
+++ b/docs/development/workflows/feature-dev.md
@@ -1,0 +1,41 @@
+# Feature Dev Workflow
+
+Use `feature-dev` only when the user explicitly selects it. It covers important features, user-visible or cross-component changes, public API or data-model changes, security-sensitive work, deployment changes, broad refactors, and architectural decisions.
+
+Read this file and `AGENTS.md` before editing. Do not load `fast-dev` at the same time.
+
+## 1. Understand and confirm
+
+1. Inspect `git status` and preserve unrelated or user-authored changes.
+2. Read the affected code, tests, contracts, and documentation.
+3. Define goals, non-goals, compatibility, rollout, rollback, security impact, and open assumptions.
+4. Before implementation, present a high-level design and normal, boundary, and failure test cases. Wait for confirmation; return here if scope or key tradeoffs change.
+
+## 2. Record the design
+
+Create or update `docs/features/<feature>.md` for important features, covering behavior, design, compatibility, failure handling, security, rollout, rollback, and validation. Add an ADR under `docs/adr/` only for durable choices with meaningful alternatives or difficult reversal.
+
+## 3. Implement
+
+- Prefer test-backed, independently verifiable steps.
+- Preserve `/v1` compatibility unless the confirmed design changes it.
+- Treat credentials, keys, authentication, authorization, quotas, routing, audit data, persistence, and distributed coordination as sensitive.
+- Keep backend, frontend, SDK, model catalog, environment examples, deployment files, and translated documentation consistent where affected.
+
+## 4. Validate
+
+Run focused tests while iterating, then all applicable checks from `AGENTS.md`:
+
+- backend formatting, `go test ./...`, and `go vet ./...`;
+- frontend install, typecheck, build, and browser regression for visible UI;
+- SDK smoke tests for API changes when a configured backend is available;
+- deployment tests and rendered Compose configuration for deployment changes; and
+- `git diff --check` plus link and path verification for documentation.
+
+Record blocked or skipped checks and remaining risk. Never report an unrun or failing check as passing.
+
+## 5. Review and handoff
+
+After validation, spawn a fresh review subagent that did not participate in implementation. Give it the final diff and validation results, and require it to remain read-only. Fix accepted findings, rerun affected checks, and use at most three rounds. If review subagents are unavailable, report that limitation instead of substituting self-review.
+
+Report the result, design-document status, checks, review outcome, unresolved findings, and remaining risk. Commit, push, or create a pull request only when separately requested; then follow `.github/pull_request_template.md`.


### PR DESCRIPTION
## Summary

Add two explicit opt-in development workflows for AI-assisted TokenHub changes. The workflows adapt the `fast-dev` and `feature-dev` risk levels to this repository while keeping normal development unchanged unless a user selects one.

## Related Issue

N/A

## Changes

- Add concise TokenHub-specific `fast-dev` and `feature-dev` workflow guides.
- Require explicit user selection and confirmation before switching workflows.
- Require each selected workflow to spawn a fresh read-only review subagent after validation.
- Document human-facing selection guidance in the English, Simplified Chinese, and Japanese READMEs.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [x] Documentation
- [ ] Deployment or configuration

## Verification

- [ ] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [ ] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- `git diff --cached --check` passed before commit.
- A local link check validated 69 Markdown links across the six changed files.
- Manually verified that both workflows require explicit selection, forbid automatic switching, and explicitly request a fresh read-only review subagent.
- Backend, frontend, SDK, and Docker checks were not run because this is a documentation-only change.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: None.
- Security or credential-handling impact: None.
- Database, environment, or deployment impact: None.
- Rollout and rollback considerations: Documentation-only; revert the commit to roll back.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
