### PR TITLE
docs: add multilingual contributing guides

### DIFF
--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -1,0 +1,107 @@
+# TokenHub へのコントリビューション
+
+[English](CONTRIBUTING.md) | [简体中文](CONTRIBUTING.zh-CN.md) | 日本語
+
+TokenHub は、Go バックエンド、Next.js 管理コンソール、Node.js SDK スモークテスト、YAML モデルカタログ、Docker Compose デプロイファイルで構成されています。このガイドでは、ローカル開発、検証、オプションの AI Agent ワークフロー、Pull Request の準備について説明します。
+
+## リポジトリ構成
+
+| パス | 用途 |
+| --- | --- |
+| `backend/` | Go HTTP API、永続化、ルーティング、認証、管理機能、バックエンドテスト |
+| `frontend/` | Next.js と React の管理コンソール |
+| `sdk/` | OpenAI-Compatible API とセキュリティポリシーエンドポイントの Node.js スモークテスト |
+| `data/model-catalog.yaml` | バージョン管理対象のモデルカタログソース |
+| `deploy/` | Docker Compose デプロイファイルと環境変数テンプレート |
+| `docs/` | 英語、簡体字中国語、日本語のドキュメント |
+
+## ローカル開発
+
+ローカル開発には Go 1.26 と Node.js 20 以降が必要です。Docker と Docker Compose は、コンテナおよびデプロイの検証でのみ必要です。
+
+リポジトリのルートからローカル開発スタック全体を起動します。
+
+```bash
+./start.sh
+```
+
+コンポーネントを個別に実行する場合は、`backend/` でバックエンドを起動します。
+
+```bash
+go run ./cmd/tokenhub
+```
+
+`frontend/` で管理コンソールを起動します。
+
+```bash
+npm ci
+npm run dev
+```
+
+互換性のあるバックエンドが利用でき、必要な環境変数が設定されている場合にのみ、`sdk/` で SDK スモークテストを実行します。
+
+```bash
+npm ci
+npm run test:deepseek
+npm run test:security-policy
+```
+
+## 変更ガイドライン
+
+- 変更範囲を限定し、無関係な既存の変更を保持します。
+- バックエンドの動作を変更する場合は、テストを追加または更新します。外部ネットワークへの依存を避け、プロセス内の HTTP または SMTP フェイクサーバーを優先します。
+- 明示的に契約を変更する場合を除き、OpenAI-Compatible `/v1` エンドポイントとの互換性を維持します。
+- 認証情報、ローカルの `.env` ファイル、データベース、生成されたバックアップ、実行時ログをコミットしないでください。
+- 環境変数を変更する場合は、関連するサンプル、Compose ファイル、`start.sh`、デプロイドキュメントを同期して更新します。
+- ユーザー向けの共通ドキュメントは、英語、簡体字中国語、日本語で同期して更新します。
+- `data/model-catalog.yaml` をバージョン管理対象のまま維持し、その他の実行時データファイルをコミットしないでください。
+
+## 検証
+
+変更中は対象範囲が最も狭いテストを実行し、Pull Request を作成する前に該当する一連のチェックを実行します。
+
+`backend/` でバックエンドを検証します。
+
+```bash
+gofmt -w path/to/changed.go
+go test ./...
+go vet ./...
+```
+
+`frontend/` でフロントエンドを検証します。
+
+```bash
+npm ci
+npm run typecheck
+npm run build
+```
+
+Docker またはデプロイ構成を変更した場合は、Docker を利用できる環境で Compose 構成をレンダリングします。
+
+```bash
+docker compose --env-file deploy/.env.example \
+  -f deploy/docker-compose.yml config
+```
+
+すべての変更で `git diff --check` を実行します。実行できなかったチェックを明記し、新しい失敗とベースブランチにすでに存在する失敗を区別してください。
+
+## オプションの AI Agent 開発ワークフロー
+
+TokenHub には、AI Agent がリポジトリを変更する際に選択できる 2 つのワークフローがあります。
+
+| ワークフロー | 適用範囲 |
+| --- | --- |
+| [`fast-dev`](docs/development/workflows/fast-dev.md) | 公開 API、永続化、認証または認可、デプロイ、コンポーネント横断の動作を変更しない、範囲が明確でリスクの低い変更 |
+| [`feature-dev`](docs/development/workflows/feature-dev.md) | 重要な機能、ユーザーに見える変更、コンポーネント横断の変更、公開 API やデータモデルの変更、セキュリティに関わる作業、デプロイ変更、大規模なリファクタリング、アーキテクチャ上の判断 |
+
+依頼でワークフロー名を明示すると有効になります。例: `この変更では fast-dev を使用してください。` 指定がなければ、Agent は通常のリポジトリガイドに従います。`fast-dev` が適さなくなった場合、Agent は `feature-dev` に切り替える前に確認を求めます。ワークフローの選択は、コミット、プッシュ、Pull Request の作成、マージ、その他の外部書き込み操作を許可するものではありません。
+
+Agent 固有のリポジトリ指示については、[AGENTS.md](AGENTS.md#optional-development-workflows)を参照してください。
+
+## Pull Request
+
+- 英語の Conventional Commits 形式のタイトル `<type>[optional scope][!]: <short summary>` を使用します。
+- タイトルは 72 文字以内とし、要約は小文字の命令形で記述し、末尾にピリオドを付けません。
+- [Pull Request テンプレート](.github/pull_request_template.md)のすべてのセクションを記入し、スキップしたチェックや該当しないチェックについて説明します。
+- 必要に応じて、API 互換性、セキュリティ、データベース、環境変数、デプロイ、ロールアウト、ロールバックへの影響を記載します。
+- デフォルトではレビュー可能な Pull Request を作成します。明示的に要求された場合にのみ Draft を使用します。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing to TokenHub
+
+English | [简体中文](CONTRIBUTING.zh-CN.md) | [日本語](CONTRIBUTING.ja.md)
+
+TokenHub includes a Go backend, a Next.js admin console, Node.js SDK smoke tests, a YAML model catalog, and Docker Compose deployment files. This guide covers local development, validation, optional AI agent workflows, and pull request preparation.
+
+## Repository Layout
+
+| Path | Purpose |
+| --- | --- |
+| `backend/` | Go HTTP API, persistence, routing, authentication, administration, and backend tests |
+| `frontend/` | Next.js and React admin console |
+| `sdk/` | Node.js smoke tests for the OpenAI-compatible API and security policy endpoints |
+| `data/model-catalog.yaml` | Tracked model catalog source |
+| `deploy/` | Docker Compose deployment and environment templates |
+| `docs/` | English, Simplified Chinese, and Japanese documentation |
+
+## Local Development
+
+Local development requires Go 1.26 and Node.js 20 or later. Docker and Docker Compose are required only for container and deployment checks.
+
+Start the full local development stack from the repository root:
+
+```bash
+./start.sh
+```
+
+To run components separately, start the backend from `backend/`:
+
+```bash
+go run ./cmd/tokenhub
+```
+
+Start the admin console from `frontend/`:
+
+```bash
+npm ci
+npm run dev
+```
+
+Run the SDK smoke tests from `sdk/` only when a compatible backend is available and the required environment variables are configured:
+
+```bash
+npm ci
+npm run test:deepseek
+npm run test:security-policy
+```
+
+## Change Guidelines
+
+- Keep changes focused and preserve unrelated work.
+- Add or update tests for backend behavior changes. Prefer in-process fake HTTP or SMTP servers over external network dependencies.
+- Preserve compatibility for the OpenAI-compatible `/v1` endpoints unless the change explicitly updates the contract.
+- Never commit credentials, local `.env` files, databases, generated backups, or runtime logs.
+- Keep environment variable changes synchronized across relevant examples, Compose files, `start.sh`, and deployment documentation.
+- Keep shared user-facing documentation synchronized across English, Simplified Chinese, and Japanese.
+- Keep `data/model-catalog.yaml` tracked. Do not commit other runtime data files.
+
+## Validation
+
+Run the narrowest relevant test while iterating, followed by the full applicable checks before opening a pull request.
+
+Backend checks from `backend/`:
+
+```bash
+gofmt -w path/to/changed.go
+go test ./...
+go vet ./...
+```
+
+Frontend checks from `frontend/`:
+
+```bash
+npm ci
+npm run typecheck
+npm run build
+```
+
+For Docker or deployment changes, render the Compose configuration when Docker is available:
+
+```bash
+docker compose --env-file deploy/.env.example \
+  -f deploy/docker-compose.yml config
+```
+
+Run `git diff --check` for every change. Report any check that could not run and distinguish new failures from failures already present on the base branch.
+
+## Optional AI Agent Development Workflows
+
+TokenHub provides two opt-in workflows for AI-assisted changes:
+
+| Workflow | Choose it for |
+| --- | --- |
+| [`fast-dev`](docs/development/workflows/fast-dev.md) | Small, well-scoped, low-risk changes that do not alter public APIs, persistence, authentication or authorization, deployment, or cross-component behavior |
+| [`feature-dev`](docs/development/workflows/feature-dev.md) | Important features, user-visible or cross-component changes, public API or data-model changes, security-sensitive work, deployment changes, broad refactors, or architectural decisions |
+
+Activate one by naming it in the request, such as `Use fast-dev for this change.` Without an explicit selection, the agent follows the normal repository guidance. If `fast-dev` no longer fits, the agent asks before switching to `feature-dev`. Workflow selection does not authorize commits, pushes, pull requests, merges, or other external writes.
+
+See [AGENTS.md](AGENTS.md#optional-development-workflows) for agent-specific repository instructions.
+
+## Pull Requests
+
+- Use an English Conventional Commits-style title: `<type>[optional scope][!]: <short summary>`.
+- Keep the title at or below 72 characters, use a lowercase imperative summary, and omit the trailing period.
+- Complete every section of [the pull request template](.github/pull_request_template.md). Explain skipped or non-applicable checks.
+- Describe API compatibility, security, database, environment, deployment, rollout, and rollback effects where applicable.
+- Create a ready-for-review pull request by default. Use a draft only when explicitly requested.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -1,0 +1,107 @@
+# 为 TokenHub 贡献代码
+
+[English](CONTRIBUTING.md) | 简体中文 | [日本語](CONTRIBUTING.ja.md)
+
+TokenHub 包含 Go 后端、Next.js 管理后台、Node.js SDK 冒烟测试、YAML 模型目录和 Docker Compose 部署文件。本指南说明本地开发、修改验证、可选的 AI Agent 工作流和 Pull Request 准备要求。
+
+## 仓库结构
+
+| 路径 | 用途 |
+| --- | --- |
+| `backend/` | Go HTTP API、持久化、路由、认证、管理功能和后端测试 |
+| `frontend/` | Next.js 和 React 管理后台 |
+| `sdk/` | OpenAI-Compatible API 和安全策略接口的 Node.js 冒烟测试 |
+| `data/model-catalog.yaml` | 纳入版本控制的模型目录源文件 |
+| `deploy/` | Docker Compose 部署和环境变量模板 |
+| `docs/` | 英文、简体中文和日文文档 |
+
+## 本地开发
+
+本地开发需要 Go 1.26 和 Node.js 20 或更高版本。仅容器和部署检查需要 Docker 与 Docker Compose。
+
+在仓库根目录启动完整的本地开发环境：
+
+```bash
+./start.sh
+```
+
+需要单独运行组件时，在 `backend/` 目录启动后端：
+
+```bash
+go run ./cmd/tokenhub
+```
+
+在 `frontend/` 目录启动管理后台：
+
+```bash
+npm ci
+npm run dev
+```
+
+仅在兼容的后端可用且必需的环境变量已配置时，才在 `sdk/` 目录运行 SDK 冒烟测试：
+
+```bash
+npm ci
+npm run test:deepseek
+npm run test:security-policy
+```
+
+## 修改要求
+
+- 保持修改范围集中，并保留无关的现有改动。
+- 后端行为发生变化时，添加或更新测试。优先使用进程内的 HTTP 或 SMTP 模拟服务器，避免依赖外部网络。
+- 除非修改明确更新接口契约，否则保持 OpenAI-Compatible `/v1` 接口兼容。
+- 不要提交凭证、本地 `.env` 文件、数据库、生成的备份或运行日志。
+- 环境变量发生变化时，同步更新相关示例、Compose 文件、`start.sh` 和部署文档。
+- 面向使用者的共享文档需要同步维护英文、简体中文和日文版本。
+- 保持 `data/model-catalog.yaml` 纳入版本控制，不要提交其他运行时数据文件。
+
+## 验证
+
+修改过程中先运行范围最小的相关测试，准备提交 Pull Request 前再运行适用的完整检查。
+
+在 `backend/` 目录运行后端检查：
+
+```bash
+gofmt -w path/to/changed.go
+go test ./...
+go vet ./...
+```
+
+在 `frontend/` 目录运行前端检查：
+
+```bash
+npm ci
+npm run typecheck
+npm run build
+```
+
+修改 Docker 或部署配置时，如果本地可以使用 Docker，需要渲染 Compose 配置：
+
+```bash
+docker compose --env-file deploy/.env.example \
+  -f deploy/docker-compose.yml config
+```
+
+所有修改都需要运行 `git diff --check`。无法运行的检查需要明确说明，并区分新增失败与基础分支已有失败。
+
+## 可选的 AI Agent 开发工作流
+
+TokenHub 为 AI Agent 修改仓库提供两套可选工作流：
+
+| 工作流 | 适用范围 |
+| --- | --- |
+| [`fast-dev`](docs/development/workflows/fast-dev.md) | 范围明确、风险较低，且不涉及公共 API、持久化、认证或授权、部署及跨组件行为的局部修改 |
+| [`feature-dev`](docs/development/workflows/feature-dev.md) | 重要功能、用户可见或跨组件修改、公共 API 或数据模型修改、安全敏感修改、部署修改、大范围重构或架构决策 |
+
+在请求中指定工作流即可启用，例如 `本次修改使用 fast-dev。` 未指定时，Agent 按仓库常规指引执行。如果 `fast-dev` 不再适用，Agent 会在切换到 `feature-dev` 前请求确认。选择工作流不代表允许提交、推送、创建 Pull Request、合并或执行其他外部写入操作。
+
+Agent 专用的仓库指令见 [AGENTS.md](AGENTS.md#optional-development-workflows)。
+
+## Pull Request
+
+- 使用英文 Conventional Commits 风格的标题：`<type>[optional scope][!]: <short summary>`。
+- 标题不超过 72 个字符，摘要使用小写祈使句，不添加句号。
+- 完整填写 [Pull Request 模板](.github/pull_request_template.md)的每一节，并说明跳过或不适用的检查。
+- 根据修改范围说明 API 兼容性、安全、数据库、环境变量、部署、上线和回滚影响。
+- 默认创建可直接评审的 Pull Request。仅在明确要求时使用 Draft。

--- a/README.ja.md
+++ b/README.ja.md
@@ -106,48 +106,13 @@ cp deploy/.env.example deploy/.env
 
 デプロイスクリプトは本番用認証情報を検証し、公開済みイメージを取得して、ローカルではビルドせずにコンテナを起動します。イメージがまだ公開されておらず、デフォルトの `latest` タグの取得に失敗した場合は、ローカルのソースビルドへ自動的に切り替えます。明示したタグでは切り替えません。秘密値を表示せずに安全でない変数を個別に報告します。その試行で作成または再起動したバックエンドコンテナの異常により Compose が失敗した場合に限り、その試行で生成された直近のバックエンドログを自動表示します。現在のチェックアウトから明示的にビルドする場合は `./deploy/install.sh --build` を使用します。
 
-## ローカル開発
-
-バックエンド:
-
-```bash
-cd backend
-go run ./cmd/tokenhub
-```
-
-フロントエンド:
-
-```bash
-cd frontend
-npm install
-npm run dev
-```
-
-SDK サンプルでモデル API の疎通を確認できます。
-
-```bash
-cd sdk
-npm install
-npm run test:deepseek
-```
-
-## オプションの AI Agent 開発ワークフロー
-
-TokenHub には、AI Agent がリポジトリを変更する際に選択できる 2 つのワークフローがあります。
-
-| ワークフロー | 適用範囲 |
-| --- | --- |
-| [`fast-dev`](docs/development/workflows/fast-dev.md) | 範囲が明確でリスクの低い局所的な変更 |
-| [`feature-dev`](docs/development/workflows/feature-dev.md) | 重要な機能、ユーザーに見える変更、コンポーネント横断の変更、公開 API やデータモデルの変更、セキュリティに関わる作業、デプロイ変更、アーキテクチャ上の判断 |
-
-依頼でワークフロー名を明示すると有効になります（例: `この変更では fast-dev を使用してください。`）。指定がなければ通常のリポジトリガイドに従います。切り替え前には確認が必要で、ワークフローの選択は Git や Pull Request の操作を許可するものではありません。詳細は [AGENTS.md](AGENTS.md#optional-development-workflows) を参照してください。
-
 ## ドキュメント
 
 - [ドキュメントホーム](docs/ja/README.md)
 - [ユーザーガイド](docs/ja/user-guide.md)
 - [チームリーダーガイド](docs/ja/team-leader-guide.md)
 - [管理者ガイド](docs/ja/administrator-guide.md)
+- [コントリビューションガイド](CONTRIBUTING.ja.md)
 - [English documentation](docs/README.md)
 - [简体中文文档](docs/zh-CN/README.md)
 

--- a/README.md
+++ b/README.md
@@ -106,48 +106,13 @@ Initial admin login:
 
 The deployment script validates production credentials, pulls published images, and starts the containers without building locally. Until the images are publicly available, a failed pull of the default `latest` tag automatically falls back to a local source build; an explicitly selected tag never does. The script reports each unsafe variable without printing secret values. If Compose fails because a backend container created or restarted by that attempt is unhealthy, it automatically shows only that attempt's recent backend logs. Use `./deploy/install.sh --build` to request a local build explicitly.
 
-## Local Development
-
-Backend:
-
-```bash
-cd backend
-go run ./cmd/tokenhub
-```
-
-Frontend:
-
-```bash
-cd frontend
-npm install
-npm run dev
-```
-
-Smoke-test the model API with the included SDK example:
-
-```bash
-cd sdk
-npm install
-npm run test:deepseek
-```
-
-## Optional AI Agent Development Workflows
-
-TokenHub provides two opt-in workflows for AI-assisted changes:
-
-| Workflow | Choose it for |
-| --- | --- |
-| [`fast-dev`](docs/development/workflows/fast-dev.md) | Small, well-scoped, low-risk changes |
-| [`feature-dev`](docs/development/workflows/feature-dev.md) | Important features, user-visible or cross-component changes, public API or data-model changes, security-sensitive work, deployment changes, or architectural decisions |
-
-Activate one by naming it in the request, such as `Use fast-dev for this change.` Without an explicit selection, the agent follows the normal repository guidance. The agent asks before switching workflows, and workflow selection does not authorize Git or pull-request actions. See [AGENTS.md](AGENTS.md#optional-development-workflows).
-
 ## Documentation
 
 - [Documentation home](docs/README.md)
 - [User Guide](docs/user-guide.md)
 - [Team Leader Guide](docs/team-leader-guide.md)
 - [Administrator Guide](docs/administrator-guide.md)
+- [Contributing Guide](CONTRIBUTING.md)
 - [简体中文文档](docs/zh-CN/README.md)
 - [日本語ドキュメント](docs/ja/README.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -106,48 +106,13 @@ cp deploy/.env.example deploy/.env
 
 部署脚本会校验生产凭证，拉取已发布镜像并启动容器，不在部署服务器构建镜像。镜像尚未公开时，如果默认 `latest` 标签拉取失败，脚本会自动改为从本地源码构建；显式指定的标签不会触发该行为。校验失败时会列出不安全的变量，但不会输出敏感值。如果本次创建或重启的后端容器异常导致 Compose 失败，脚本只会自动显示本次启动产生的后端近期日志。需要明确从当前代码构建时，使用 `./deploy/install.sh --build`。
 
-## 本地开发
-
-后端：
-
-```bash
-cd backend
-go run ./cmd/tokenhub
-```
-
-前端：
-
-```bash
-cd frontend
-npm install
-npm run dev
-```
-
-使用 SDK 示例测试模型 API 链路：
-
-```bash
-cd sdk
-npm install
-npm run test:deepseek
-```
-
-## 可选的 AI Agent 开发工作流
-
-TokenHub 为 AI Agent 修改仓库提供两套可选工作流：
-
-| 工作流 | 适用范围 |
-| --- | --- |
-| [`fast-dev`](docs/development/workflows/fast-dev.md) | 范围明确、风险较低的局部修改 |
-| [`feature-dev`](docs/development/workflows/feature-dev.md) | 重要功能、用户可见或跨组件修改、公共 API 或数据模型修改、安全敏感修改、部署修改或架构决策 |
-
-在请求中指定工作流即可启用，例如 `本次修改使用 fast-dev。` 未指定时，Agent 按仓库常规指引执行。切换工作流前需要确认，选择工作流也不代表允许 Git 或 Pull Request 操作。Agent 规则见 [AGENTS.md](AGENTS.md#optional-development-workflows)。
-
 ## 文档
 
 - [文档首页](docs/zh-CN/README.md)
 - [普通用户指南](docs/zh-CN/user-guide.md)
 - [团队负责人指南](docs/zh-CN/team-leader-guide.md)
 - [管理员指南](docs/zh-CN/administrator-guide.md)
+- [贡献指南](CONTRIBUTING.zh-CN.md)
 - [English documentation](docs/README.md)
 - [日本語ドキュメント](docs/ja/README.md)
 


### PR DESCRIPTION
## Summary

Move contributor-oriented development instructions out of the project overview and into dedicated contributing guides. This keeps the README files focused on product setup and documentation while preserving contributor guidance in English, Simplified Chinese, and Japanese.

## Related Issue

N/A

## Changes

- Add English, Simplified Chinese, and Japanese contributing guides.
- Document the repository layout, local development commands, change guidelines, validation, optional AI agent workflows, and pull request requirements.
- Replace the local development and AI agent workflow sections in each README with a localized contributing guide link.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [x] Documentation
- [ ] Deployment or configuration

## Verification

- [ ] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [ ] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- `git diff --check`
- Verified local Markdown link targets across all six changed files.
- Verified balanced Markdown code fences and absence of trailing whitespace.
- Backend, frontend, SDK, and Docker checks were not run because this change only reorganizes documentation.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: None.
- Security or credential-handling impact: None.
- Database, environment, or deployment impact: None.
- Rollout and rollback considerations: None; documentation-only change.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
