### PR TITLE
fix(frontend): restore typecheck command

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,8 +7,7 @@
     "dev": "next dev --hostname 0.0.0.0",
     "build": "next build",
     "start": "next start --hostname 0.0.0.0",
-    "check:lines": "node scripts/check-source-lines.mjs",
-    "typecheck": "npm run check:lines && tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "lucide-react": "1.17.0",


### PR DESCRIPTION
## Summary

Restores the frontend type-check command by removing a reference to a source-line script that is not present in the repository. This allows the required TypeScript check to run again.

## Related Issue

N/A

## Changes

- Remove the stale `check:lines` script entry from the frontend package scripts.
- Run `tsc --noEmit` directly from `npm run typecheck`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [ ] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [x] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- `npm ci` completed successfully in `frontend/`.
- `npm run typecheck` passed.
- `npm run build` passed.
- `git diff --check` passed.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: None.
- Security or credential-handling impact: None.
- Database, environment, or deployment impact: None.
- Rollout and rollback considerations: No runtime behavior changes. Revert the commit to restore the former package script configuration.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.