### PR TITLE
feat(gateway): support Claude Code via Anthropic Messages

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -47,7 +47,7 @@ TokenHub は、日常的なモデル利用、チームガバナンス、プラ�
 
 ## プラットフォーム機能
 
-- OpenAI-Compatible モデル API: `/v1/chat/completions`、`/v1/responses`、`/v1/embeddings`。
+- OpenAI-Compatible モデル API: `/v1/chat/completions`、`/v1/responses`、`/v1/embeddings`。Anthropic Messages API: `/v1/messages`、`/v1/messages/count_tokens`。
 - Provider チャネル: OpenAI-Compatible、Azure OpenAI、Anthropic、Gemini、DeepSeek、Qwen、ローカル vLLM/Ollama、カスタム上流。
 - モデルカタログとルーティングポリシー: 優先度、重み、フェイルオーバー順序、ルートヘルス診断に対応。
 - プロジェクト単位の Key 管理: チーム所有、メンバー権限、クォータ、並行数制限に対応。

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ TokenHub separates everyday model usage, team governance, and platform administr
 
 ## Platform Capabilities
 
-- OpenAI-compatible model APIs: `/v1/chat/completions`, `/v1/responses`, `/v1/embeddings`.
+- OpenAI-compatible model APIs: `/v1/chat/completions`, `/v1/responses`, `/v1/embeddings`; Anthropic Messages APIs: `/v1/messages`, `/v1/messages/count_tokens`.
 - Provider channels for OpenAI-compatible, Azure OpenAI, Anthropic, Gemini, DeepSeek, Qwen, local vLLM/Ollama, and custom upstreams.
 - Model catalog and routing policies with priority, weight, failover order, and route health diagnostics.
 - Project-scoped key management with team ownership, member permissions, quotas, and concurrency controls.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,7 +47,7 @@ TokenHub 将日常模型使用、团队治理和平台运维拆成清晰的角�
 
 ## 平台能力
 
-- OpenAI-Compatible 模型 API：`/v1/chat/completions`、`/v1/responses`、`/v1/embeddings`。
+- OpenAI-Compatible 模型 API：`/v1/chat/completions`、`/v1/responses`、`/v1/embeddings`；Anthropic Messages API：`/v1/messages`、`/v1/messages/count_tokens`。
 - Provider 渠道：OpenAI-Compatible、Azure OpenAI、Anthropic、Gemini、DeepSeek、Qwen、本地 vLLM/Ollama 和自定义上游。
 - 模型目录和路由策略：支持优先级、权重、失败回退顺序和路由健康诊断。
 - 按项目归属的 Key 管理：支持团队归属、成员权限、额度和并发限制。

--- a/backend/internal/server/anthropic_messages.go
+++ b/backend/internal/server/anthropic_messages.go
@@ -1,0 +1,1509 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+type anthropicMessagesRequest struct {
+	Raw       map[string]any
+	Model     string
+	MaxTokens int
+	Messages  []any
+	Stream    bool
+}
+
+func (s *Server) handleAnthropicMessages(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeAnthropicError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+		return
+	}
+	project, key, err := s.authenticate(r)
+	if err != nil {
+		writeAnthropicError(w, r, err)
+		return
+	}
+	req, err := decodeAnthropicMessagesRequest(r, true)
+	if err != nil {
+		writeAnthropicError(w, r, err)
+		return
+	}
+
+	routed, ok := s.startAnthropicRoutedCall(w, r, project, key, req)
+	if !ok {
+		return
+	}
+	if req.Stream {
+		s.handleAnthropicMessagesStream(w, r, routed, req)
+		return
+	}
+
+	resp, route, usage, attempts, err := s.executeRoutedAnthropicMessages(r, routed, req)
+	if err != nil {
+		s.finishFailedRoutedCall(r, routed, attempts, err)
+		s.recordRequestPayload(routed.Call.RequestID, req.Raw, auditErrorPayload(err, routed.Call.RequestID))
+		writeAnthropicError(w, r, err)
+		return
+	}
+	s.store.MarkRouteUsed(route.Route.ID)
+	s.store.MarkProviderResourceUsed(routeResourceID(route))
+	s.store.RecordRouteAttempts(routed.Call.RequestID, attempts)
+	s.store.FinishCall(routed.Call, route, usage, http.StatusOK, "", s.clientIP(r), r.UserAgent())
+	s.recordRequestPayload(routed.Call.RequestID, req.Raw, resp)
+	w.Header().Set("x-request-id", routed.Call.RequestID)
+	s.writeRouteHeaders(w, routed.Call, route, len(attempts))
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleAnthropicCountTokens(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeAnthropicError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+		return
+	}
+	_, key, err := s.authenticate(r)
+	if err != nil {
+		writeAnthropicError(w, r, err)
+		return
+	}
+	req, err := decodeAnthropicMessagesRequest(r, false)
+	if err != nil {
+		writeAnthropicError(w, r, err)
+		return
+	}
+	if !keyCanAccessModel(s.store, key, req.Model) {
+		writeAnthropicError(w, r, ErrModelNotAllowed)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"input_tokens": estimateAnthropicInputTokens(req.Raw),
+	})
+}
+
+func decodeAnthropicMessagesRequest(r *http.Request, requireMaxTokens bool) (anthropicMessagesRequest, error) {
+	var raw map[string]any
+	if err := decodeJSON(r, &raw); err != nil {
+		return anthropicMessagesRequest{}, NewHTTPError(http.StatusBadRequest, "invalid_request", err.Error())
+	}
+	model, _ := raw["model"].(string)
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return anthropicMessagesRequest{}, NewHTTPError(http.StatusBadRequest, "missing_model", "model is required")
+	}
+	messages, ok := raw["messages"].([]any)
+	if !ok || len(messages) == 0 {
+		return anthropicMessagesRequest{}, NewHTTPError(http.StatusBadRequest, "missing_messages", "messages are required")
+	}
+	for _, item := range messages {
+		message, ok := item.(map[string]any)
+		if !ok {
+			return anthropicMessagesRequest{}, NewHTTPError(http.StatusBadRequest, "invalid_message", "each message must be an object")
+		}
+		role, _ := message["role"].(string)
+		if role != "user" && role != "assistant" {
+			return anthropicMessagesRequest{}, NewHTTPError(http.StatusBadRequest, "invalid_message", "message role must be user or assistant")
+		}
+		if _, exists := message["content"]; !exists {
+			return anthropicMessagesRequest{}, NewHTTPError(http.StatusBadRequest, "invalid_message", "message content is required")
+		}
+	}
+	maxTokens := int(int64FromAny(raw["max_tokens"]))
+	if requireMaxTokens && maxTokens <= 0 {
+		return anthropicMessagesRequest{}, NewHTTPError(http.StatusBadRequest, "invalid_max_tokens", "max_tokens must be greater than zero")
+	}
+	stream, _ := raw["stream"].(bool)
+	return anthropicMessagesRequest{
+		Raw:       raw,
+		Model:     model,
+		MaxTokens: maxTokens,
+		Messages:  messages,
+		Stream:    stream,
+	}, nil
+}
+
+func keyCanAccessModel(store Store, key APIKey, model string) bool {
+	for _, candidate := range store.AccessibleModels(key) {
+		if candidate.Name == model || candidate.ID == model {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Server) startAnthropicRoutedCall(
+	w http.ResponseWriter,
+	r *http.Request,
+	project Project,
+	key APIKey,
+	req anthropicMessagesRequest,
+) (RoutedCall, bool) {
+	call, err := s.store.StartCall(r.Context(), project, key, req.Model)
+	if err != nil {
+		httpErr := AsHTTPError(err)
+		requestID := s.store.RecordRejectedRequest(project, key, req.Model, httpErr.Status, httpErr.Code, s.clientIP(r), r.UserAgent())
+		w.Header().Set("x-request-id", requestID)
+		s.recordRequestPayload(requestID, req.Raw, auditErrorPayload(err, requestID))
+		writeAnthropicError(w, r, err)
+		return RoutedCall{}, false
+	}
+	w.Header().Set("x-request-id", call.RequestID)
+	if call.requestContext != nil {
+		*r = *r.WithContext(call.requestContext)
+	}
+	routes, err := s.store.SelectRouteCandidates(req.Model)
+	if err != nil {
+		httpErr := AsHTTPError(err)
+		s.store.FinishCall(call, RouteSelection{}, Usage{}, httpErr.Status, httpErr.Code, s.clientIP(r), r.UserAgent())
+		s.recordRequestPayload(call.RequestID, req.Raw, auditErrorPayload(err, call.RequestID))
+		writeAnthropicError(w, r, err)
+		return RoutedCall{}, false
+	}
+	return RoutedCall{Call: call, Routes: s.planRouteOrder(call, routes)}, true
+}
+
+func (s *Server) executeRoutedAnthropicMessages(
+	r *http.Request,
+	routed RoutedCall,
+	req anthropicMessagesRequest,
+) (map[string]any, RouteSelection, Usage, []RouteAttempt, error) {
+	compatible, compatibilityErr := compatibleAnthropicRoutes(routed, req)
+	if compatibilityErr != nil {
+		return nil, RouteSelection{}, Usage{}, nil, compatibilityErr
+	}
+	return executeRoutedWithStore(r.Context(), s.store, compatible, false, func(ctx context.Context, route RouteSelection, _ bool) (map[string]any, Usage, error) {
+		route, err := s.prepareRouteForUpstream(ctx, route)
+		if err != nil {
+			return nil, Usage{}, err
+		}
+		return s.executeAnthropicMessagesRoute(ctx, route, req, r.Header)
+	})
+}
+
+func (s *Server) executeAnthropicMessagesRoute(
+	ctx context.Context,
+	route RouteSelection,
+	req anthropicMessagesRequest,
+	headers http.Header,
+) (map[string]any, Usage, error) {
+	if route.Provider.Type == ProviderAnthropic {
+		return s.executeNativeAnthropicMessages(ctx, route, req, headers)
+	}
+	if !openAIMessageProvider(route.Provider.Type) {
+		return nil, Usage{}, NewHTTPError(
+			http.StatusNotImplemented,
+			"provider_capability_not_supported",
+			"Provider does not support the Anthropic Messages gateway",
+		)
+	}
+	chatReq, err := anthropicToOpenAIChatRequest(req)
+	if err != nil {
+		return nil, Usage{}, err
+	}
+	adapter, err := s.adapterForRoute(route)
+	if err != nil {
+		return nil, Usage{}, err
+	}
+	resp, usage, err := adapter.Chat(ctx, route.Provider, route.ProviderModel, chatReq)
+	if err != nil {
+		return nil, usage, err
+	}
+	body, ok := resp.(map[string]any)
+	if !ok {
+		return nil, usage, NewHTTPError(http.StatusBadGateway, "provider_invalid_response", "Provider returned an invalid chat response")
+	}
+	converted, err := openAIResponseToAnthropic(body, req.Model, usage)
+	if err != nil {
+		return nil, usage, err
+	}
+	return converted, usage, nil
+}
+
+func openAIMessageProvider(providerType string) bool {
+	switch providerType {
+	case ProviderMock, ProviderOpenAI, ProviderOpenAICompatible, ProviderAzureOpenAI, "deepseek", "qwen", "local":
+		return true
+	default:
+		return false
+	}
+}
+
+func compatibleAnthropicRoutes(
+	routed RoutedCall,
+	req anthropicMessagesRequest,
+) (RoutedCall, error) {
+	compatible := routed
+	compatible.Routes = make([]RouteSelection, 0, len(routed.Routes))
+	var firstErr error
+	for _, route := range routed.Routes {
+		err := validateAnthropicRouteCompatibility(route, req)
+		if err == nil {
+			compatible.Routes = append(compatible.Routes, route)
+			continue
+		}
+		if !isAnthropicRouteIncompatibility(err) {
+			return compatible, err
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	if len(compatible.Routes) == 0 {
+		if firstErr == nil {
+			firstErr = ErrProviderMissing
+		}
+		return compatible, firstErr
+	}
+	return compatible, nil
+}
+
+func validateAnthropicRouteCompatibility(route RouteSelection, req anthropicMessagesRequest) error {
+	if route.Provider.Type == ProviderAnthropic {
+		return nil
+	}
+	if !openAIMessageProvider(route.Provider.Type) {
+		return NewHTTPError(
+			http.StatusNotImplemented,
+			"provider_capability_not_supported",
+			"Provider does not support the Anthropic Messages gateway",
+		)
+	}
+	_, err := anthropicToOpenAIChatRequest(req)
+	return err
+}
+
+func isAnthropicRouteIncompatibility(err error) bool {
+	switch AsHTTPError(err).Code {
+	case "provider_capability_not_supported",
+		"unsupported_content_block",
+		"unsupported_image_source",
+		"unsupported_tool",
+		"unsupported_tool_choice",
+		"unsupported_tool_result":
+		return true
+	default:
+		return false
+	}
+}
+
+func anthropicToOpenAIChatRequest(req anthropicMessagesRequest) (ChatCompletionRequest, error) {
+	messages := make([]ChatMessage, 0, len(req.Messages)+1)
+	if system, exists := req.Raw["system"]; exists {
+		text, err := anthropicSystemText(system)
+		if err != nil {
+			return ChatCompletionRequest{}, err
+		}
+		if text != "" {
+			messages = append(messages, ChatMessage{Role: "system", Content: text})
+		}
+	}
+	for _, rawMessage := range req.Messages {
+		message := rawMessage.(map[string]any)
+		converted, err := anthropicMessageToOpenAI(message)
+		if err != nil {
+			return ChatCompletionRequest{}, err
+		}
+		messages = append(messages, converted...)
+	}
+	tools, err := anthropicToolsToOpenAI(req.Raw["tools"])
+	if err != nil {
+		return ChatCompletionRequest{}, err
+	}
+	toolChoice, parallelToolCalls, err := anthropicToolChoiceToOpenAI(req.Raw["tool_choice"])
+	if err != nil {
+		return ChatCompletionRequest{}, err
+	}
+	temperature, err := optionalFloat(req.Raw["temperature"], "temperature")
+	if err != nil {
+		return ChatCompletionRequest{}, err
+	}
+	topP, err := optionalFloat(req.Raw["top_p"], "top_p")
+	if err != nil {
+		return ChatCompletionRequest{}, err
+	}
+	var reasoningEffort *string
+	if value, ok := req.Raw["effort"].(string); ok && strings.TrimSpace(value) != "" {
+		effort := strings.TrimSpace(value)
+		reasoningEffort = &effort
+	}
+	if outputConfig, ok := req.Raw["output_config"].(map[string]any); ok {
+		if value, ok := outputConfig["effort"].(string); ok && strings.TrimSpace(value) != "" {
+			effort := strings.TrimSpace(value)
+			reasoningEffort = &effort
+		}
+	}
+	chatReq := ChatCompletionRequest{
+		Model:             req.Model,
+		Messages:          messages,
+		Stream:            req.Stream,
+		MaxTokens:         req.MaxTokens,
+		Temperature:       temperature,
+		TopP:              topP,
+		Tools:             tools,
+		ToolChoice:        toolChoice,
+		ParallelToolCalls: parallelToolCalls,
+		ReasoningEffort:   reasoningEffort,
+	}
+	if stop, ok := req.Raw["stop_sequences"].([]any); ok {
+		values := make([]string, 0, len(stop))
+		for _, item := range stop {
+			value, ok := item.(string)
+			if !ok {
+				return ChatCompletionRequest{}, NewHTTPError(http.StatusBadRequest, "invalid_stop_sequences", "stop_sequences must contain strings")
+			}
+			values = append(values, value)
+		}
+		chatReq.Stop = values
+	}
+	return chatReq, nil
+}
+
+func optionalFloat(value any, field string) (*float64, error) {
+	if value == nil {
+		return nil, nil
+	}
+	switch typed := value.(type) {
+	case json.Number:
+		parsed, err := typed.Float64()
+		if err != nil {
+			return nil, NewHTTPError(http.StatusBadRequest, "invalid_"+field, field+" must be a number")
+		}
+		return &parsed, nil
+	case float64:
+		return &typed, nil
+	default:
+		return nil, NewHTTPError(http.StatusBadRequest, "invalid_"+field, field+" must be a number")
+	}
+}
+
+func anthropicSystemText(value any) (string, error) {
+	switch typed := value.(type) {
+	case string:
+		return typed, nil
+	case []any:
+		parts := make([]string, 0, len(typed))
+		for _, item := range typed {
+			block, ok := item.(map[string]any)
+			if !ok || block["type"] != "text" {
+				return "", NewHTTPError(http.StatusBadRequest, "unsupported_content_block", "OpenAI-compatible routes support only text system blocks")
+			}
+			text, ok := block["text"].(string)
+			if !ok {
+				return "", NewHTTPError(http.StatusBadRequest, "invalid_content_block", "text block text must be a string")
+			}
+			parts = append(parts, text)
+		}
+		return strings.Join(parts, "\n"), nil
+	default:
+		return "", NewHTTPError(http.StatusBadRequest, "invalid_system", "system must be a string or an array of text blocks")
+	}
+}
+
+func anthropicMessageToOpenAI(message map[string]any) ([]ChatMessage, error) {
+	role, _ := message["role"].(string)
+	blocks, err := anthropicContentBlocks(message["content"])
+	if err != nil {
+		return nil, err
+	}
+	if role == "assistant" {
+		return anthropicAssistantMessageToOpenAI(blocks)
+	}
+	return anthropicUserMessageToOpenAI(blocks)
+}
+
+func anthropicContentBlocks(content any) ([]map[string]any, error) {
+	switch typed := content.(type) {
+	case string:
+		return []map[string]any{{"type": "text", "text": typed}}, nil
+	case []any:
+		blocks := make([]map[string]any, 0, len(typed))
+		for _, item := range typed {
+			block, ok := item.(map[string]any)
+			if !ok {
+				return nil, NewHTTPError(http.StatusBadRequest, "invalid_content_block", "content blocks must be objects")
+			}
+			blocks = append(blocks, block)
+		}
+		return blocks, nil
+	default:
+		return nil, NewHTTPError(http.StatusBadRequest, "invalid_message", "message content must be a string or an array")
+	}
+}
+
+func anthropicAssistantMessageToOpenAI(blocks []map[string]any) ([]ChatMessage, error) {
+	contentBlocks := make([]map[string]any, 0, len(blocks))
+	toolCalls := make([]map[string]any, 0)
+	for _, block := range blocks {
+		blockType, _ := block["type"].(string)
+		switch blockType {
+		case "text", "image":
+			part, err := anthropicBlockToOpenAIContentPart(block)
+			if err != nil {
+				return nil, err
+			}
+			contentBlocks = append(contentBlocks, part)
+		case "tool_use":
+			id, _ := block["id"].(string)
+			name, _ := block["name"].(string)
+			if id == "" || name == "" {
+				return nil, NewHTTPError(http.StatusBadRequest, "invalid_tool_use", "tool_use requires id and name")
+			}
+			input := block["input"]
+			if input == nil {
+				input = map[string]any{}
+			}
+			arguments, err := json.Marshal(input)
+			if err != nil {
+				return nil, NewHTTPError(http.StatusBadRequest, "invalid_tool_use", "tool_use input must be JSON")
+			}
+			toolCalls = append(toolCalls, map[string]any{
+				"id":   id,
+				"type": "function",
+				"function": map[string]any{
+					"name":      name,
+					"arguments": string(arguments),
+				},
+			})
+		case "thinking", "redacted_thinking":
+			// OpenAI-compatible providers do not accept Anthropic thinking blocks.
+		default:
+			return nil, NewHTTPError(
+				http.StatusBadRequest,
+				"unsupported_content_block",
+				fmt.Sprintf("OpenAI-compatible routes do not support assistant content block type %q", blockType),
+			)
+		}
+	}
+	content := openAIContentFromParts(contentBlocks)
+	if len(toolCalls) > 0 && content == nil {
+		content = ""
+	}
+	return []ChatMessage{{
+		Role:      "assistant",
+		Content:   content,
+		ToolCalls: toolCalls,
+	}}, nil
+}
+
+func anthropicUserMessageToOpenAI(blocks []map[string]any) ([]ChatMessage, error) {
+	toolMessages := make([]ChatMessage, 0)
+	contentBlocks := make([]map[string]any, 0, len(blocks))
+	for _, block := range blocks {
+		blockType, _ := block["type"].(string)
+		switch blockType {
+		case "text", "image":
+			part, err := anthropicBlockToOpenAIContentPart(block)
+			if err != nil {
+				return nil, err
+			}
+			contentBlocks = append(contentBlocks, part)
+		case "tool_result":
+			toolUseID, _ := block["tool_use_id"].(string)
+			if toolUseID == "" {
+				return nil, NewHTTPError(http.StatusBadRequest, "invalid_tool_result", "tool_result requires tool_use_id")
+			}
+			content, err := anthropicToolResultContent(block["content"])
+			if err != nil {
+				return nil, err
+			}
+			if isError, _ := block["is_error"].(bool); isError {
+				if text, ok := content.(string); ok {
+					content = "Error: " + text
+				}
+			}
+			toolMessages = append(toolMessages, ChatMessage{
+				Role:       "tool",
+				Content:    content,
+				ToolCallID: toolUseID,
+			})
+		default:
+			return nil, NewHTTPError(
+				http.StatusBadRequest,
+				"unsupported_content_block",
+				fmt.Sprintf("OpenAI-compatible routes do not support user content block type %q", blockType),
+			)
+		}
+	}
+	if content := openAIContentFromParts(contentBlocks); content != nil {
+		toolMessages = append(toolMessages, ChatMessage{Role: "user", Content: content})
+	}
+	if len(toolMessages) == 0 {
+		toolMessages = append(toolMessages, ChatMessage{Role: "user", Content: ""})
+	}
+	return toolMessages, nil
+}
+
+func anthropicBlockToOpenAIContentPart(block map[string]any) (map[string]any, error) {
+	blockType, _ := block["type"].(string)
+	if blockType == "text" {
+		text, ok := block["text"].(string)
+		if !ok {
+			return nil, NewHTTPError(http.StatusBadRequest, "invalid_content_block", "text block text must be a string")
+		}
+		return map[string]any{"type": "text", "text": text}, nil
+	}
+	source, ok := block["source"].(map[string]any)
+	if !ok {
+		return nil, NewHTTPError(http.StatusBadRequest, "invalid_image", "image block source is required")
+	}
+	sourceType, _ := source["type"].(string)
+	var imageURL string
+	switch sourceType {
+	case "base64":
+		mediaType, _ := source["media_type"].(string)
+		data, _ := source["data"].(string)
+		if mediaType == "" || data == "" {
+			return nil, NewHTTPError(http.StatusBadRequest, "invalid_image", "base64 image source requires media_type and data")
+		}
+		imageURL = "data:" + mediaType + ";base64," + data
+	case "url":
+		imageURL, _ = source["url"].(string)
+		if imageURL == "" {
+			return nil, NewHTTPError(http.StatusBadRequest, "invalid_image", "URL image source requires url")
+		}
+	default:
+		return nil, NewHTTPError(http.StatusBadRequest, "unsupported_image_source", "OpenAI-compatible routes support base64 and URL image sources")
+	}
+	return map[string]any{
+		"type":      "image_url",
+		"image_url": map[string]any{"url": imageURL},
+	}, nil
+}
+
+func openAIContentFromParts(parts []map[string]any) any {
+	if len(parts) == 0 {
+		return nil
+	}
+	if len(parts) == 1 && parts[0]["type"] == "text" {
+		return parts[0]["text"]
+	}
+	result := make([]any, 0, len(parts))
+	for _, part := range parts {
+		result = append(result, part)
+	}
+	return result
+}
+
+func anthropicToolResultContent(content any) (any, error) {
+	if content == nil {
+		return "", nil
+	}
+	if text, ok := content.(string); ok {
+		return text, nil
+	}
+	blocks, err := anthropicContentBlocks(content)
+	if err != nil {
+		return nil, err
+	}
+	parts := make([]map[string]any, 0, len(blocks))
+	for _, block := range blocks {
+		blockType, _ := block["type"].(string)
+		if blockType != "text" && blockType != "image" {
+			return nil, NewHTTPError(http.StatusBadRequest, "unsupported_tool_result", "OpenAI-compatible routes support text and image tool results")
+		}
+		part, err := anthropicBlockToOpenAIContentPart(block)
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, part)
+	}
+	return openAIContentFromParts(parts), nil
+}
+
+func anthropicToolsToOpenAI(value any) (any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	rawTools, ok := value.([]any)
+	if !ok {
+		return nil, NewHTTPError(http.StatusBadRequest, "invalid_tools", "tools must be an array")
+	}
+	tools := make([]any, 0, len(rawTools))
+	for _, item := range rawTools {
+		tool, ok := item.(map[string]any)
+		if !ok {
+			return nil, NewHTTPError(http.StatusBadRequest, "invalid_tool", "each tool must be an object")
+		}
+		if toolType, _ := tool["type"].(string); toolType != "" && toolType != "custom" {
+			return nil, NewHTTPError(
+				http.StatusBadRequest,
+				"unsupported_tool",
+				fmt.Sprintf("OpenAI-compatible routes do not support Anthropic tool type %q", toolType),
+			)
+		}
+		name, _ := tool["name"].(string)
+		if name == "" {
+			return nil, NewHTTPError(http.StatusBadRequest, "invalid_tool", "tool name is required")
+		}
+		inputSchema, ok := tool["input_schema"].(map[string]any)
+		if !ok {
+			return nil, NewHTTPError(http.StatusBadRequest, "invalid_tool", "tool input_schema must be an object")
+		}
+		function := map[string]any{
+			"name":       name,
+			"parameters": inputSchema,
+		}
+		if description, ok := tool["description"].(string); ok && description != "" {
+			function["description"] = description
+		}
+		if strict, ok := tool["strict"].(bool); ok {
+			function["strict"] = strict
+		}
+		tools = append(tools, map[string]any{
+			"type":     "function",
+			"function": function,
+		})
+	}
+	return tools, nil
+}
+
+func anthropicToolChoiceToOpenAI(value any) (any, *bool, error) {
+	if value == nil {
+		return nil, nil, nil
+	}
+	choice, ok := value.(map[string]any)
+	if !ok {
+		return nil, nil, NewHTTPError(http.StatusBadRequest, "invalid_tool_choice", "tool_choice must be an object")
+	}
+	choiceType, _ := choice["type"].(string)
+	var converted any
+	switch choiceType {
+	case "auto", "":
+		converted = "auto"
+	case "any":
+		converted = "required"
+	case "none":
+		converted = "none"
+	case "tool":
+		name, _ := choice["name"].(string)
+		if name == "" {
+			return nil, nil, NewHTTPError(http.StatusBadRequest, "invalid_tool_choice", "tool_choice tool requires name")
+		}
+		converted = map[string]any{
+			"type":     "function",
+			"function": map[string]any{"name": name},
+		}
+	default:
+		return nil, nil, NewHTTPError(http.StatusBadRequest, "unsupported_tool_choice", "unsupported tool_choice type")
+	}
+	var parallel *bool
+	if disabled, ok := choice["disable_parallel_tool_use"].(bool); ok {
+		enabled := !disabled
+		parallel = &enabled
+	}
+	return converted, parallel, nil
+}
+
+func openAIResponseToAnthropic(body map[string]any, model string, usage Usage) (map[string]any, error) {
+	choices, ok := anySlice(body["choices"])
+	if !ok || len(choices) == 0 {
+		return nil, NewHTTPError(http.StatusBadGateway, "provider_invalid_response", "Provider response is missing choices")
+	}
+	choice, ok := choices[0].(map[string]any)
+	if !ok {
+		return nil, NewHTTPError(http.StatusBadGateway, "provider_invalid_response", "Provider choice is invalid")
+	}
+	message, ok := choice["message"].(map[string]any)
+	if !ok {
+		return nil, NewHTTPError(http.StatusBadGateway, "provider_invalid_response", "Provider choice is missing message")
+	}
+	content := make([]any, 0)
+	if text := openAIMessageText(message["content"]); text != "" {
+		content = append(content, map[string]any{"type": "text", "text": text})
+	}
+	toolCalls, err := openAIToolCallsToAnthropic(message["tool_calls"])
+	if err != nil {
+		return nil, err
+	}
+	content = append(content, toolCalls...)
+	if len(content) == 0 {
+		content = append(content, map[string]any{"type": "text", "text": ""})
+	}
+	finishReason, _ := choice["finish_reason"].(string)
+	stopReason := openAIFinishReasonToAnthropic(finishReason, len(toolCalls) > 0)
+	id, _ := body["id"].(string)
+	if id == "" {
+		id = NewID("msg")
+	}
+	return map[string]any{
+		"id":            id,
+		"type":          "message",
+		"role":          "assistant",
+		"content":       content,
+		"model":         model,
+		"stop_reason":   stopReason,
+		"stop_sequence": nil,
+		"usage":         anthropicUsageObject(usage),
+	}, nil
+}
+
+func openAIMessageText(content any) string {
+	switch typed := content.(type) {
+	case string:
+		return typed
+	case []any:
+		parts := make([]string, 0, len(typed))
+		for _, item := range typed {
+			block, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if text, ok := block["text"].(string); ok {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, "")
+	default:
+		return ""
+	}
+}
+
+func openAIToolCallsToAnthropic(value any) ([]any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	rawCalls, ok := anySlice(value)
+	if !ok {
+		return nil, NewHTTPError(http.StatusBadGateway, "provider_invalid_response", "Provider tool_calls is invalid")
+	}
+	result := make([]any, 0, len(rawCalls))
+	for _, item := range rawCalls {
+		call, ok := item.(map[string]any)
+		if !ok {
+			return nil, NewHTTPError(http.StatusBadGateway, "provider_invalid_response", "Provider tool call is invalid")
+		}
+		id, _ := call["id"].(string)
+		function, _ := call["function"].(map[string]any)
+		name, _ := function["name"].(string)
+		arguments, _ := function["arguments"].(string)
+		if id == "" || name == "" {
+			return nil, NewHTTPError(http.StatusBadGateway, "provider_invalid_response", "Provider tool call requires id and function name")
+		}
+		input := map[string]any{}
+		if strings.TrimSpace(arguments) != "" {
+			decoder := json.NewDecoder(strings.NewReader(arguments))
+			decoder.UseNumber()
+			if err := decoder.Decode(&input); err != nil {
+				return nil, NewHTTPError(http.StatusBadGateway, "provider_invalid_response", "Provider tool call arguments are not valid JSON")
+			}
+		}
+		result = append(result, map[string]any{
+			"type":  "tool_use",
+			"id":    id,
+			"name":  name,
+			"input": input,
+		})
+	}
+	return result, nil
+}
+
+func anySlice(value any) ([]any, bool) {
+	switch typed := value.(type) {
+	case []any:
+		return typed, true
+	case []map[string]any:
+		result := make([]any, 0, len(typed))
+		for _, item := range typed {
+			result = append(result, item)
+		}
+		return result, true
+	default:
+		return nil, false
+	}
+}
+
+func openAIFinishReasonToAnthropic(reason string, hasTools bool) string {
+	if hasTools || reason == "tool_calls" || reason == "function_call" {
+		return "tool_use"
+	}
+	switch reason {
+	case "length":
+		return "max_tokens"
+	case "stop", "":
+		return "end_turn"
+	case "content_filter":
+		return "refusal"
+	default:
+		return "end_turn"
+	}
+}
+
+func anthropicUsageObject(usage Usage) map[string]any {
+	cachedInputTokens := minInt64(maxInt64(usage.CachedInputTokens, 0), maxInt64(usage.PromptTokens, 0))
+	return map[string]any{
+		"input_tokens":                maxInt64(usage.PromptTokens-cachedInputTokens, 0),
+		"cache_creation_input_tokens": int64(0),
+		"cache_read_input_tokens":     cachedInputTokens,
+		"output_tokens":               usage.CompletionTokens,
+	}
+}
+
+func (s *Server) executeNativeAnthropicMessages(
+	ctx context.Context,
+	route RouteSelection,
+	req anthropicMessagesRequest,
+	headers http.Header,
+) (map[string]any, Usage, error) {
+	payload := cloneAnyMap(req.Raw)
+	payload["model"] = route.ProviderModel
+	payload["stream"] = false
+	resp, err := s.doNativeAnthropicRequest(ctx, route.Provider, "/v1/messages", payload, headers)
+	if err != nil {
+		return nil, Usage{}, err
+	}
+	defer resp.Body.Close()
+	var body map[string]any
+	decoder := json.NewDecoder(resp.Body)
+	decoder.UseNumber()
+	if err := decoder.Decode(&body); err != nil {
+		return nil, Usage{}, NewHTTPError(http.StatusBadGateway, "provider_invalid_response", "Anthropic provider returned invalid JSON")
+	}
+	body["model"] = req.Model
+	return body, anthropicUsage(body), nil
+}
+
+func (s *Server) doNativeAnthropicRequest(
+	ctx context.Context,
+	provider Provider,
+	endpoint string,
+	payload map[string]any,
+	downstreamHeaders http.Header,
+) (*http.Response, error) {
+	baseURL := strings.TrimRight(provider.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "https://api.anthropic.com"
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	version := strings.TrimSpace(downstreamHeaders.Get("anthropic-version"))
+	if version == "" {
+		version = strings.TrimSpace(provider.Options["anthropic_version"])
+	}
+	if version == "" {
+		version = "2023-06-01"
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("x-api-key", provider.APIKey)
+	req.Header.Set("anthropic-version", version)
+	if betas := strings.TrimSpace(downstreamHeaders.Get("anthropic-beta")); betas != "" {
+		req.Header.Set("anthropic-beta", betas)
+	}
+	for key, value := range provider.Headers {
+		req.Header.Set(key, value)
+	}
+	client := http.DefaultClient
+	if adapter, ok := s.adapters[ProviderAnthropic].(AnthropicAdapter); ok && adapter.Client != nil {
+		client = adapter.Client
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		defer resp.Body.Close()
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, newProviderHTTPError(resp.StatusCode, data)
+	}
+	return resp, nil
+}
+
+func cloneAnyMap(input map[string]any) map[string]any {
+	output := make(map[string]any, len(input))
+	for key, value := range input {
+		output[key] = value
+	}
+	return output
+}
+
+func (s *Server) handleAnthropicMessagesStream(
+	w http.ResponseWriter,
+	r *http.Request,
+	routed RoutedCall,
+	req anthropicMessagesRequest,
+) {
+	compatible, compatibilityErr := compatibleAnthropicRoutes(routed, req)
+	if compatibilityErr != nil {
+		s.finishFailedRoutedCall(r, routed, nil, compatibilityErr)
+		s.recordRequestPayload(routed.Call.RequestID, req.Raw, auditErrorPayload(compatibilityErr, routed.Call.RequestID))
+		writeAnthropicError(w, r, compatibilityErr)
+		return
+	}
+	routed = compatible
+	route := routed.Routes[0]
+	resourceID := routeResourceID(route)
+	leaseID, leaseCtx, err := s.store.CheckProviderResourceCapacity(r.Context(), resourceID)
+	if err != nil {
+		attempts := []RouteAttempt{{
+			Selection: route,
+			Status:    AsHTTPError(err).Status,
+			ErrorCode: AsHTTPError(err).Code,
+			Error:     err.Error(),
+		}}
+		s.finishFailedRoutedCall(r, routed, attempts, err)
+		s.recordRequestPayload(routed.Call.RequestID, req.Raw, auditErrorPayload(err, routed.Call.RequestID))
+		writeAnthropicError(w, r, err)
+		return
+	}
+	route, err = s.prepareRouteForUpstream(leaseCtx, route)
+	if err != nil {
+		finishProviderResourceAttempt(s.store, resourceID, leaseID, err, Usage{})
+		attempts := []RouteAttempt{{
+			Selection: route,
+			Status:    AsHTTPError(err).Status,
+			ErrorCode: AsHTTPError(err).Code,
+			Error:     err.Error(),
+		}}
+		s.finishFailedRoutedCall(r, routed, attempts, err)
+		s.recordRequestPayload(routed.Call.RequestID, req.Raw, auditErrorPayload(err, routed.Call.RequestID))
+		writeAnthropicError(w, r, err)
+		return
+	}
+
+	w.Header().Set("content-type", "text/event-stream")
+	w.Header().Set("cache-control", "no-cache")
+	w.Header().Set("x-request-id", routed.Call.RequestID)
+	s.writeRouteHeaders(w, routed.Call, route, 1)
+	tracker := &streamWriteTracker{writer: w}
+	var usage Usage
+	if route.Provider.Type == ProviderAnthropic {
+		usage, err = s.streamNativeAnthropicMessages(leaseCtx, route, req, r.Header, tracker)
+	} else if openAIMessageProvider(route.Provider.Type) {
+		usage, err = s.streamOpenAIAsAnthropic(leaseCtx, route, req, tracker)
+	} else {
+		err = NewHTTPError(
+			http.StatusNotImplemented,
+			"provider_capability_not_supported",
+			"Provider does not support the Anthropic Messages gateway",
+		)
+	}
+	if leaseErr := coordinationLeaseError(leaseCtx); leaseErr != nil {
+		err = leaseErr
+	}
+	finishProviderResourceAttempt(s.store, resourceID, leaseID, err, usage)
+	status, code := statusAndCode(err)
+	attempts := []RouteAttempt{{
+		Selection: route,
+		Status:    status,
+		ErrorCode: code,
+		Error:     errorMessage(err),
+	}}
+	if err == nil {
+		s.store.MarkRouteUsed(route.Route.ID)
+		s.store.MarkProviderResourceUsed(routeResourceID(route))
+	}
+	s.store.RecordRouteAttempts(routed.Call.RequestID, attempts)
+	s.store.FinishCall(routed.Call, route, usage, status, code, s.clientIP(r), r.UserAgent())
+	s.recordRequestPayload(routed.Call.RequestID, req.Raw, auditStreamPayload(status, code, err))
+	if err != nil {
+		if tracker.Wrote() {
+			_ = writeAnthropicStreamError(tracker, err)
+		} else {
+			w.Header().Del("cache-control")
+			writeAnthropicError(w, r, err)
+		}
+	}
+}
+
+func (s *Server) streamNativeAnthropicMessages(
+	ctx context.Context,
+	route RouteSelection,
+	req anthropicMessagesRequest,
+	headers http.Header,
+	writer io.Writer,
+) (Usage, error) {
+	payload := cloneAnyMap(req.Raw)
+	payload["model"] = route.ProviderModel
+	payload["stream"] = true
+	resp, err := s.doNativeAnthropicRequest(ctx, route.Provider, "/v1/messages", payload, headers)
+	if err != nil {
+		return Usage{}, err
+	}
+	defer resp.Body.Close()
+	return copyNativeAnthropicStream(writer, resp.Body, req.Model)
+}
+
+func copyNativeAnthropicStream(writer io.Writer, body io.Reader, model string) (Usage, error) {
+	reader := bufio.NewReader(body)
+	var usage Usage
+	for {
+		line, readErr := reader.ReadString('\n')
+		if line != "" {
+			output := line
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "data:") {
+				payload := strings.TrimSpace(strings.TrimPrefix(trimmed, "data:"))
+				if payload != "" && payload != "[DONE]" {
+					var event map[string]any
+					decoder := json.NewDecoder(strings.NewReader(payload))
+					decoder.UseNumber()
+					if err := decoder.Decode(&event); err != nil {
+						return usage, NewHTTPError(http.StatusBadGateway, "provider_invalid_response", "Anthropic provider returned invalid stream JSON")
+					}
+					if message, ok := event["message"].(map[string]any); ok {
+						message["model"] = model
+						if eventUsage, ok := message["usage"].(map[string]any); ok {
+							usage = mergeAnthropicStreamUsage(usage, eventUsage)
+						}
+					}
+					if eventUsage, ok := event["usage"].(map[string]any); ok {
+						usage = mergeAnthropicStreamUsage(usage, eventUsage)
+					}
+					encoded, _ := json.Marshal(event)
+					output = "data: " + string(encoded) + "\n"
+				}
+			}
+			if _, err := io.WriteString(writer, output); err != nil {
+				return usage, err
+			}
+			if flusher, ok := writer.(http.Flusher); ok {
+				flusher.Flush()
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				return usage, nil
+			}
+			return usage, readErr
+		}
+	}
+}
+
+func mergeAnthropicStreamUsage(current Usage, raw map[string]any) Usage {
+	inputTokens := int64FromAny(raw["input_tokens"])
+	cacheCreationInputTokens := int64FromAny(raw["cache_creation_input_tokens"])
+	cacheReadInputTokens := int64FromAny(raw["cache_read_input_tokens"])
+	if inputTokens > 0 || cacheCreationInputTokens > 0 || cacheReadInputTokens > 0 {
+		current.PromptTokens = inputTokens + cacheCreationInputTokens + cacheReadInputTokens
+		current.CachedInputTokens = cacheReadInputTokens
+	}
+	if value := int64FromAny(raw["output_tokens"]); value > 0 {
+		current.CompletionTokens = value
+	}
+	current.TotalTokens = current.PromptTokens + current.CompletionTokens
+	return current
+}
+
+func (s *Server) streamOpenAIAsAnthropic(
+	ctx context.Context,
+	route RouteSelection,
+	req anthropicMessagesRequest,
+	writer io.Writer,
+) (Usage, error) {
+	chatReq, err := anthropicToOpenAIChatRequest(req)
+	if err != nil {
+		return Usage{}, err
+	}
+	adapter, err := s.adapterForRoute(route)
+	if err != nil {
+		return Usage{}, err
+	}
+	converter := newOpenAIAnthropicStreamConverter(writer, req.Model, estimateAnthropicInputTokens(req.Raw))
+	usage, err := adapter.ChatStream(ctx, route.Provider, route.ProviderModel, chatReq, converter)
+	if err != nil {
+		return usage, err
+	}
+	if usage.TotalTokens == 0 {
+		usage = converter.usage
+	}
+	if usage.PromptTokens == 0 {
+		usage.PromptTokens = estimateAnthropicInputTokens(req.Raw)
+	}
+	if usage.CompletionTokens == 0 {
+		usage.CompletionTokens = EstimateTextTokens(converter.outputText.String() + converter.toolArgumentText())
+	}
+	usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+	if err := converter.Finalize(usage); err != nil {
+		return usage, err
+	}
+	return usage, nil
+}
+
+type openAIStreamToolCall struct {
+	Index     int
+	ID        string
+	Name      string
+	Arguments strings.Builder
+}
+
+type openAIAnthropicStreamConverter struct {
+	writer      io.Writer
+	model       string
+	messageID   string
+	inputTokens int64
+	buffer      string
+	started     bool
+	textStarted bool
+	textIndex   int
+	nextIndex   int
+	finish      string
+	finalized   bool
+	tools       map[int]*openAIStreamToolCall
+	usage       Usage
+	outputText  strings.Builder
+}
+
+func newOpenAIAnthropicStreamConverter(writer io.Writer, model string, inputTokens int64) *openAIAnthropicStreamConverter {
+	return &openAIAnthropicStreamConverter{
+		writer:      writer,
+		model:       model,
+		messageID:   NewID("msg"),
+		inputTokens: inputTokens,
+		tools:       map[int]*openAIStreamToolCall{},
+	}
+}
+
+func (c *openAIAnthropicStreamConverter) Write(data []byte) (int, error) {
+	c.buffer += string(data)
+	for {
+		index := strings.IndexByte(c.buffer, '\n')
+		if index < 0 {
+			break
+		}
+		line := c.buffer[:index]
+		c.buffer = c.buffer[index+1:]
+		if err := c.consumeLine(line); err != nil {
+			return 0, err
+		}
+	}
+	return len(data), nil
+}
+
+func (c *openAIAnthropicStreamConverter) consumeLine(line string) error {
+	payload := strings.TrimSpace(line)
+	if payload == "" || strings.HasPrefix(payload, ":") || strings.HasPrefix(payload, "event:") {
+		return nil
+	}
+	if !strings.HasPrefix(payload, "data:") {
+		return nil
+	}
+	payload = strings.TrimSpace(strings.TrimPrefix(payload, "data:"))
+	if payload == "" || payload == "[DONE]" {
+		return nil
+	}
+	var event map[string]any
+	decoder := json.NewDecoder(strings.NewReader(payload))
+	decoder.UseNumber()
+	if err := decoder.Decode(&event); err != nil {
+		return NewHTTPError(http.StatusBadGateway, "provider_invalid_response", "OpenAI provider returned invalid stream JSON")
+	}
+	if id, ok := event["id"].(string); ok && id != "" {
+		c.messageID = id
+	}
+	if parsed := usageFromMap(event); parsed.TotalTokens > 0 {
+		c.usage = parsed
+	}
+	choices, ok := anySlice(event["choices"])
+	if !ok || len(choices) == 0 {
+		return nil
+	}
+	choice, ok := choices[0].(map[string]any)
+	if !ok {
+		return NewHTTPError(http.StatusBadGateway, "provider_invalid_response", "OpenAI stream choice is invalid")
+	}
+	if finish, ok := choice["finish_reason"].(string); ok && finish != "" {
+		c.finish = finish
+	}
+	delta, _ := choice["delta"].(map[string]any)
+	if text, ok := delta["content"].(string); ok && text != "" {
+		if err := c.startMessage(); err != nil {
+			return err
+		}
+		if !c.textStarted {
+			c.textIndex = c.nextIndex
+			c.nextIndex++
+			c.textStarted = true
+			if err := c.emit("content_block_start", map[string]any{
+				"type":  "content_block_start",
+				"index": c.textIndex,
+				"content_block": map[string]any{
+					"type": "text",
+					"text": "",
+				},
+			}); err != nil {
+				return err
+			}
+		}
+		c.outputText.WriteString(text)
+		if err := c.emit("content_block_delta", map[string]any{
+			"type":  "content_block_delta",
+			"index": c.textIndex,
+			"delta": map[string]any{
+				"type": "text_delta",
+				"text": text,
+			},
+		}); err != nil {
+			return err
+		}
+	}
+	rawToolCalls, _ := anySlice(delta["tool_calls"])
+	for _, item := range rawToolCalls {
+		call, ok := item.(map[string]any)
+		if !ok {
+			return NewHTTPError(http.StatusBadGateway, "provider_invalid_response", "OpenAI stream tool call is invalid")
+		}
+		index := int(int64FromAny(call["index"]))
+		current := c.tools[index]
+		if current == nil {
+			current = &openAIStreamToolCall{Index: index}
+			c.tools[index] = current
+		}
+		if id, ok := call["id"].(string); ok {
+			current.ID += id
+		}
+		if function, ok := call["function"].(map[string]any); ok {
+			if name, ok := function["name"].(string); ok {
+				current.Name += name
+			}
+			if arguments, ok := function["arguments"].(string); ok {
+				current.Arguments.WriteString(arguments)
+			}
+		}
+	}
+	return nil
+}
+
+func (c *openAIAnthropicStreamConverter) startMessage() error {
+	if c.started {
+		return nil
+	}
+	c.started = true
+	return c.emit("message_start", map[string]any{
+		"type": "message_start",
+		"message": map[string]any{
+			"id":            c.messageID,
+			"type":          "message",
+			"role":          "assistant",
+			"content":       []any{},
+			"model":         c.model,
+			"stop_reason":   nil,
+			"stop_sequence": nil,
+			"usage": map[string]any{
+				"input_tokens":  c.inputTokens,
+				"output_tokens": int64(0),
+			},
+		},
+	})
+}
+
+func (c *openAIAnthropicStreamConverter) Finalize(usage Usage) error {
+	if c.finalized {
+		return nil
+	}
+	c.finalized = true
+	if c.buffer != "" {
+		if err := c.consumeLine(c.buffer); err != nil {
+			return err
+		}
+		c.buffer = ""
+	}
+	if err := c.startMessage(); err != nil {
+		return err
+	}
+	if c.textStarted {
+		if err := c.emit("content_block_stop", map[string]any{
+			"type":  "content_block_stop",
+			"index": c.textIndex,
+		}); err != nil {
+			return err
+		}
+	}
+	toolIndexes := make([]int, 0, len(c.tools))
+	for index := range c.tools {
+		toolIndexes = append(toolIndexes, index)
+	}
+	sort.Ints(toolIndexes)
+	for _, toolIndex := range toolIndexes {
+		call := c.tools[toolIndex]
+		if call.ID == "" || call.Name == "" {
+			return NewHTTPError(http.StatusBadGateway, "provider_invalid_response", "OpenAI stream tool call requires id and function name")
+		}
+		arguments := call.Arguments.String()
+		if strings.TrimSpace(arguments) == "" {
+			arguments = "{}"
+		}
+		var input any
+		decoder := json.NewDecoder(strings.NewReader(arguments))
+		decoder.UseNumber()
+		if err := decoder.Decode(&input); err != nil {
+			return NewHTTPError(http.StatusBadGateway, "provider_invalid_response", "OpenAI stream tool call arguments are not valid JSON")
+		}
+		index := c.nextIndex
+		c.nextIndex++
+		if err := c.emit("content_block_start", map[string]any{
+			"type":  "content_block_start",
+			"index": index,
+			"content_block": map[string]any{
+				"type":  "tool_use",
+				"id":    call.ID,
+				"name":  call.Name,
+				"input": map[string]any{},
+			},
+		}); err != nil {
+			return err
+		}
+		if err := c.emit("content_block_delta", map[string]any{
+			"type":  "content_block_delta",
+			"index": index,
+			"delta": map[string]any{
+				"type":         "input_json_delta",
+				"partial_json": arguments,
+			},
+		}); err != nil {
+			return err
+		}
+		if err := c.emit("content_block_stop", map[string]any{
+			"type":  "content_block_stop",
+			"index": index,
+		}); err != nil {
+			return err
+		}
+	}
+	stopReason := openAIFinishReasonToAnthropic(c.finish, len(c.tools) > 0)
+	if err := c.emit("message_delta", map[string]any{
+		"type": "message_delta",
+		"delta": map[string]any{
+			"stop_reason":   stopReason,
+			"stop_sequence": nil,
+		},
+		"usage": map[string]any{
+			"output_tokens": usage.CompletionTokens,
+		},
+	}); err != nil {
+		return err
+	}
+	return c.emit("message_stop", map[string]any{"type": "message_stop"})
+}
+
+func (c *openAIAnthropicStreamConverter) emit(event string, payload map[string]any) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(c.writer, "event: %s\ndata: %s\n\n", event, data); err != nil {
+		return err
+	}
+	if flusher, ok := c.writer.(http.Flusher); ok {
+		flusher.Flush()
+	}
+	return nil
+}
+
+func (c *openAIAnthropicStreamConverter) toolArgumentText() string {
+	var output strings.Builder
+	indexes := make([]int, 0, len(c.tools))
+	for index := range c.tools {
+		indexes = append(indexes, index)
+	}
+	sort.Ints(indexes)
+	for _, index := range indexes {
+		output.WriteString(c.tools[index].Arguments.String())
+	}
+	return output.String()
+}
+
+func estimateAnthropicInputTokens(payload map[string]any) int64 {
+	var tokens int64
+	for _, key := range []string{"system", "messages", "tools", "tool_choice"} {
+		tokens += estimateAnthropicValueTokens(payload[key])
+	}
+	if tokens <= 0 {
+		return 1
+	}
+	return tokens
+}
+
+func estimateAnthropicValueTokens(value any) int64 {
+	switch typed := value.(type) {
+	case nil:
+		return 0
+	case string:
+		return EstimateTextTokens(typed)
+	case json.Number:
+		return 1
+	case bool:
+		return 1
+	case []any:
+		var total int64
+		for _, item := range typed {
+			total += estimateAnthropicValueTokens(item) + 1
+		}
+		return total
+	case map[string]any:
+		if blockType, _ := typed["type"].(string); blockType == "image" {
+			return 1600
+		}
+		var total int64
+		for key, item := range typed {
+			if key == "cache_control" || key == "signature" || key == "data" {
+				continue
+			}
+			total += EstimateTextTokens(key) + estimateAnthropicValueTokens(item) + 1
+		}
+		return total
+	default:
+		return EstimateTextTokens(fmt.Sprint(typed))
+	}
+}
+
+func writeAnthropicError(w http.ResponseWriter, r *http.Request, err error) {
+	httpErr := AsHTTPError(err)
+	requestID := strings.TrimSpace(w.Header().Get("x-request-id"))
+	if requestID == "" {
+		requestID = NewID("req")
+	}
+	w.Header().Set("x-request-id", requestID)
+	writeJSON(w, httpErr.Status, map[string]any{
+		"type": "error",
+		"error": map[string]any{
+			"type":    anthropicErrorType(httpErr.Status),
+			"message": httpErr.Message,
+			"code":    httpErr.Code,
+		},
+		"request_id": requestID,
+	})
+}
+
+func anthropicErrorType(status int) string {
+	switch status {
+	case http.StatusBadRequest, http.StatusNotFound, http.StatusMethodNotAllowed:
+		return "invalid_request_error"
+	case http.StatusUnauthorized:
+		return "authentication_error"
+	case http.StatusForbidden:
+		return "permission_error"
+	case http.StatusTooManyRequests:
+		return "rate_limit_error"
+	case http.StatusServiceUnavailable:
+		return "overloaded_error"
+	default:
+		return "api_error"
+	}
+}
+
+func writeAnthropicStreamError(writer io.Writer, err error) error {
+	httpErr := AsHTTPError(err)
+	payload, marshalErr := json.Marshal(map[string]any{
+		"type": "error",
+		"error": map[string]any{
+			"type":    anthropicErrorType(httpErr.Status),
+			"message": httpErr.Message,
+			"code":    httpErr.Code,
+		},
+	})
+	if marshalErr != nil {
+		return marshalErr
+	}
+	_, writeErr := fmt.Fprintf(writer, "event: error\ndata: %s\n\n", payload)
+	return writeErr
+}

--- a/backend/internal/server/anthropic_messages_live_test.go
+++ b/backend/internal/server/anthropic_messages_live_test.go
@@ -1,0 +1,396 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	liveAnthropicPublicModel = "claude-sonnet-4-6"
+	liveAnthropicProjectKey  = "thk_live_claude_code_e2e"
+)
+
+// TestClaudeCodeLiveE2E is an opt-in live validation. It keeps the upstream
+// credential in process memory, exercises the SDK smoke test, and asks the
+// installed Claude Code CLI to inspect this repository through TokenHub.
+func TestClaudeCodeLiveE2E(t *testing.T) {
+	upstreamAPIKey := strings.TrimSpace(os.Getenv("TOKENHUB_LIVE_ARK_API_KEY"))
+	if upstreamAPIKey == "" {
+		t.Skip("set TOKENHUB_LIVE_ARK_API_KEY to run the live Claude Code validation")
+	}
+
+	upstreamBaseURL := strings.TrimSpace(os.Getenv("TOKENHUB_LIVE_ARK_BASE_URL"))
+	if upstreamBaseURL == "" {
+		upstreamBaseURL = "https://ark-cn-beijing.bytedance.net/api/v3"
+	}
+	upstreamModel := strings.TrimSpace(os.Getenv("TOKENHUB_LIVE_ARK_MODEL"))
+	if upstreamModel == "" {
+		upstreamModel = "ep-20260110190602-xswg5"
+	}
+
+	st := NewMemoryStore()
+	project := st.CreateProject(Project{Name: "claude-code-live", Status: StatusActive})
+	if _, _, err := st.CreateAPIKey(project.ID, APIKey{
+		Name:    "claude-code-live",
+		Allowed: []string{liveAnthropicPublicModel},
+		Status:  StatusActive,
+	}, liveAnthropicProjectKey); err != nil {
+		t.Fatal(err)
+	}
+	st.AddModel(Model{
+		Name:                liveAnthropicPublicModel,
+		Family:              "claude",
+		Modality:            "chat",
+		ContextWindow:       200000,
+		InputModalities:     []string{"text", "image"},
+		Capabilities:        []string{"chat", "vision", "tools"},
+		InputPriceUSDPer1M:  0,
+		OutputPriceUSDPer1M: 0,
+		SupportedParameters: []string{"tools", "image_input"},
+		Status:              StatusActive,
+	})
+	provider := st.AddProvider(Provider{
+		ID:      "prv_ark_live",
+		Name:    "ark-live",
+		Type:    ProviderOpenAICompatible,
+		BaseURL: upstreamBaseURL,
+		Status:  StatusActive,
+		Healthy: true,
+	})
+	st.AddRoute(ModelRoute{
+		ID:            "route_ark_live",
+		ModelName:     liveAnthropicPublicModel,
+		ProviderID:    provider.ID,
+		ProviderModel: upstreamModel,
+		Priority:      1,
+		Weight:        100,
+		Status:        StatusActive,
+		Strategy:      RouteStrategyPriorityOnly,
+	})
+
+	app := New(st)
+	liveAdapter := liveCredentialAdapter{
+		apiKey:   upstreamAPIKey,
+		delegate: OpenAICompatibleAdapter{},
+	}
+	app.adapters[ProviderOpenAICompatible] = liveAdapter
+	app.adapterRegistry.Register(
+		ProviderOpenAICompatible,
+		liveAdapter,
+		AdapterCapabilityChat,
+		AdapterCapabilityChatStream,
+		AdapterCapabilityResponses,
+		AdapterCapabilityEmbeddings,
+		AdapterCapabilityProbe,
+	)
+	gateway := httptest.NewServer(app.Handler())
+	t.Cleanup(gateway.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	t.Run("vision_message", func(t *testing.T) {
+		requestBody := map[string]any{
+			"model":      liveAnthropicPublicModel,
+			"max_tokens": 256,
+			"messages": []map[string]any{{
+				"role": "user",
+				"content": []map[string]any{
+					{
+						"type": "image",
+						"source": map[string]any{
+							"type": "url",
+							"url":  "https://ark-project.tos-cn-beijing.ivolces.com/images/view.jpeg",
+						},
+					},
+					{"type": "text", "text": "这是哪里？请简短回答。"},
+				},
+			}},
+		}
+		response := postLiveAnthropicMessage(t, ctx, gateway.URL, requestBody)
+		content, _ := response["content"].([]any)
+		if len(content) == 0 {
+			t.Fatalf("expected vision response content, got %#v", response)
+		}
+		t.Logf("vision response: %s", truncateLiveOutput(mustJSON(response), 2000))
+	})
+
+	repositoryRoot := liveRepositoryRoot(t)
+	commandEnvironment := liveCommandEnvironment(gateway.URL)
+
+	t.Run("sdk_smoke", func(t *testing.T) {
+		command := exec.CommandContext(ctx, "npm", "run", "test:anthropic-messages")
+		command.Dir = filepath.Join(repositoryRoot, "sdk")
+		command.Env = commandEnvironment
+		output, err := command.CombinedOutput()
+		t.Logf("SDK smoke output:\n%s", truncateLiveOutput(string(output), 6000))
+		if err != nil {
+			t.Fatalf("SDK Anthropic Messages smoke test failed: %v", err)
+		}
+	})
+
+	t.Run("claude_code_repository_understanding", func(t *testing.T) {
+		claudePath, err := exec.LookPath("claude")
+		if err != nil {
+			t.Fatalf("Claude Code executable is required for live validation: %v", err)
+		}
+		prompt := strings.Join([]string{
+			"Understand this repository thoroughly.",
+			"Collect focused evidence by issuing exactly five parallel Bash tool calls, one for each command:",
+			"`sed -n '1,220p' README.md`;",
+			"`sed -n '1,220p' docs/development/workflows/feature-dev.md`;",
+			"`sed -n '1,120p' frontend/package.json`;",
+			"`rg -n 'HandleFunc\\\\(\\\"/v1|handleChatCompletions|authenticate\\\\(' backend/internal/server/http.go`;",
+			"and `rg -n 'type ProviderAdapter|OpenAICompatibleAdapter|AnthropicAdapter' backend/internal/server/providers.go`.",
+			"After that single parallel tool round, do not call another tool; answer from the collected evidence.",
+			"Explain the architecture, request-routing flow, security boundaries, and validation workflow.",
+			"Identify two concrete engineering risks.",
+			"Cite the relevant repository file path for every major claim.",
+			"Do not modify any file.",
+		}, " ")
+		command := exec.CommandContext(
+			ctx,
+			claudePath,
+			"-p",
+			"--max-turns", "8",
+			"--no-session-persistence",
+			"--output-format", "json",
+			"--tools=Bash",
+			prompt,
+		)
+		command.Dir = repositoryRoot
+		command.Env = commandEnvironment
+		output, err := command.CombinedOutput()
+		t.Logf("Claude Code output:\n%s", truncateLiveOutput(string(output), 12000))
+		if err != nil {
+			t.Fatalf("Claude Code repository query failed: %v", err)
+		}
+
+		var result struct {
+			Type     string `json:"type"`
+			Subtype  string `json:"subtype"`
+			Result   string `json:"result"`
+			NumTurns int    `json:"num_turns"`
+			IsError  bool   `json:"is_error"`
+		}
+		if err := json.Unmarshal(output, &result); err != nil {
+			t.Fatalf("decode Claude Code JSON output: %v", err)
+		}
+		if result.IsError || result.Type != "result" {
+			t.Fatalf("Claude Code returned an unsuccessful result: type=%q subtype=%q", result.Type, result.Subtype)
+		}
+		if result.NumTurns < 2 {
+			t.Fatalf("expected a multi-turn tool-using query, got %d turn(s)", result.NumTurns)
+		}
+		for _, expected := range []string{"backend/", "frontend/", "README.md"} {
+			if !strings.Contains(result.Result, expected) {
+				t.Fatalf("Claude Code result did not cite %q", expected)
+			}
+		}
+	})
+}
+
+type liveCredentialAdapter struct {
+	apiKey   string
+	delegate OpenAICompatibleAdapter
+}
+
+func (a liveCredentialAdapter) Chat(
+	ctx context.Context,
+	provider Provider,
+	providerModel string,
+	request ChatCompletionRequest,
+) (any, Usage, error) {
+	provider.APIKey = a.apiKey
+	return a.delegate.Chat(ctx, provider, providerModel, request)
+}
+
+func (a liveCredentialAdapter) ChatStream(
+	ctx context.Context,
+	provider Provider,
+	providerModel string,
+	request ChatCompletionRequest,
+	writer io.Writer,
+) (Usage, error) {
+	provider.APIKey = a.apiKey
+	return a.delegate.ChatStream(ctx, provider, providerModel, request, writer)
+}
+
+func (a liveCredentialAdapter) Responses(
+	ctx context.Context,
+	provider Provider,
+	providerModel string,
+	request ResponsesRequest,
+) (any, Usage, error) {
+	provider.APIKey = a.apiKey
+	return a.delegate.Responses(ctx, provider, providerModel, request)
+}
+
+func (a liveCredentialAdapter) Embeddings(
+	ctx context.Context,
+	provider Provider,
+	providerModel string,
+	request EmbeddingsRequest,
+) (any, Usage, error) {
+	provider.APIKey = a.apiKey
+	return a.delegate.Embeddings(ctx, provider, providerModel, request)
+}
+
+func postLiveAnthropicMessage(
+	t *testing.T,
+	ctx context.Context,
+	baseURL string,
+	requestBody map[string]any,
+) map[string]any {
+	t.Helper()
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		baseURL+"/v1/messages",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+liveAnthropicProjectKey)
+	request.Header.Set("anthropic-version", "2023-06-01")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("Anthropic Messages returned %d: %s", response.StatusCode, responseBody)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(responseBody, &decoded); err != nil {
+		t.Fatalf("decode Anthropic Messages response: %v; body=%s", err, responseBody)
+	}
+	return decoded
+}
+
+func liveRepositoryRoot(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve live test source path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", ".."))
+}
+
+func liveCommandEnvironment(gatewayURL string) []string {
+	allowedInherited := map[string]struct{}{
+		"COLORTERM":       {},
+		"HOME":            {},
+		"LANG":            {},
+		"LC_ALL":          {},
+		"LOGNAME":         {},
+		"NO_COLOR":        {},
+		"PATH":            {},
+		"SHELL":           {},
+		"TERM":            {},
+		"TMPDIR":          {},
+		"USER":            {},
+		"XDG_CACHE_HOME":  {},
+		"XDG_CONFIG_HOME": {},
+	}
+	overrides := map[string]string{
+		"ANTHROPIC_API_KEY":                        "",
+		"ANTHROPIC_AUTH_TOKEN":                     liveAnthropicProjectKey,
+		"ANTHROPIC_BASE_URL":                       gatewayURL,
+		"ANTHROPIC_MODEL":                          liveAnthropicPublicModel,
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+		"CLAUDE_CODE_USE_BEDROCK":                  "",
+		"CLAUDE_CODE_USE_VERTEX":                   "",
+		"CLAUDE_CODE_USE_FOUNDRY":                  "",
+		"DISABLE_AUTOUPDATER":                      "1",
+		"TOKENHUB_API_KEY":                         liveAnthropicProjectKey,
+		"TOKENHUB_BASE_URL":                        gatewayURL + "/v1",
+		"TOKENHUB_MODEL":                           liveAnthropicPublicModel,
+	}
+	environment := make([]string, 0, len(allowedInherited)+len(overrides))
+	for _, item := range os.Environ() {
+		name, _, found := strings.Cut(item, "=")
+		if _, allowed := allowedInherited[name]; !found || !allowed {
+			continue
+		}
+		environment = append(environment, item)
+	}
+	for name, value := range overrides {
+		environment = append(environment, name+"="+value)
+	}
+	return environment
+}
+
+func TestLiveCommandEnvironmentExcludesCredentialsAndDefaultAliases(t *testing.T) {
+	for name, value := range map[string]string{
+		"TOKENHUB_LIVE_ARK_API_KEY":          "upstream-secret-must-not-leak",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL":       "unexpected-opus",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL":     "unexpected-sonnet",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL":      "unexpected-haiku",
+		"TOKENHUB_UNRELATED_TEST_CREDENTIAL": "unrelated-secret-must-not-leak",
+	} {
+		t.Setenv(name, value)
+	}
+
+	environment := map[string]string{}
+	for _, item := range liveCommandEnvironment("http://127.0.0.1:9876") {
+		name, value, found := strings.Cut(item, "=")
+		if found {
+			environment[name] = value
+		}
+	}
+	for _, forbidden := range []string{
+		"TOKENHUB_LIVE_ARK_API_KEY",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+		"TOKENHUB_UNRELATED_TEST_CREDENTIAL",
+	} {
+		if _, exists := environment[forbidden]; exists {
+			t.Fatalf("sensitive or model-alias environment variable %q leaked to child process", forbidden)
+		}
+	}
+	if environment["ANTHROPIC_MODEL"] != liveAnthropicPublicModel {
+		t.Fatalf("expected documented ANTHROPIC_MODEL, got %q", environment["ANTHROPIC_MODEL"])
+	}
+	if environment["ANTHROPIC_AUTH_TOKEN"] != liveAnthropicProjectKey {
+		t.Fatalf("expected synthetic TokenHub credential, got %q", environment["ANTHROPIC_AUTH_TOKEN"])
+	}
+}
+
+func mustJSON(value any) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("%#v", value)
+	}
+	return string(encoded)
+}
+
+func truncateLiveOutput(value string, limit int) string {
+	if len(value) <= limit {
+		return value
+	}
+	return value[:limit] + "\n... (truncated)"
+}

--- a/backend/internal/server/anthropic_messages_test.go
+++ b/backend/internal/server/anthropic_messages_test.go
@@ -1,0 +1,750 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestAnthropicMessagesConvertsToolsAndToolResultsForOpenAI(t *testing.T) {
+	var mu sync.Mutex
+	var upstreamRequests []map[string]any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("unexpected upstream path %q", r.URL.Path)
+		}
+		if r.Header.Get("authorization") != "Bearer upstream-secret" {
+			t.Errorf("unexpected upstream authorization %q", r.Header.Get("authorization"))
+		}
+		var payload map[string]any
+		decoder := json.NewDecoder(r.Body)
+		decoder.UseNumber()
+		if err := decoder.Decode(&payload); err != nil {
+			t.Errorf("decode upstream request: %v", err)
+			return
+		}
+		mu.Lock()
+		upstreamRequests = append(upstreamRequests, payload)
+		requestNumber := len(upstreamRequests)
+		mu.Unlock()
+
+		w.Header().Set("content-type", "application/json")
+		if requestNumber == 1 {
+			_, _ = io.WriteString(w, `{
+				"id":"chatcmpl_tools",
+				"choices":[{
+					"index":0,
+					"message":{
+						"role":"assistant",
+						"content":"I will inspect both files.",
+						"tool_calls":[
+							{"id":"call_read_1","type":"function","function":{"name":"Read","arguments":"{\"file_path\":\"README.md\"}"}},
+							{"id":"call_read_2","type":"function","function":{"name":"Read","arguments":"{\"file_path\":\"backend/internal/server/http.go\"}"}}
+						]
+					},
+					"finish_reason":"tool_calls"
+				}],
+				"usage":{
+					"prompt_tokens":120,
+					"completion_tokens":30,
+					"total_tokens":150,
+					"prompt_tokens_details":{"cached_tokens":80}
+				}
+			}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl_final",
+			"choices":[{
+				"index":0,
+				"message":{"role":"assistant","content":"TokenHub is a Go gateway with a Next.js console."},
+				"finish_reason":"stop"
+			}],
+			"usage":{"prompt_tokens":180,"completion_tokens":20,"total_tokens":200}
+		}`)
+	}))
+	defer upstream.Close()
+
+	handler, store, secret := newAnthropicGateway(t, upstream.URL, ProviderOpenAICompatible)
+	first := doAnthropicRequest(t, handler, "/v1/messages", map[string]any{
+		"model":      "claude-tokenhub-test",
+		"max_tokens": 2048,
+		"system": []any{
+			map[string]any{"type": "text", "text": "Understand the repository.", "cache_control": map[string]any{"type": "ephemeral"}},
+		},
+		"messages": []any{
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "text", "text": "Inspect the repository."},
+					map[string]any{
+						"type": "image",
+						"source": map[string]any{
+							"type": "url",
+							"url":  "https://example.com/architecture.png",
+						},
+					},
+				},
+			},
+		},
+		"tools": []any{
+			map[string]any{
+				"name":        "Read",
+				"description": "Read a file",
+				"input_schema": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"file_path": map[string]any{"type": "string"}},
+					"required":   []any{"file_path"},
+				},
+				"cache_control": map[string]any{"type": "ephemeral"},
+			},
+		},
+		"tool_choice": map[string]any{"type": "auto", "disable_parallel_tool_use": false},
+	}, "Bearer "+secret, "")
+	if first.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", first.Code, first.Body.String())
+	}
+	var firstResponse map[string]any
+	if err := json.Unmarshal(first.Body.Bytes(), &firstResponse); err != nil {
+		t.Fatal(err)
+	}
+	if firstResponse["type"] != "message" || firstResponse["model"] != "claude-tokenhub-test" || firstResponse["stop_reason"] != "tool_use" {
+		t.Fatalf("unexpected Anthropic response: %s", first.Body)
+	}
+	content, _ := firstResponse["content"].([]any)
+	if len(content) != 3 {
+		t.Fatalf("expected text and two tool_use blocks: %s", first.Body)
+	}
+	for _, index := range []int{1, 2} {
+		block, _ := content[index].(map[string]any)
+		if block["type"] != "tool_use" || block["name"] != "Read" {
+			t.Fatalf("unexpected tool block: %#v", block)
+		}
+	}
+	firstUsage, _ := firstResponse["usage"].(map[string]any)
+	if firstUsage["input_tokens"] != float64(40) || firstUsage["cache_read_input_tokens"] != float64(80) {
+		t.Fatalf("expected Anthropic cache usage without double counting: %#v", firstUsage)
+	}
+
+	mu.Lock()
+	firstUpstream := upstreamRequests[0]
+	mu.Unlock()
+	if firstUpstream["model"] != "upstream-model" {
+		t.Fatalf("expected routed provider model, got %#v", firstUpstream["model"])
+	}
+	upstreamMessages, _ := firstUpstream["messages"].([]any)
+	if len(upstreamMessages) != 2 {
+		t.Fatalf("expected system and user messages, got %#v", upstreamMessages)
+	}
+	userMessage, _ := upstreamMessages[1].(map[string]any)
+	userContent, _ := userMessage["content"].([]any)
+	imagePart, _ := userContent[1].(map[string]any)
+	if imagePart["type"] != "image_url" {
+		t.Fatalf("expected OpenAI image_url conversion, got %#v", imagePart)
+	}
+	upstreamTools, _ := firstUpstream["tools"].([]any)
+	if len(upstreamTools) != 1 {
+		t.Fatalf("expected one converted tool, got %#v", firstUpstream["tools"])
+	}
+	if firstUpstream["parallel_tool_calls"] != true {
+		t.Fatalf("expected parallel tool calls to remain enabled: %#v", firstUpstream)
+	}
+
+	second := doAnthropicRequest(t, handler, "/v1/messages", map[string]any{
+		"model":      "claude-tokenhub-test",
+		"max_tokens": 2048,
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Inspect the repository."},
+			map[string]any{"role": "assistant", "content": content},
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "tool_result", "tool_use_id": "call_read_1", "content": "# TokenHub"},
+					map[string]any{"type": "tool_result", "tool_use_id": "call_read_2", "content": "package server"},
+				},
+			},
+		},
+		"tools": []any{
+			map[string]any{
+				"name":         "Read",
+				"description":  "Read a file",
+				"input_schema": map[string]any{"type": "object"},
+			},
+		},
+	}, "Bearer "+secret, "")
+	if second.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", second.Code, second.Body.String())
+	}
+	if !strings.Contains(second.Body.String(), "TokenHub is a Go gateway") {
+		t.Fatalf("unexpected final response: %s", second.Body)
+	}
+
+	mu.Lock()
+	secondUpstream := upstreamRequests[1]
+	mu.Unlock()
+	secondMessages, _ := secondUpstream["messages"].([]any)
+	if len(secondMessages) != 4 {
+		t.Fatalf("expected user, assistant, and two tool messages, got %#v", secondMessages)
+	}
+	assistantMessage, _ := secondMessages[1].(map[string]any)
+	assistantCalls, _ := assistantMessage["tool_calls"].([]any)
+	if len(assistantCalls) != 2 {
+		t.Fatalf("expected two upstream tool_calls, got %#v", assistantMessage)
+	}
+	for _, index := range []int{2, 3} {
+		toolMessage, _ := secondMessages[index].(map[string]any)
+		if toolMessage["role"] != "tool" || toolMessage["tool_call_id"] == "" {
+			t.Fatalf("unexpected tool result message: %#v", toolMessage)
+		}
+	}
+
+	if len(store.ListUsageRecords()) != 2 {
+		t.Fatalf("expected two billed inference records, got %d", len(store.ListUsageRecords()))
+	}
+}
+
+func TestAnthropicMessagesConvertsOpenAIStreamingTextAndToolCall(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode upstream request: %v", err)
+		}
+		if payload["stream"] != true {
+			t.Errorf("expected streaming upstream request: %#v", payload)
+		}
+		options, _ := payload["stream_options"].(map[string]any)
+		if options["include_usage"] != true {
+			t.Errorf("expected include_usage stream option: %#v", options)
+		}
+		w.Header().Set("content-type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl_stream\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"I will inspect \"},\"finish_reason\":null}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl_stream\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_read\",\"type\":\"function\",\"function\":{\"name\":\"Read\",\"arguments\":\"{\\\"file_path\\\":\"}}]},\"finish_reason\":null}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl_stream\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"README.md\\\"}\"}}]},\"finish_reason\":null}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl_stream\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":90,\"completion_tokens\":12,\"total_tokens\":102}}\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	handler, store, secret := newAnthropicGateway(t, upstream.URL, ProviderOpenAICompatible)
+	resp := doAnthropicRequest(t, handler, "/v1/messages", map[string]any{
+		"model":      "claude-tokenhub-test",
+		"max_tokens": 1024,
+		"stream":     true,
+		"messages":   []any{map[string]any{"role": "user", "content": "Understand this repo."}},
+		"tools": []any{
+			map[string]any{
+				"name":         "Read",
+				"description":  "Read a file",
+				"input_schema": map[string]any{"type": "object"},
+			},
+		},
+	}, "Bearer "+secret, "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	body := resp.Body.String()
+	for _, expected := range []string{
+		"event: message_start",
+		"event: content_block_start",
+		`"text":"I will inspect ","type":"text_delta"`,
+		`"id":"call_read","input":{},"name":"Read","type":"tool_use"`,
+		`"partial_json":"{\"file_path\":\"README.md\"}","type":"input_json_delta"`,
+		`"stop_reason":"tool_use"`,
+		"event: message_stop",
+	} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("stream is missing %q:\n%s", expected, body)
+		}
+	}
+	records := store.ListUsageRecords()
+	if len(records) != 1 || records[0].TotalTokens != 102 {
+		t.Fatalf("unexpected streaming usage records: %+v", records)
+	}
+}
+
+func TestAnthropicMessagesPreservesNativeProtocolAndHeaders(t *testing.T) {
+	var upstreamPayload map[string]any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/messages" {
+			t.Errorf("unexpected upstream path %q", r.URL.Path)
+		}
+		if r.Header.Get("x-api-key") != "upstream-secret" {
+			t.Errorf("unexpected upstream key %q", r.Header.Get("x-api-key"))
+		}
+		if r.Header.Get("anthropic-version") != "2023-06-01" {
+			t.Errorf("unexpected version %q", r.Header.Get("anthropic-version"))
+		}
+		if r.Header.Get("anthropic-beta") != "interleaved-thinking-2025-05-14" {
+			t.Errorf("unexpected beta %q", r.Header.Get("anthropic-beta"))
+		}
+		decoder := json.NewDecoder(r.Body)
+		decoder.UseNumber()
+		if err := decoder.Decode(&upstreamPayload); err != nil {
+			t.Errorf("decode upstream request: %v", err)
+		}
+		w.Header().Set("content-type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"msg_native",
+			"type":"message",
+			"role":"assistant",
+			"model":"upstream-model",
+			"content":[{"type":"tool_use","id":"toolu_native","name":"Read","input":{"file_path":"README.md"}}],
+			"stop_reason":"tool_use",
+			"stop_sequence":null,
+			"usage":{"input_tokens":50,"output_tokens":10}
+		}`)
+	}))
+	defer upstream.Close()
+
+	handler, _, secret := newAnthropicGateway(t, upstream.URL, ProviderAnthropic)
+	resp := doAnthropicRequest(t, handler, "/v1/messages", map[string]any{
+		"model":      "claude-tokenhub-test",
+		"max_tokens": 1024,
+		"thinking":   map[string]any{"type": "adaptive"},
+		"messages":   []any{map[string]any{"role": "user", "content": "Inspect the repository."}},
+		"tools": []any{
+			map[string]any{
+				"name":         "Read",
+				"input_schema": map[string]any{"type": "object"},
+			},
+		},
+	}, "Bearer "+secret, "interleaved-thinking-2025-05-14")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if upstreamPayload["model"] != "upstream-model" || upstreamPayload["stream"] != false {
+		t.Fatalf("unexpected native upstream payload: %#v", upstreamPayload)
+	}
+	if _, ok := upstreamPayload["thinking"].(map[string]any); !ok {
+		t.Fatalf("expected native thinking payload to be preserved: %#v", upstreamPayload)
+	}
+	if !strings.Contains(resp.Body.String(), `"model":"claude-tokenhub-test"`) ||
+		!strings.Contains(resp.Body.String(), `"type":"tool_use"`) {
+		t.Fatalf("native response was not preserved and remapped: %s", resp.Body)
+	}
+}
+
+func TestAnthropicMessagesPreservesNativeStreamingAndUsage(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode upstream request: %v", err)
+		}
+		if payload["stream"] != true || payload["model"] != "upstream-model" {
+			t.Errorf("unexpected native stream payload: %#v", payload)
+		}
+		w.Header().Set("content-type", "text/event-stream")
+		_, _ = io.WriteString(w, "event: message_start\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_upstream\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"model\":\"upstream-model\",\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":0,\"cache_read_input_tokens\":40,\"output_tokens\":1}}}\n\n")
+		_, _ = io.WriteString(w, "event: content_block_start\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n")
+		_, _ = io.WriteString(w, "event: content_block_delta\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Native stream\"}}\n\n")
+		_, _ = io.WriteString(w, "event: content_block_stop\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n")
+		_, _ = io.WriteString(w, "event: message_delta\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"output_tokens\":8}}\n\n")
+		_, _ = io.WriteString(w, "event: message_stop\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"message_stop\"}\n\n")
+	}))
+	defer upstream.Close()
+
+	handler, store, secret := newAnthropicGateway(t, upstream.URL, ProviderAnthropic)
+	resp := doAnthropicRequest(t, handler, "/v1/messages", map[string]any{
+		"model":      "claude-tokenhub-test",
+		"max_tokens": 1024,
+		"stream":     true,
+		"messages":   []any{map[string]any{"role": "user", "content": "Stream natively."}},
+	}, "Bearer "+secret, "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), `"model":"claude-tokenhub-test"`) ||
+		strings.Contains(resp.Body.String(), `"model":"upstream-model"`) {
+		t.Fatalf("expected public model name in native stream: %s", resp.Body)
+	}
+	records := store.ListUsageRecords()
+	if len(records) != 1 ||
+		records[0].InputTokens != 40 ||
+		records[0].CachedInputTokens != 40 ||
+		records[0].OutputTokens != 8 {
+		t.Fatalf("unexpected native stream usage: %+v", records)
+	}
+}
+
+func TestAnthropicCountTokensAndAuthentication(t *testing.T) {
+	handler, store, secret := newAnthropicGateway(t, "http://127.0.0.1:1", ProviderOpenAICompatible)
+	payload := map[string]any{
+		"model":    "claude-tokenhub-test",
+		"system":   "Understand the codebase.",
+		"messages": []any{map[string]any{"role": "user", "content": "Inspect backend and frontend."}},
+		"tools": []any{
+			map[string]any{
+				"name":         "Read",
+				"description":  "Read a file",
+				"input_schema": map[string]any{"type": "object"},
+			},
+		},
+	}
+	resp := doAnthropicRequest(t, handler, "/v1/messages/count_tokens", payload, "", secret)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected x-api-key authentication to work, got %d: %s", resp.Code, resp.Body.String())
+	}
+	var result map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["input_tokens"].(float64) <= 1 {
+		t.Fatalf("expected a non-trivial token count: %s", resp.Body)
+	}
+	if len(store.ListUsageRecords()) != 0 {
+		t.Fatalf("token counting must not create billed usage: %+v", store.ListUsageRecords())
+	}
+
+	malformed := doAnthropicRequest(t, handler, "/v1/messages/count_tokens", payload, "Basic invalid", secret)
+	if malformed.Code != http.StatusUnauthorized {
+		t.Fatalf("malformed Authorization must not fall back to x-api-key: %d %s", malformed.Code, malformed.Body.String())
+	}
+	if !strings.Contains(malformed.Body.String(), `"type":"authentication_error"`) {
+		t.Fatalf("expected Anthropic authentication error: %s", malformed.Body)
+	}
+}
+
+func TestOpenAIChatCompletionPreservesDocumentedToolFields(t *testing.T) {
+	var upstreamPayload map[string]any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&upstreamPayload); err != nil {
+			t.Errorf("decode upstream request: %v", err)
+		}
+		w.Header().Set("content-type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl_direct_tools",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":10,"completion_tokens":1,"total_tokens":11}
+		}`)
+	}))
+	defer upstream.Close()
+
+	handler, _, secret := newAnthropicGateway(t, upstream.URL, ProviderOpenAICompatible)
+	resp := doJSON(t, handler, http.MethodPost, "/v1/chat/completions", map[string]any{
+		"model":    "claude-tokenhub-test",
+		"messages": []any{map[string]any{"role": "user", "content": "Inspect the repository."}},
+		"tools": []any{
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":       "inspect_repository",
+					"parameters": map[string]any{"type": "object"},
+				},
+			},
+		},
+		"tool_choice":         "auto",
+		"parallel_tool_calls": true,
+		"response_format":     map[string]any{"type": "json_object"},
+	}, secret)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body)
+	}
+	for _, field := range []string{"tools", "tool_choice", "parallel_tool_calls", "response_format"} {
+		if _, exists := upstreamPayload[field]; !exists {
+			t.Fatalf("expected direct Chat Completions field %q upstream: %#v", field, upstreamPayload)
+		}
+	}
+}
+
+func TestAnthropicMessagesSkipsIncompatibleRouteWithoutProviderPenalty(t *testing.T) {
+	var nativeCalls int
+	nativeUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nativeCalls++
+		w.Header().Set("content-type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"msg_native_fallback",
+			"type":"message",
+			"role":"assistant",
+			"model":"native-upstream-model",
+			"content":[{"type":"text","text":"Native server tool route selected."}],
+			"stop_reason":"end_turn",
+			"stop_sequence":null,
+			"usage":{"input_tokens":20,"output_tokens":5}
+		}`)
+	}))
+	defer nativeUpstream.Close()
+
+	store := NewMemoryStore()
+	project := store.CreateProject(Project{Name: "Route Compatibility Project", Status: StatusActive})
+	_, secret, err := store.CreateAPIKey(project.ID, APIKey{
+		Name:    "route-compatibility-key",
+		Allowed: []string{"claude-route-compatibility"},
+		Status:  StatusActive,
+	}, "thk_route_compatibility")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.AddModel(Model{
+		Name:          "claude-route-compatibility",
+		Family:        "claude",
+		Modality:      "chat",
+		ContextWindow: 200000,
+		Status:        StatusActive,
+	})
+	openAIProvider := store.AddProvider(Provider{
+		ID:      "prv_incompatible_openai",
+		Name:    "Incompatible OpenAI",
+		Type:    ProviderOpenAICompatible,
+		BaseURL: "http://127.0.0.1:1",
+		Status:  StatusActive,
+		Healthy: true,
+	})
+	openAIResource, err := store.AddProviderResource(ProviderResource{
+		ID:           "rsrc_incompatible_openai",
+		ProviderID:   openAIProvider.ID,
+		Name:         "Incompatible OpenAI Resource",
+		ResourceType: ProviderResourceAPIKey,
+		Status:       StatusActive,
+		Healthy:      true,
+		Priority:     1,
+		Weight:       100,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	nativeProvider := store.AddProvider(Provider{
+		ID:      "prv_compatible_anthropic",
+		Name:    "Compatible Anthropic",
+		Type:    ProviderAnthropic,
+		BaseURL: nativeUpstream.URL,
+		APIKey:  "native-secret",
+		Status:  StatusActive,
+		Healthy: true,
+	})
+	store.AddRoute(ModelRoute{
+		ID:                 "route_incompatible_openai",
+		ModelName:          "claude-route-compatibility",
+		ProviderID:         openAIProvider.ID,
+		ProviderResourceID: openAIResource.ID,
+		ProviderModel:      "openai-upstream-model",
+		Priority:           1,
+		Weight:             100,
+		Status:             StatusActive,
+		Strategy:           RouteStrategyPriorityOnly,
+	})
+	store.AddRoute(ModelRoute{
+		ID:            "route_compatible_anthropic",
+		ModelName:     "claude-route-compatibility",
+		ProviderID:    nativeProvider.ID,
+		ProviderModel: "native-upstream-model",
+		Priority:      2,
+		Weight:        100,
+		Status:        StatusActive,
+		Strategy:      RouteStrategyPriorityOnly,
+	})
+
+	handler := New(store).Handler()
+	for attempt := 0; attempt < 3; attempt++ {
+		resp := doAnthropicRequest(t, handler, "/v1/messages", map[string]any{
+			"model":      "claude-route-compatibility",
+			"max_tokens": 256,
+			"messages":   []any{map[string]any{"role": "user", "content": "Search the web."}},
+			"tools": []any{
+				map[string]any{"type": "web_search_20260209", "name": "web_search"},
+			},
+		}, "Bearer "+secret, "")
+		if resp.Code != http.StatusOK {
+			t.Fatalf("attempt %d: expected native fallback, got %d: %s", attempt+1, resp.Code, resp.Body.String())
+		}
+	}
+	if nativeCalls != 3 {
+		t.Fatalf("expected three native fallback calls, got %d", nativeCalls)
+	}
+	var routeAttempts []RouteAttemptLog
+	if err := store.db.Order("created_at asc, attempt_index asc").Find(&routeAttempts).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(routeAttempts) != 3 {
+		t.Fatalf("expected only the three contacted native routes to be audited, got %#v", routeAttempts)
+	}
+	for _, attempt := range routeAttempts {
+		if attempt.RouteID != "route_compatible_anthropic" ||
+			attempt.ProviderID != nativeProvider.ID ||
+			attempt.StatusCode != http.StatusOK ||
+			attempt.AttemptIndex != 1 {
+			t.Fatalf("uncontacted or misordered route was audited: %#v", routeAttempts)
+		}
+	}
+	for _, resource := range store.ListProviderResources() {
+		if resource.ID == openAIResource.ID {
+			if resource.FailureCount != 0 || !resource.Healthy || resource.CooldownUntil != nil {
+				t.Fatalf("route incompatibility penalized provider resource: %+v", resource)
+			}
+			return
+		}
+	}
+	t.Fatalf("provider resource %q not found", openAIResource.ID)
+}
+
+func TestCompatibleAnthropicRoutesUsesHighestPriorityError(t *testing.T) {
+	req := anthropicMessagesRequest{
+		Raw: map[string]any{
+			"model":      "claude-route-compatibility",
+			"max_tokens": 256,
+			"messages":   []any{map[string]any{"role": "user", "content": "Search the web."}},
+			"tools": []any{
+				map[string]any{"type": "web_search_20260209", "name": "web_search"},
+			},
+		},
+		Model: "claude-route-compatibility",
+		Messages: []any{
+			map[string]any{"role": "user", "content": "Search the web."},
+		},
+		MaxTokens: 256,
+	}
+	routed := RoutedCall{Routes: []RouteSelection{
+		{
+			Route:    ModelRoute{ID: "route_high_priority_openai", Priority: 1},
+			Provider: Provider{ID: "prv_openai", Type: ProviderOpenAICompatible},
+		},
+		{
+			Route:    ModelRoute{ID: "route_lower_priority_gemini", Priority: 2},
+			Provider: Provider{ID: "prv_gemini", Type: ProviderGemini},
+		},
+	}}
+
+	compatible, err := compatibleAnthropicRoutes(routed, req)
+	if len(compatible.Routes) != 0 {
+		t.Fatalf("expected no compatible routes, got %#v", compatible.Routes)
+	}
+	if AsHTTPError(err).Code != "unsupported_tool" {
+		t.Fatalf("expected highest-priority route error, got %v", err)
+	}
+}
+
+func TestAnthropicMessagesRejectsUnsupportedServerToolOnOpenAIRoute(t *testing.T) {
+	handler, _, secret := newAnthropicGateway(t, "http://127.0.0.1:1", ProviderOpenAICompatible)
+	resp := doAnthropicRequest(t, handler, "/v1/messages", map[string]any{
+		"model":      "claude-tokenhub-test",
+		"max_tokens": 1024,
+		"messages":   []any{map[string]any{"role": "user", "content": "Search the web."}},
+		"tools": []any{
+			map[string]any{"type": "web_search_20260209", "name": "web_search"},
+		},
+	}, "Bearer "+secret, "")
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), `"code":"unsupported_tool"`) {
+		t.Fatalf("expected explicit unsupported_tool error: %s", resp.Body)
+	}
+}
+
+func TestGatewayModelsIncludeAnthropicDiscoveryFields(t *testing.T) {
+	handler := newTestServer()
+	resp := doJSON(t, handler, http.MethodGet, "/v1/models", nil, "thk_demo_local")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(resp.Body), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["has_more"] != false || payload["first_id"] == "" || payload["last_id"] == "" {
+		t.Fatalf("expected Anthropic pagination fields: %s", resp.Body)
+	}
+	data, _ := payload["data"].([]any)
+	first, _ := data[0].(map[string]any)
+	for _, field := range []string{"type", "display_name", "created_at", "max_input_tokens", "max_tokens"} {
+		if _, exists := first[field]; !exists {
+			t.Fatalf("expected field %q in model discovery response: %s", field, resp.Body)
+		}
+	}
+}
+
+func newAnthropicGateway(t *testing.T, upstreamURL string, providerType string) (http.Handler, *GormStore, string) {
+	t.Helper()
+	store := NewMemoryStore()
+	project := store.CreateProject(Project{Name: "Claude Code Project", Status: StatusActive})
+	_, secret, err := store.CreateAPIKey(project.ID, APIKey{
+		Name:    "claude-code-key",
+		Allowed: []string{"claude-tokenhub-test"},
+		Status:  StatusActive,
+	}, "thk_claude_code_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.AddModel(Model{
+		Name:                "claude-tokenhub-test",
+		Family:              "claude",
+		Modality:            "chat",
+		ContextWindow:       200000,
+		Capabilities:        []string{"chat", "vision", "tools", "reasoning"},
+		SupportedParameters: []string{"tools", "image_input", "reasoning"},
+		Status:              StatusActive,
+	})
+	provider := store.AddProvider(Provider{
+		ID:      "prv_claude_code",
+		Name:    "Claude Code Test Provider",
+		Type:    providerType,
+		BaseURL: upstreamURL,
+		APIKey:  "upstream-secret",
+		Status:  StatusActive,
+		Healthy: true,
+	})
+	store.AddRoute(ModelRoute{
+		ID:            "route_claude_code",
+		ModelName:     "claude-tokenhub-test",
+		ProviderID:    provider.ID,
+		ProviderModel: "upstream-model",
+		Priority:      1,
+		Weight:        100,
+		Status:        StatusActive,
+		Strategy:      RouteStrategyPriorityOnly,
+	})
+	return New(store).Handler(), store, secret
+}
+
+func doAnthropicRequest(
+	t *testing.T,
+	handler http.Handler,
+	path string,
+	payload any,
+	authorization string,
+	apiKey string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(body))
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("anthropic-version", "2023-06-01")
+	if authorization != "" {
+		req.Header.Set("authorization", authorization)
+	}
+	if apiKey != "" {
+		req.Header.Set("x-api-key", apiKey)
+	}
+	if strings.Contains(fmt.Sprint(payload), "interleaved-thinking") {
+		req.Header.Set("anthropic-beta", "interleaved-thinking-2025-05-14")
+	}
+	if beta := findTestBeta(payload); beta != "" {
+		req.Header.Set("anthropic-beta", beta)
+	}
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	return resp
+}
+
+func findTestBeta(payload any) string {
+	body, _ := json.Marshal(payload)
+	if strings.Contains(string(body), `"thinking"`) {
+		return "interleaved-thinking-2025-05-14"
+	}
+	return ""
+}

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -95,6 +95,8 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("/v1/models", s.handleModels)
 	s.mux.HandleFunc("/v1/models/", s.handleModel)
 	s.mux.HandleFunc("/v1/chat/completions", s.handleChatCompletions)
+	s.mux.HandleFunc("/v1/messages", s.handleAnthropicMessages)
+	s.mux.HandleFunc("/v1/messages/count_tokens", s.handleAnthropicCountTokens)
 	s.mux.HandleFunc("/v1/responses", s.handleResponses)
 	s.mux.HandleFunc("/v1/responses/compact", s.handleResponsesCompact)
 	s.mux.HandleFunc("/v1/embeddings", s.handleEmbeddings)
@@ -197,11 +199,17 @@ func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
 	for _, model := range models {
 		data = append(data, buildModelListItem(model))
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
-		"object": "list",
-		"data":   data,
-		"models": []any{},
-	})
+	payload := map[string]any{
+		"object":   "list",
+		"data":     data,
+		"models":   []any{},
+		"has_more": false,
+	}
+	if len(data) > 0 {
+		payload["first_id"] = data[0].ID
+		payload["last_id"] = data[len(data)-1].ID
+	}
+	writeJSON(w, http.StatusOK, payload)
 }
 
 func (s *Server) handleModel(w http.ResponseWriter, r *http.Request) {
@@ -245,12 +253,17 @@ type modelListItem struct {
 	ID                   string `json:"id"`
 	Created              int64  `json:"created"`
 	Object               string `json:"object"`
+	Type                 string `json:"type"`
 	OwnedBy              string `json:"owned_by,omitempty"`
 	InputTokenPricePerM  int64  `json:"input_token_price_per_m"`
 	OutputTokenPricePerM int64  `json:"output_token_price_per_m"`
 	Title                string `json:"title"`
+	DisplayName          string `json:"display_name"`
 	Description          string `json:"description"`
 	ContextSize          int64  `json:"context_size"`
+	CreatedAt            string `json:"created_at"`
+	MaxInputTokens       int64  `json:"max_input_tokens"`
+	MaxTokens            int64  `json:"max_tokens"`
 }
 
 func buildModelListItem(model Model) modelListItem {
@@ -262,12 +275,17 @@ func buildModelListItem(model Model) modelListItem {
 		ID:                   model.Name,
 		Created:              modelCreatedUnix(model),
 		Object:               "model",
+		Type:                 "model",
 		OwnedBy:              "tokenhub",
 		InputTokenPricePerM:  modelTokenPricePerM(inputPrice),
 		OutputTokenPricePerM: modelTokenPricePerM(model.OutputPriceUSDPer1M),
 		Title:                modelTitle(model),
+		DisplayName:          modelTitle(model),
 		Description:          modelDescription(model),
 		ContextSize:          model.ContextWindow,
+		CreatedAt:            modelCreatedAt(model),
+		MaxInputTokens:       model.ContextWindow,
+		MaxTokens:            modelMaxOutputTokens(model),
 	}
 }
 
@@ -276,6 +294,25 @@ func modelCreatedUnix(model Model) int64 {
 		return 0
 	}
 	return model.CreatedAt.Unix()
+}
+
+func modelCreatedAt(model Model) string {
+	if model.CreatedAt.IsZero() {
+		return time.Unix(0, 0).UTC().Format(time.RFC3339)
+	}
+	return model.CreatedAt.UTC().Format(time.RFC3339)
+}
+
+func modelMaxOutputTokens(model Model) int64 {
+	for _, key := range []string{"max_output_tokens", "max_tokens"} {
+		if value := strings.TrimSpace(model.Metadata[key]); value != "" {
+			parsed, err := strconv.ParseInt(value, 10, 64)
+			if err == nil && parsed >= 0 {
+				return parsed
+			}
+		}
+	}
+	return 0
 }
 
 func modelTokenPricePerM(priceUSDPer1M float64) int64 {
@@ -969,6 +1006,15 @@ func (w *streamWriteTracker) Wrote() bool {
 	return w != nil && w.wrote
 }
 
+func (w *streamWriteTracker) Flush() {
+	if w == nil {
+		return
+	}
+	if flusher, ok := w.writer.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
 func (s *Server) finishFailedRoutedCall(r *http.Request, routed RoutedCall, attempts []RouteAttempt, err error) {
 	httpErr := AsHTTPError(err)
 	route := lastAttemptRoute(attempts)
@@ -1339,14 +1385,17 @@ func (s *Server) writeRouteHeaders(w http.ResponseWriter, call CallContext, rout
 
 func (s *Server) authenticate(r *http.Request) (Project, APIKey, error) {
 	auth := r.Header.Get("authorization")
-	if auth == "" {
-		return Project{}, APIKey{}, ErrInvalidAPIKey
+	if auth != "" {
+		const prefix = "Bearer "
+		if !strings.HasPrefix(auth, prefix) {
+			return Project{}, APIKey{}, ErrInvalidAPIKey
+		}
+		return s.store.ValidateAPIKey(strings.TrimSpace(strings.TrimPrefix(auth, prefix)), s.clientIP(r))
 	}
-	const prefix = "Bearer "
-	if !strings.HasPrefix(auth, prefix) {
-		return Project{}, APIKey{}, ErrInvalidAPIKey
+	if apiKey := strings.TrimSpace(r.Header.Get("x-api-key")); apiKey != "" {
+		return s.store.ValidateAPIKey(apiKey, s.clientIP(r))
 	}
-	return s.store.ValidateAPIKey(strings.TrimSpace(strings.TrimPrefix(auth, prefix)), s.clientIP(r))
+	return Project{}, APIKey{}, ErrInvalidAPIKey
 }
 
 func (s *Server) handleAdminLogin(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/server/types.go
+++ b/backend/internal/server/types.go
@@ -525,21 +525,30 @@ type SQLiteBackupRecord struct {
 }
 
 type ChatMessage struct {
-	Role    string `json:"role"`
-	Content any    `json:"content"`
+	Role       string `json:"role"`
+	Content    any    `json:"content"`
+	Name       string `json:"name,omitempty"`
+	ToolCallID string `json:"tool_call_id,omitempty"`
+	ToolCalls  any    `json:"tool_calls,omitempty"`
 }
 
 type ReasoningOptions = ResponsesReasoning
 
 type ChatCompletionRequest struct {
-	Model           string         `json:"model"`
-	Messages        []ChatMessage  `json:"messages"`
-	Stream          bool           `json:"stream,omitempty"`
-	StreamOptions   map[string]any `json:"stream_options,omitempty"`
-	MaxTokens       int            `json:"max_tokens,omitempty"`
-	Temperature     *float64       `json:"temperature,omitempty"`
-	ReasoningEffort *string        `json:"reasoning_effort,omitempty"`
-	Metadata        map[string]any `json:"metadata,omitempty"`
+	Model             string         `json:"model"`
+	Messages          []ChatMessage  `json:"messages"`
+	Stream            bool           `json:"stream,omitempty"`
+	StreamOptions     map[string]any `json:"stream_options,omitempty"`
+	MaxTokens         int            `json:"max_tokens,omitempty"`
+	Temperature       *float64       `json:"temperature,omitempty"`
+	TopP              *float64       `json:"top_p,omitempty"`
+	Stop              any            `json:"stop,omitempty"`
+	Tools             any            `json:"tools,omitempty"`
+	ToolChoice        any            `json:"tool_choice,omitempty"`
+	ParallelToolCalls *bool          `json:"parallel_tool_calls,omitempty"`
+	ResponseFormat    any            `json:"response_format,omitempty"`
+	ReasoningEffort   *string        `json:"reasoning_effort,omitempty"`
+	Metadata          map[string]any `json:"metadata,omitempty"`
 }
 
 type PlaygroundChatResponse struct {

--- a/docs/development/workflows/feature-dev.md
+++ b/docs/development/workflows/feature-dev.md
@@ -9,20 +9,16 @@ Read this file and `AGENTS.md` before editing. Do not load `fast-dev` at the sam
 1. Inspect `git status` and preserve unrelated or user-authored changes.
 2. Read the affected code, tests, contracts, and documentation.
 3. Define goals, non-goals, compatibility, rollout, rollback, security impact, and open assumptions.
-4. Before implementation, present a high-level design and normal, boundary, and failure test cases. Wait for confirmation; return here if scope or key tradeoffs change.
+4. Before implementation, present a high-level design and normal, boundary, and failure test cases in the task context. Wait for confirmation; return here if scope or key tradeoffs change.
 
-## 2. Record the design
-
-Create or update `docs/features/<feature>.md` for important features, covering behavior, design, compatibility, failure handling, security, rollout, rollback, and validation. Add an ADR under `docs/adr/` only for durable choices with meaningful alternatives or difficult reversal.
-
-## 3. Implement
+## 2. Implement
 
 - Prefer test-backed, independently verifiable steps.
 - Preserve `/v1` compatibility unless the confirmed design changes it.
 - Treat credentials, keys, authentication, authorization, quotas, routing, audit data, persistence, and distributed coordination as sensitive.
 - Keep backend, frontend, SDK, model catalog, environment examples, deployment files, and translated documentation consistent where affected.
 
-## 4. Validate
+## 3. Validate
 
 Run focused tests while iterating, then all applicable checks from `AGENTS.md`:
 
@@ -34,8 +30,8 @@ Run focused tests while iterating, then all applicable checks from `AGENTS.md`:
 
 Record blocked or skipped checks and remaining risk. Never report an unrun or failing check as passing.
 
-## 5. Review and handoff
+## 4. Review and handoff
 
 After validation, spawn a fresh review subagent that did not participate in implementation. Give it the final diff and validation results, and require it to remain read-only. Fix accepted findings, rerun affected checks, and use at most three rounds. If review subagents are unavailable, report that limitation instead of substituting self-review.
 
-Report the result, design-document status, checks, review outcome, unresolved findings, and remaining risk. Commit, push, or create a pull request only when separately requested; then follow `.github/pull_request_template.md`.
+Report the result, checks, review outcome, unresolved findings, and remaining risk. Commit, push, or create a pull request only when separately requested; then follow `.github/pull_request_template.md`.

--- a/docs/ja/user-guide.md
+++ b/docs/ja/user-guide.md
@@ -8,7 +8,7 @@ Language: [English](../user-guide.md) | [简体中文](../zh-CN/user-guide.md) |
 
 | 項目 | 用途 |
 | --- | --- |
-| Base URL | OpenAI 互換 endpoint root。例: `http://localhost:8080/v1` |
+| Base URL | OpenAI 互換 root は `http://localhost:8080/v1`、Claude Code Host URL は `http://localhost:8080` |
 | Project API Key | `Authorization: Bearer YOUR_TOKENHUB_API_KEY` で送信 |
 | Model ID | `GET /v1/models` で返り、`model` に指定 |
 | request_id | 失敗時に Request Logs で調査するために利用 |
@@ -20,7 +20,7 @@ Language: [English](../user-guide.md) | [简体中文](../zh-CN/user-guide.md) |
 1. **Key Management** を開き、API Key を作成またはコピーします。新しい Key は一度だけ表示されます。
 2. TokenHub は個人 Key を割り当て済み Project に自動帰属し、未割り当ての場合はプラットフォームのデフォルト Project に帰属します。
 3. `GET /v1/models` で、その Key から利用できるモデル一覧を確認します。
-4. モデル ID を選び、`POST /v1/chat/completions`、`POST /v1/responses`、`POST /v1/embeddings` を呼び出します。
+4. モデル ID を選び、`POST /v1/chat/completions`、`POST /v1/messages`、`POST /v1/responses`、`POST /v1/embeddings` を呼び出します。
 5. **Usage Analytics** と **Request Logs** でリクエスト、Token、コスト、エラーを確認します。
 
 ## モデル一覧
@@ -42,8 +42,12 @@ curl --request GET \
 | `input_token_price_per_m` | JieKou 互換の 100 万 input tokens あたり整数価格 |
 | `output_token_price_per_m` | JieKou 互換の 100 万 output tokens あたり整数価格 |
 | `title` | モデルタイトル |
+| `display_name` | Anthropic 互換のモデル表示名 |
 | `description` | モデル説明 |
 | `context_size` | 最大コンテキスト長 |
+| `created_at` | Anthropic 互換の RFC 3339 作成日時 |
+| `max_input_tokens` | Anthropic 互換の最大入力コンテキスト |
+| `max_tokens` | 設定済みの最大出力 tokens。未設定時は `0` |
 
 ## 指定モデル情報
 
@@ -112,6 +116,39 @@ Responses は OpenAI 互換のネスト形式を受け付けます。
 TokenHub は推論強度をベストエフォートのヒントとして扱い、ルートの順序を変更しません。OpenAI 互換 Provider には値をそのまま渡します。Anthropic のネイティブルートでは対応する値を `output_config.effort` に変換します。Gemini のネイティブルートでは、モデル固有の対応表に従って Gemini 3 以降の `thinkingLevel`、または Gemini 2.5 の公式 `thinkingBudget` に変換します。対応しない値や空値は省略され、上流モデルのデフォルト動作が使われます。上流 Provider が推論強度フィールドを明示する `400` または `422` のパラメーターエラーを返した場合、TokenHub は同じルートでそのフィールドを除いて一度再試行し、その後は従来のフェイルオーバー処理を適用します。物理的な再試行はそれぞれ Provider Resource RPM に加算され、ルート試行として記録されます。
 
 Responses の推論強度は OpenAI 互換、Anthropic、Gemini の各ルートで利用できます。Azure OpenAI Responses と Responses のストリーミングは未実装で、`501 provider_capability_not_supported` を返します。
+
+## Anthropic Messages と Claude Code
+
+TokenHub は Claude Code と Anthropic 互換クライアント向けに `POST /v1/messages` と `POST /v1/messages/count_tokens` を提供します。Project Key は Bearer Token として送信します。
+
+```bash
+curl --request POST \
+  --url "http://localhost:8080/v1/messages" \
+  --header "Authorization: Bearer YOUR_TOKENHUB_API_KEY" \
+  --header "anthropic-version: 2023-06-01" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "model": "CLAUDE_COMPATIBLE_MODEL_ID",
+    "max_tokens": 2048,
+    "messages": [
+      {"role": "user", "content": "Understand this repository and summarize its architecture."}
+    ]
+  }'
+```
+
+Anthropic ネイティブルートでは Anthropic content block と beta header を保持します。OpenAI 互換ルートではテキスト、画像、クライアントツール、ツール結果、並列ツール呼び出し、ストリーミング event を変換します。OpenAI 互換 Provider で表現できない Anthropic サーバーツールには `400 unsupported_tool` を返します。
+
+ローカル Claude Code には `/v1` suffix を付けず、TokenHub Host URL を設定します。
+
+```bash
+export ANTHROPIC_BASE_URL="http://localhost:8080"
+export ANTHROPIC_AUTH_TOKEN="YOUR_TOKENHUB_API_KEY"
+export ANTHROPIC_MODEL="CLAUDE_COMPATIBLE_MODEL_ID"
+
+claude
+```
+
+`ANTHROPIC_AUTH_TOKEN` は TokenHub Key を `Authorization: Bearer` で送信します。Authorization header がない場合は、`ANTHROPIC_API_KEY` の `x-api-key` も利用できます。Token 見積もりは Key とモデル権限を確認しますが、課金対象の推論レコードは作成しません。
 
 ## SDK 設定
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -8,7 +8,7 @@ This guide is for employees and application developers who call approved large l
 
 | Item | Purpose |
 | --- | --- |
-| Base URL | OpenAI-compatible endpoint root, for example `http://localhost:8080/v1` |
+| Base URL | OpenAI-compatible root `http://localhost:8080/v1`; Claude Code host `http://localhost:8080` |
 | Project API Key | Sent as `Authorization: Bearer YOUR_TOKENHUB_API_KEY` |
 | Model ID | Returned by `GET /v1/models` and used as the `model` field |
 | Request ID | Used in Request Logs when troubleshooting failures |
@@ -20,7 +20,7 @@ Console login tokens cannot call model APIs. Use a project API key from **Key Ma
 1. Open **Key Management** and create or copy an API key. New keys are shown only once.
 2. TokenHub automatically attributes a personal key to an assigned project, or to the platform default project when none is assigned.
 3. Call `GET /v1/models` to see the model list available to that key.
-4. Use one model ID in `POST /v1/chat/completions`, `POST /v1/responses`, or `POST /v1/embeddings`.
+4. Use one model ID in `POST /v1/chat/completions`, `POST /v1/messages`, `POST /v1/responses`, or `POST /v1/embeddings`.
 5. Review **Usage Analytics** and **Request Logs** for requests, tokens, cost, and errors.
 
 ## List Models
@@ -42,8 +42,12 @@ Typical model fields:
 | `input_token_price_per_m` | JieKou-compatible integer input price per million tokens |
 | `output_token_price_per_m` | JieKou-compatible integer output price per million tokens |
 | `title` | Model title |
+| `display_name` | Anthropic-compatible display name |
 | `description` | Model description |
 | `context_size` | Maximum context window |
+| `created_at` | Anthropic-compatible RFC 3339 creation timestamp |
+| `max_input_tokens` | Anthropic-compatible maximum input context |
+| `max_tokens` | Configured maximum output tokens, or `0` when unspecified |
 
 ## Retrieve Model
 
@@ -112,6 +116,39 @@ Responses accepts the nested OpenAI-compatible form:
 TokenHub treats reasoning effort as a best-effort hint and does not change route ordering. OpenAI-compatible providers receive the value unchanged. Native Anthropic routes convert supported values to `output_config.effort`. Native Gemini routes convert supported values according to the model-specific `thinkingLevel` matrix for Gemini 3 and later models or the documented `thinkingBudget` for Gemini 2.5 models. Unsupported or blank values are omitted so the upstream model default remains in effect. If an upstream provider returns a `400` or `422` parameter error that explicitly identifies the effort field, TokenHub retries the same route once without that field before applying the existing failover behavior. Each physical retry counts toward Provider Resource RPM and appears as a route attempt.
 
 Responses reasoning effort is supported on OpenAI-compatible, Anthropic, and Gemini routes. Azure OpenAI Responses and streaming Responses are not implemented; those requests return `501 provider_capability_not_supported`.
+
+## Anthropic Messages and Claude Code
+
+TokenHub exposes `POST /v1/messages` and `POST /v1/messages/count_tokens` for Claude Code and Anthropic-compatible clients. Use a project key as a bearer token:
+
+```bash
+curl --request POST \
+  --url "http://localhost:8080/v1/messages" \
+  --header "Authorization: Bearer YOUR_TOKENHUB_API_KEY" \
+  --header "anthropic-version: 2023-06-01" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "model": "CLAUDE_COMPATIBLE_MODEL_ID",
+    "max_tokens": 2048,
+    "messages": [
+      {"role": "user", "content": "Understand this repository and summarize its architecture."}
+    ]
+  }'
+```
+
+Native Anthropic routes preserve Anthropic content blocks and beta headers. OpenAI-compatible routes translate text, images, client tools, tool results, parallel tool calls, and streaming events. Anthropic server tools that cannot be represented by an OpenAI-compatible provider return `400 unsupported_tool`.
+
+Configure local Claude Code with the TokenHub host URL, without the `/v1` suffix:
+
+```bash
+export ANTHROPIC_BASE_URL="http://localhost:8080"
+export ANTHROPIC_AUTH_TOKEN="YOUR_TOKENHUB_API_KEY"
+export ANTHROPIC_MODEL="CLAUDE_COMPATIBLE_MODEL_ID"
+
+claude
+```
+
+`ANTHROPIC_AUTH_TOKEN` sends the TokenHub key in `Authorization: Bearer`. `ANTHROPIC_API_KEY` also works through `x-api-key` when no Authorization header is present. Token counting verifies key and model access but does not create a billed inference record.
 
 ## SDK Setup
 

--- a/docs/zh-CN/user-guide.md
+++ b/docs/zh-CN/user-guide.md
@@ -4,11 +4,11 @@ Language: [English](../user-guide.md) | 简体中文 | [日本語](../ja/user-gu
 
 本指南面向通过 TokenHub 调用企业已批准大语言模型的员工和应用开发者。
 
-## 你需要什么
+## 所需信息
 
 | 项目 | 用途 |
 | --- | --- |
-| Base URL | OpenAI 兼容接口根地址，例如 `http://localhost:8080/v1` |
+| Base URL | OpenAI 兼容根地址为 `http://localhost:8080/v1`；Claude Code Host URL 为 `http://localhost:8080` |
 | 项目 API Key | 通过 `Authorization: Bearer YOUR_TOKENHUB_API_KEY` 发送 |
 | 模型 ID | 由 `GET /v1/models` 返回，并填写到 `model` 字段 |
 | request_id | 调用失败时用于在请求日志中排查 |
@@ -20,7 +20,7 @@ Language: [English](../user-guide.md) | 简体中文 | [日本語](../ja/user-gu
 1. 打开 **Key 管理**，创建或复制 API Key。新 Key 只展示一次。
 2. TokenHub 会自动把个人 Key 归入已分配项目；尚未分配项目时归入平台默认项目。
 3. 调用 `GET /v1/models` 查看这个 Key 可用的模型列表。
-4. 选择一个模型 ID，调用 `POST /v1/chat/completions`、`POST /v1/responses` 或 `POST /v1/embeddings`。
+4. 选择一个模型 ID，调用 `POST /v1/chat/completions`、`POST /v1/messages`、`POST /v1/responses` 或 `POST /v1/embeddings`。
 5. 在 **用量统计** 和 **请求日志** 中查看请求、Token、成本和错误。
 
 ## 获取模型列表
@@ -42,8 +42,12 @@ curl --request GET \
 | `input_token_price_per_m` | 兼容 jiekou 的每百万输入 tokens 整数价格 |
 | `output_token_price_per_m` | 兼容 jiekou 的每百万输出 tokens 整数价格 |
 | `title` | 模型标题 |
+| `display_name` | Anthropic 兼容的模型显示名称 |
 | `description` | 模型描述 |
 | `context_size` | 模型最大上下文长度 |
+| `created_at` | Anthropic 兼容的 RFC 3339 创建时间 |
+| `max_input_tokens` | Anthropic 兼容的最大输入上下文 |
+| `max_tokens` | 已配置的最大输出 Token 数；未配置时为 `0` |
 
 ## 获取指定模型信息
 
@@ -112,6 +116,39 @@ Responses 接受 OpenAI 兼容的嵌套格式：
 TokenHub 将推理强度作为尽力应用的提示字段，不改变路由顺序。OpenAI 兼容 Provider 接收原值；原生 Anthropic 路由将支持的值转换为 `output_config.effort`；原生 Gemini 路由根据具体模型的支持矩阵转换为 Gemini 3 及以上模型的 `thinkingLevel`，或 Gemini 2.5 模型的官方 `thinkingBudget`。不支持的值或空值会被省略，继续使用上游模型的默认行为。如果上游返回 `400` 或 `422` 参数错误，并且错误信息明确指向推理强度字段，TokenHub 会在同一路由内移除该字段并重试一次，之后再按原有故障转移逻辑处理。每次物理重试均计入 Provider Resource RPM，并记录为一次路由尝试。
 
 Responses 推理强度支持 OpenAI 兼容、Anthropic 和 Gemini 路由。Azure OpenAI Responses 与 Responses 流式响应尚未实现，此类请求返回 `501 provider_capability_not_supported`。
+
+## Anthropic Messages 与 Claude Code
+
+TokenHub 提供 `POST /v1/messages` 和 `POST /v1/messages/count_tokens`，供 Claude Code 与 Anthropic 兼容客户端调用。项目 Key 通过 Bearer Token 发送：
+
+```bash
+curl --request POST \
+  --url "http://localhost:8080/v1/messages" \
+  --header "Authorization: Bearer YOUR_TOKENHUB_API_KEY" \
+  --header "anthropic-version: 2023-06-01" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "model": "CLAUDE_COMPATIBLE_MODEL_ID",
+    "max_tokens": 2048,
+    "messages": [
+      {"role": "user", "content": "Understand this repository and summarize its architecture."}
+    ]
+  }'
+```
+
+原生 Anthropic 路由保留 Anthropic 内容块与 beta Header。OpenAI 兼容路由转换文本、图片、客户端工具、工具结果、并行工具调用和流式事件。Anthropic 服务端工具无法转换到 OpenAI 兼容 Provider 时，接口返回 `400 unsupported_tool`。
+
+本地 Claude Code 使用 TokenHub Host URL，不添加 `/v1` 后缀：
+
+```bash
+export ANTHROPIC_BASE_URL="http://localhost:8080"
+export ANTHROPIC_AUTH_TOKEN="YOUR_TOKENHUB_API_KEY"
+export ANTHROPIC_MODEL="CLAUDE_COMPATIBLE_MODEL_ID"
+
+claude
+```
+
+`ANTHROPIC_AUTH_TOKEN` 通过 `Authorization: Bearer` 发送 TokenHub Key。没有 Authorization Header 时，也可通过 `ANTHROPIC_API_KEY` 使用 `x-api-key`。Token 估算会检查 Key 和模型权限，但不生成计费推理记录。
 
 ## SDK 配置
 

--- a/frontend/check-source-lines.mjs
+++ b/frontend/check-source-lines.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import { readdir, readFile } from "node:fs/promises";
+import { extname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const frontendRoot = fileURLToPath(new URL(".", import.meta.url));
+const sourceRoots = ["app", "features", "lib"];
+const sourceExtensions = new Set([".css", ".ts", ".tsx"]);
+const maximumLines = 1500;
+const legacyLineBaselines = new Map([
+  ["app/styles/legacy/resources.css", 1510],
+  ["features/admin/views/provider-editor.tsx", 2093],
+]);
+
+const sourceFiles = [];
+for (const sourceRoot of sourceRoots) {
+  await collectSourceFiles(join(frontendRoot, sourceRoot), sourceFiles);
+}
+
+const violations = [];
+for (const sourceFile of sourceFiles) {
+  const contents = await readFile(sourceFile, "utf8");
+  const lineCount = contents === "" ? 0 : contents.split(/\r?\n/).length;
+  const relativePath = relative(frontendRoot, sourceFile);
+  const allowedLines = legacyLineBaselines.get(relativePath) ?? maximumLines;
+  if (lineCount > allowedLines) {
+    violations.push({
+      file: relativePath,
+      lineCount,
+      allowedLines,
+    });
+  }
+}
+
+if (violations.length > 0) {
+  console.error(`Frontend source files exceeded their line limit:`);
+  for (const violation of violations) {
+    console.error(
+      `- ${violation.file}: ${violation.lineCount} lines (limit ${violation.allowedLines})`,
+    );
+  }
+  process.exitCode = 1;
+} else {
+  console.log(
+    `Source line check passed (${sourceFiles.length} files, default limit ${maximumLines}, ${legacyLineBaselines.size} fixed baselines).`,
+  );
+}
+
+async function collectSourceFiles(directory, output) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      await collectSourceFiles(path, output);
+      continue;
+    }
+    if (entry.isFile() && sourceExtensions.has(extname(entry.name))) {
+      output.push(path);
+    }
+  }
+}

--- a/frontend/features/admin/i18n/en.tsx
+++ b/frontend/features/admin/i18n/en.tsx
@@ -683,6 +683,7 @@ export const enTranslations: Record<string, string> = {
     "AI 工具接入": "AI Tool Integration",
     "API 类型": "API Type",
     "OpenAI 兼容工具": "OpenAI-Compatible Tools",
+    "AI 工具类型": "AI tool type",
     "示例使用环境变量保存完整 Key。当前凭证：": "The examples store the full Key in an environment variable. Current credential:",
     "代码语言": "Code Language",
     "环境变量": "Environment Variables",

--- a/frontend/features/admin/i18n/ja.tsx
+++ b/frontend/features/admin/i18n/ja.tsx
@@ -683,6 +683,7 @@ export const jaTranslations: Record<string, string> = {
     "AI 工具接入": "AI ツール接続",
     "API 类型": "API タイプ",
     "OpenAI 兼容工具": "OpenAI 互換ツール",
+    "AI 工具类型": "AI ツール種別",
     "示例使用环境变量保存完整 Key。当前凭证：": "サンプルでは完全な Key を環境変数に保存します。現在の認証情報:",
     "代码语言": "コード言語",
     "环境变量": "環境変数",

--- a/frontend/features/admin/views/gateway-llm-en.tsx
+++ b/frontend/features/admin/views/gateway-llm-en.tsx
@@ -44,6 +44,45 @@ export function gatewayStreamingCurl(stats: GatewayDocStats) {
   }'`;
 }
 
+export function gatewayAnthropicMessagesCurl(stats: GatewayDocStats) {
+  return `curl -N --request POST \\
+  --url "${stats.baseURL}/messages" \\
+  --header "${stats.authHeader}" \\
+  --header "anthropic-version: 2023-06-01" \\
+  --header "Content-Type: application/json" \\
+  --data '{
+    "model": "${stats.sampleModel}",
+    "max_tokens": 2048,
+    "messages": [
+      {"role": "user", "content": "Understand this repository and summarize its architecture."}
+    ],
+    "stream": true
+  }'`;
+}
+
+export function gatewayAnthropicCountTokensCurl(stats: GatewayDocStats) {
+  return `curl --request POST \\
+  --url "${stats.baseURL}/messages/count_tokens" \\
+  --header "${stats.authHeader}" \\
+  --header "anthropic-version: 2023-06-01" \\
+  --header "Content-Type: application/json" \\
+  --data '{
+    "model": "${stats.sampleModel}",
+    "messages": [
+      {"role": "user", "content": "Understand this repository."}
+    ]
+  }'`;
+}
+
+export function gatewayClaudeCodeExample(stats: GatewayDocStats) {
+  const anthropicBaseURL = stats.baseURL.replace(/\/v1\/?$/, "");
+  return `export ANTHROPIC_BASE_URL="${anthropicBaseURL}"
+export ANTHROPIC_AUTH_TOKEN="YOUR_TOKENHUB_API_KEY"
+export ANTHROPIC_MODEL="${stats.sampleModel}"
+
+claude`;
+}
+
 export function gatewayResponsesCurl(stats: GatewayDocStats) {
   return `curl --request POST \\
   --url "${stats.baseURL}/responses" \\
@@ -307,6 +346,48 @@ export function gatewayEnglishLLMUsageDocs(stats: GatewayDocStats, role: AppRole
             examples: [{ title: "cURL", code: gatewayResponsesCurl(stats) }],
           },
           {
+            id: "anthropic-messages",
+            group: "LLM API Reference",
+            method: "POST",
+            path: "/v1/messages",
+            title: "Create Anthropic Message",
+            description: "Call TokenHub from Claude Code or an Anthropic-compatible client with text, images, client tools, tool results, and streaming.",
+            params: {
+              title: "Request body",
+              columns: ["Field", "Type", "Required", "Description"],
+              rows: [
+                ["model", "string", "Yes", "A callable TokenHub model ID."],
+                ["max_tokens", "integer", "Yes", "Maximum generated tokens."],
+                ["messages", "array", "Yes", "Anthropic user and assistant messages with structured content blocks."],
+                ["system", "string | array", "No", "Top-level Anthropic system prompt."],
+                ["tools", "array", "No", "Client tool definitions using input_schema."],
+                ["tool_choice", "object", "No", "Controls automatic, required, named, or disabled tool use."],
+                ["stream", "boolean", "No", "Returns Anthropic named Server-Sent Events when true."],
+              ],
+            },
+            notesTitle: "Routing behavior",
+            notes: [
+              "Native Anthropic routes preserve Anthropic content blocks and beta headers.",
+              "OpenAI-compatible routes translate client tools, tool results, images, and streaming events.",
+              "Unsupported Anthropic server tools return an explicit 400 response on OpenAI-compatible routes.",
+            ],
+            examplesTitle: "Examples",
+            examples: [
+              { title: "Messages API", code: gatewayAnthropicMessagesCurl(stats) },
+              { title: "Claude Code", code: gatewayClaudeCodeExample(stats) },
+            ],
+          },
+          {
+            id: "anthropic-count-tokens",
+            group: "LLM API Reference",
+            method: "POST",
+            path: "/v1/messages/count_tokens",
+            title: "Count Anthropic Message Tokens",
+            description: "Return a deterministic input-token estimate after authenticating the key and verifying model access. This request is not billed as inference.",
+            examplesTitle: "Example",
+            examples: [{ title: "cURL", code: gatewayAnthropicCountTokensCurl(stats) }],
+          },
+          {
             id: "embeddings-api",
             group: "LLM API Reference",
             method: "POST",
@@ -358,12 +439,13 @@ export function gatewayEnglishLLMUsageDocs(stats: GatewayDocStats, role: AppRole
             id: "sdk-examples",
             group: teamLeader ? "Team Rollout" : "Project Keys",
             badge: "SDK",
-            title: "OpenAI-Compatible SDKs",
-            description: "Point any OpenAI-compatible SDK at the TokenHub Base URL and use a TokenHub project API key.",
-            examplesTitle: "SDK examples",
+            title: "SDKs and Claude Code",
+            description: "Use the TokenHub Base URL with OpenAI-compatible SDKs or the TokenHub host URL with Claude Code.",
+            examplesTitle: "Client examples",
             examples: [
               { title: "Node.js", code: gatewayOpenAISDKExample(stats) },
               { title: "Python", code: gatewayPythonSDKExample(stats) },
+              { title: "Claude Code", code: gatewayClaudeCodeExample(stats) },
             ],
           },
           {

--- a/frontend/features/admin/views/gateway-llm-ja.tsx
+++ b/frontend/features/admin/views/gateway-llm-ja.tsx
@@ -1,6 +1,17 @@
 import { type AppRole } from "../core/types";
 import { formatNumber } from "../domain/formatting";
-import { gatewayEmbeddingsCurl, gatewayListModelsCurl, gatewayOpenAISDKExample, gatewayPythonSDKExample, gatewayResponsesCurl, gatewayRetrieveModelCurl, gatewayStreamingCurl } from "./gateway-llm-en";
+import {
+  gatewayAnthropicCountTokensCurl,
+  gatewayAnthropicMessagesCurl,
+  gatewayClaudeCodeExample,
+  gatewayEmbeddingsCurl,
+  gatewayListModelsCurl,
+  gatewayOpenAISDKExample,
+  gatewayPythonSDKExample,
+  gatewayResponsesCurl,
+  gatewayRetrieveModelCurl,
+  gatewayStreamingCurl,
+} from "./gateway-llm-en";
 import { type GatewayDocBundle, type GatewayDocStats } from "./gateway-view";
 
 export function gatewayJapaneseLLMUsageDocs(stats: GatewayDocStats, role: AppRole): GatewayDocBundle {
@@ -208,6 +219,48 @@ export function gatewayJapaneseLLMUsageDocs(stats: GatewayDocStats, role: AppRol
             examples: [{ title: "cURL", code: gatewayResponsesCurl(stats) }],
           },
           {
+            id: "anthropic-messages",
+            group: "LLM API",
+            method: "POST",
+            path: "/v1/messages",
+            title: "Anthropic Message を作成",
+            description: "Claude Code または Anthropic 互換クライアントから、テキスト、画像、クライアントツール、ツール結果、ストリーミングを利用できます。",
+            params: {
+              title: "リクエスト Body",
+              columns: ["フィールド", "型", "必須", "説明"],
+              rows: [
+                ["model", "string", "はい", "呼び出し可能な TokenHub モデル ID。"],
+                ["max_tokens", "integer", "はい", "最大生成 tokens。"],
+                ["messages", "array", "はい", "user、assistant、構造化 content block からなる Anthropic メッセージ。"],
+                ["system", "string | array", "いいえ", "トップレベルの Anthropic system prompt。"],
+                ["tools", "array", "いいえ", "input_schema で定義するクライアントツール。"],
+                ["tool_choice", "object", "いいえ", "自動、必須、指定、無効のツール利用を制御します。"],
+                ["stream", "boolean", "いいえ", "true の場合は Anthropic の名前付き SSE event を返します。"],
+              ],
+            },
+            notesTitle: "ルーティング動作",
+            notes: [
+              "Anthropic ネイティブルートでは content block と beta header を保持します。",
+              "OpenAI 互換ルートではクライアントツール、ツール結果、画像、ストリーミング event を変換します。",
+              "OpenAI 互換ルートで未対応の Anthropic サーバーツールを受けた場合は、明示的な 400 response を返します。",
+            ],
+            examplesTitle: "例",
+            examples: [
+              { title: "Messages API", code: gatewayAnthropicMessagesCurl(stats) },
+              { title: "Claude Code", code: gatewayClaudeCodeExample(stats) },
+            ],
+          },
+          {
+            id: "anthropic-count-tokens",
+            group: "LLM API",
+            method: "POST",
+            path: "/v1/messages/count_tokens",
+            title: "Anthropic Message の Token を見積もる",
+            description: "Key 認証とモデル権限の確認後、決定的な input token 見積もりを返します。推論利用としては課金されません。",
+            examplesTitle: "例",
+            examples: [{ title: "cURL", code: gatewayAnthropicCountTokensCurl(stats) }],
+          },
+          {
             id: "embeddings-api",
             group: "LLM API",
             method: "POST",
@@ -259,12 +312,13 @@ export function gatewayJapaneseLLMUsageDocs(stats: GatewayDocStats, role: AppRol
             id: "sdk-examples",
             group: teamLeader ? "チーム導入" : "Project Key",
             badge: "SDK",
-            title: "OpenAI 互換 SDK",
-            description: "OpenAI 互換 SDK の base URL を TokenHub に向け、TokenHub Project API Key を使います。",
-            examplesTitle: "SDK 例",
+            title: "SDK と Claude Code",
+            description: "OpenAI 互換 SDK は TokenHub Base URL を使い、Claude Code は TokenHub Host URL を使います。",
+            examplesTitle: "クライアント例",
             examples: [
               { title: "Node.js", code: gatewayOpenAISDKExample(stats) },
               { title: "Python", code: gatewayPythonSDKExample(stats) },
+              { title: "Claude Code", code: gatewayClaudeCodeExample(stats) },
             ],
           },
           {

--- a/frontend/features/admin/views/gateway-llm-zh.tsx
+++ b/frontend/features/admin/views/gateway-llm-zh.tsx
@@ -1,6 +1,17 @@
 import { type AppRole } from "../core/types";
 import { formatNumber } from "../domain/formatting";
-import { gatewayEmbeddingsCurl, gatewayListModelsCurl, gatewayOpenAISDKExample, gatewayPythonSDKExample, gatewayResponsesCurl, gatewayRetrieveModelCurl, gatewayStreamingCurl } from "./gateway-llm-en";
+import {
+  gatewayAnthropicCountTokensCurl,
+  gatewayAnthropicMessagesCurl,
+  gatewayClaudeCodeExample,
+  gatewayEmbeddingsCurl,
+  gatewayListModelsCurl,
+  gatewayOpenAISDKExample,
+  gatewayPythonSDKExample,
+  gatewayResponsesCurl,
+  gatewayRetrieveModelCurl,
+  gatewayStreamingCurl,
+} from "./gateway-llm-en";
 import { type GatewayDocBundle, type GatewayDocStats } from "./gateway-view";
 
 export function gatewayChineseLLMUsageDocs(stats: GatewayDocStats, role: AppRole): GatewayDocBundle {
@@ -208,6 +219,48 @@ export function gatewayChineseLLMUsageDocs(stats: GatewayDocStats, role: AppRole
             examples: [{ title: "cURL", code: gatewayResponsesCurl(stats) }],
           },
           {
+            id: "anthropic-messages",
+            group: "大模型 API",
+            method: "POST",
+            path: "/v1/messages",
+            title: "创建 Anthropic Messages 请求",
+            description: "供 Claude Code 或 Anthropic 兼容客户端调用，支持文本、图片、客户端工具、工具结果和流式响应。",
+            params: {
+              title: "请求体",
+              columns: ["字段", "类型", "必填", "说明"],
+              rows: [
+                ["model", "string", "是", "可调用的 TokenHub 模型 ID。"],
+                ["max_tokens", "integer", "是", "最大生成 Token 数。"],
+                ["messages", "array", "是", "由 user、assistant 和结构化内容块组成的 Anthropic 消息。"],
+                ["system", "string | array", "否", "顶层 Anthropic system prompt。"],
+                ["tools", "array", "否", "使用 input_schema 定义的客户端工具。"],
+                ["tool_choice", "object", "否", "控制自动、强制、指定或停用工具调用。"],
+                ["stream", "boolean", "否", "true 时返回 Anthropic 命名 SSE 事件。"],
+              ],
+            },
+            notesTitle: "路由行为",
+            notes: [
+              "原生 Anthropic 路由保留内容块和 beta Header。",
+              "OpenAI 兼容路由转换客户端工具、工具结果、图片和流式事件。",
+              "OpenAI 兼容路由遇到不支持的 Anthropic 服务端工具时返回明确的 400 响应。",
+            ],
+            examplesTitle: "示例",
+            examples: [
+              { title: "Messages API", code: gatewayAnthropicMessagesCurl(stats) },
+              { title: "Claude Code", code: gatewayClaudeCodeExample(stats) },
+            ],
+          },
+          {
+            id: "anthropic-count-tokens",
+            group: "大模型 API",
+            method: "POST",
+            path: "/v1/messages/count_tokens",
+            title: "估算 Anthropic Messages Token",
+            description: "完成 Key 认证和模型权限检查后返回确定性的输入 Token 估算值，不计为模型推理请求。",
+            examplesTitle: "示例",
+            examples: [{ title: "cURL", code: gatewayAnthropicCountTokensCurl(stats) }],
+          },
+          {
             id: "embeddings-api",
             group: "大模型 API",
             method: "POST",
@@ -259,12 +312,13 @@ export function gatewayChineseLLMUsageDocs(stats: GatewayDocStats, role: AppRole
             id: "sdk-examples",
             group: teamLeader ? "团队接入" : "项目 Key",
             badge: "SDK",
-            title: "OpenAI 兼容 SDK",
-            description: "把任意 OpenAI 兼容 SDK 指向 TokenHub Base URL，并使用 TokenHub 项目 API Key。",
-            examplesTitle: "SDK 示例",
+            title: "SDK 与 Claude Code",
+            description: "OpenAI 兼容 SDK 使用 TokenHub Base URL；Claude Code 使用 TokenHub Host URL。",
+            examplesTitle: "客户端示例",
             examples: [
               { title: "Node.js", code: gatewayOpenAISDKExample(stats) },
               { title: "Python", code: gatewayPythonSDKExample(stats) },
+              { title: "Claude Code", code: gatewayClaudeCodeExample(stats) },
             ],
           },
           {

--- a/frontend/features/admin/views/quick-access.tsx
+++ b/frontend/features/admin/views/quick-access.tsx
@@ -13,7 +13,8 @@ import { GatewayCodeBlock } from "./gateway-docs-ui";
 
 type QuickAccessStep = "keys" | "models" | "usage";
 type UsageMode = "api" | "tools";
-type APIStyle = "chat" | "responses";
+type APIStyle = "chat" | "responses" | "messages";
+type ToolStyle = "openai" | "claude";
 type CodeLanguage = "curl" | "python" | "node";
 
 export function QuickAccessView({
@@ -493,11 +494,12 @@ function ModelDetail({ model, data }: { model: Model; data: AppData }) {
 function UsageStep({ api, keyHint, model }: { api: ApiContext; keyHint: string; model: Model }) {
   const [mode, setMode] = useState<UsageMode>("api");
   const [apiStyle, setAPIStyle] = useState<APIStyle>("chat");
+  const [toolStyle, setToolStyle] = useState<ToolStyle>("openai");
   const [language, setLanguage] = useState<CodeLanguage>("curl");
   const baseURL = apiGatewayBaseURL(api.baseURL);
   const code = mode === "api"
     ? apiExamples(baseURL, model.name, apiStyle)[language]
-    : toolExamples(baseURL, model.name)[language];
+    : toolExamples(baseURL, model.name, toolStyle)[language];
 
   return (
     <div className="quick-access-usage-step">
@@ -515,8 +517,14 @@ function UsageStep({ api, keyHint, model }: { api: ApiContext; keyHint: string; 
           <div className="quick-access-segmented" aria-label={tx("API 类型")}>
             <button className={apiStyle === "chat" ? "active" : ""} onClick={() => setAPIStyle("chat")} type="button">Chat Completions</button>
             <button className={apiStyle === "responses" ? "active" : ""} onClick={() => setAPIStyle("responses")} type="button">Responses API</button>
+            <button className={apiStyle === "messages" ? "active" : ""} onClick={() => setAPIStyle("messages")} type="button">Anthropic Messages</button>
           </div>
-        ) : <strong>{tx("OpenAI 兼容工具")}</strong>}
+        ) : (
+          <div className="quick-access-segmented" aria-label={tx("AI 工具类型")}>
+            <button className={toolStyle === "openai" ? "active" : ""} onClick={() => setToolStyle("openai")} type="button">{tx("OpenAI 兼容工具")}</button>
+            <button className={toolStyle === "claude" ? "active" : ""} onClick={() => setToolStyle("claude")} type="button">Claude Code</button>
+          </div>
+        )}
         <span>{tx("当前模型")} <code>{model.name}</code></span>
       </div>
 
@@ -548,42 +556,60 @@ function maskedKey(key?: APIKey) {
 }
 
 function apiExamples(baseURL: string, model: string, style: APIStyle): Record<CodeLanguage, string> {
-  const endpoint = style === "chat" ? "chat/completions" : "responses";
-  const body = style === "chat"
-    ? `{
+  const endpoint = style === "chat" ? "chat/completions" : style === "responses" ? "responses" : "messages";
+  const body = style === "chat" ? `{
     "model": "${model}",
     "messages": [
       {"role": "user", "content": "Hello, TokenHub"}
     ]
-  }`
-    : `{
+  }` : style === "responses" ? `{
     "model": "${model}",
     "input": "Hello, TokenHub"
+  }` : `{
+    "model": "${model}",
+    "max_tokens": 1024,
+    "messages": [
+      {"role": "user", "content": "Hello, TokenHub"}
+    ]
   }`;
-  const pythonCall = style === "chat"
-    ? `client.chat.completions.create(
+  const pythonCall = style === "chat" ? `client.chat.completions.create(
     model="${model}",
     messages=[{"role": "user", "content": "Hello, TokenHub"}],
-)`
-    : `client.responses.create(
+)` : style === "responses" ? `client.responses.create(
     model="${model}",
     input="Hello, TokenHub",
+)` : `client.messages.create(
+    model="${model}",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "Hello, TokenHub"}],
 )`;
-  const nodeCall = style === "chat"
-    ? `client.chat.completions.create({
+  const nodeCall = style === "chat" ? `client.chat.completions.create({
   model: "${model}",
   messages: [{ role: "user", content: "Hello, TokenHub" }],
-})`
-    : `client.responses.create({
+})` : style === "responses" ? `client.responses.create({
   model: "${model}",
   input: "Hello, TokenHub",
+})` : `client.messages.create({
+  model: "${model}",
+  max_tokens: 1024,
+  messages: [{ role: "user", content: "Hello, TokenHub" }],
 })`;
+  const anthropicHostURL = baseURL.replace(/\/v1\/?$/, "");
   return {
     curl: `curl -X POST '${baseURL}/${endpoint}' \\
   -H "Authorization: Bearer $TOKENHUB_API_KEY" \\
-  -H 'Content-Type: application/json' \\
+${style === "messages" ? "  -H 'anthropic-version: 2023-06-01' \\\n" : ""}  -H 'Content-Type: application/json' \\
   -d '${body}'`,
-    python: `import os
+    python: style === "messages" ? `import os
+from anthropic import Anthropic
+
+client = Anthropic(
+    api_key=os.environ["TOKENHUB_API_KEY"],
+    base_url="${anthropicHostURL}",
+)
+
+response = ${pythonCall}
+print(response)` : `import os
 from openai import OpenAI
 
 client = OpenAI(
@@ -593,7 +619,15 @@ client = OpenAI(
 
 response = ${pythonCall}
 print(response)`,
-    node: `import OpenAI from "openai";
+    node: style === "messages" ? `import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic({
+  apiKey: process.env.TOKENHUB_API_KEY,
+  baseURL: "${anthropicHostURL}",
+});
+
+const response = await ${nodeCall};
+console.log(response);` : `import OpenAI from "openai";
 
 const client = new OpenAI({
   apiKey: process.env.TOKENHUB_API_KEY,
@@ -605,7 +639,25 @@ console.log(response);`,
   };
 }
 
-function toolExamples(baseURL: string, model: string): Record<CodeLanguage, string> {
+function toolExamples(baseURL: string, model: string, style: ToolStyle): Record<CodeLanguage, string> {
+  if (style === "claude") {
+    const anthropicHostURL = baseURL.replace(/\/v1\/?$/, "");
+    return {
+      curl: `export ANTHROPIC_BASE_URL="${anthropicHostURL}"
+export ANTHROPIC_AUTH_TOKEN="$TOKENHUB_API_KEY"
+export ANTHROPIC_MODEL="${model}"
+
+claude`,
+      node: `{
+  "env": {
+    "ANTHROPIC_BASE_URL": "${anthropicHostURL}",
+    "ANTHROPIC_AUTH_TOKEN": "${"${TOKENHUB_API_KEY}"}",
+    "ANTHROPIC_MODEL": "${model}"
+  }
+}`,
+      python: "",
+    };
+  }
   return {
     curl: `export OPENAI_API_KEY="$TOKENHUB_API_KEY"
 export OPENAI_BASE_URL="${baseURL}"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev --hostname 0.0.0.0",
     "build": "next build",
     "start": "next start --hostname 0.0.0.0",
-    "check:lines": "node scripts/check-source-lines.mjs",
+    "check:lines": "node check-source-lines.mjs",
     "typecheck": "npm run check:lines && tsc --noEmit"
   },
   "dependencies": {

--- a/sdk/.env.example
+++ b/sdk/.env.example
@@ -1,6 +1,8 @@
 TOKENHUB_BASE_URL=http://localhost:8080/v1
 TOKENHUB_API_KEY=thk_your_tokenhub_key
 TOKENHUB_MODEL=deepseek-chat
+TOKENHUB_ANTHROPIC_BASE_URL=http://localhost:8080
+TOKENHUB_ANTHROPIC_MODEL=claude-compatible-model
 TOKENHUB_PROMPT=Explain in three sentences that the TokenHub gateway path is working.
 TOKENHUB_ADMIN_BASE_URL=http://localhost:8080
 TOKENHUB_ADMIN_TOKEN=dev_admin_token

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -23,6 +23,13 @@ Then run:
 npm run test:deepseek
 ```
 
+To verify the Anthropic Messages and Claude Code gateway:
+
+```bash
+TOKENHUB_ANTHROPIC_MODEL=claude-compatible-model \
+  npm run test:anthropic-messages
+```
+
 To verify the Admin API path for security policies:
 
 ```bash
@@ -38,6 +45,10 @@ Before running the test, make sure TokenHub has:
 - An internal API Key whose allowed models include `deepseek-chat`.
 
 The script calls `GET /v1/models` first, then sends a `generateText` request through AI SDK.
+
+The Anthropic Messages script checks model discovery, token counting, and an
+Anthropic SSE request with a client tool. `TOKENHUB_ANTHROPIC_BASE_URL` is the
+TokenHub host URL without the `/v1` suffix.
 
 The security policy script calls the Admin API with `TOKENHUB_ADMIN_TOKEN`, then creates or updates the policy identified by `TOKENHUB_SECURITY_POLICY_ID`. It is idempotent, so you can run it repeatedly without creating duplicate policies.
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -5,6 +5,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
+    "test:anthropic-messages": "node ./test-anthropic-messages.mjs",
     "test:deepseek": "node ./test-deepseek.mjs",
     "test:security-policy": "node ./test-security-policy.mjs"
   },

--- a/sdk/test-anthropic-messages.mjs
+++ b/sdk/test-anthropic-messages.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+loadDotEnv(resolve(__dirname, ".env"));
+
+const baseURL = normalizeHostURL(
+  process.env.TOKENHUB_ANTHROPIC_BASE_URL
+    || process.env.TOKENHUB_BASE_URL
+    || "http://localhost:8080",
+);
+const apiKey = process.env.TOKENHUB_API_KEY || "";
+const model = process.env.TOKENHUB_ANTHROPIC_MODEL || process.env.TOKENHUB_MODEL || "";
+
+if (!apiKey || apiKey === "thk_your_tokenhub_key" || !model) {
+  console.error("Missing TOKENHUB_API_KEY or TOKENHUB_ANTHROPIC_MODEL.");
+  console.error("Run with:");
+  console.error("  TOKENHUB_API_KEY=thk_xxx TOKENHUB_ANTHROPIC_MODEL=claude-model npm run test:anthropic-messages");
+  process.exit(1);
+}
+
+console.log("TokenHub Anthropic Messages smoke test");
+console.log(`Base URL: ${baseURL}`);
+console.log(`Model:    ${model}`);
+console.log(`API Key:  ${maskKey(apiKey)}`);
+console.log("");
+
+await checkModelVisibility();
+await checkTokenCount();
+await checkStreamingToolRequest();
+
+async function checkModelVisibility() {
+  const response = await fetch(`${baseURL}/v1/models`, {
+    headers: { authorization: `Bearer ${apiKey}` },
+  });
+  const payload = await responseJSON(response, "GET /v1/models");
+  const models = Array.isArray(payload.data) ? payload.data : [];
+  if (!models.some((item) => item?.id === model)) {
+    throw new Error(`Model ${model} is not visible to the TokenHub key`);
+  }
+  console.log("Model discovery: passed");
+}
+
+async function checkTokenCount() {
+  const response = await fetch(`${baseURL}/v1/messages/count_tokens`, {
+    method: "POST",
+    headers: anthropicHeaders(),
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: "Understand this repository." }],
+      tools: [repositoryTool()],
+    }),
+  });
+  const payload = await responseJSON(response, "POST /v1/messages/count_tokens");
+  if (!Number.isFinite(payload.input_tokens) || payload.input_tokens <= 0) {
+    throw new Error(`Invalid token count response: ${JSON.stringify(payload)}`);
+  }
+  console.log(`Token counting: passed (${payload.input_tokens} estimated input tokens)`);
+}
+
+async function checkStreamingToolRequest() {
+  const response = await fetch(`${baseURL}/v1/messages`, {
+    method: "POST",
+    headers: anthropicHeaders(),
+    body: JSON.stringify({
+      model,
+      max_tokens: 1024,
+      stream: true,
+      system: "Use the provided repository tool when it helps answer the request.",
+      messages: [{
+        role: "user",
+        content: "Call inspect_repository for the backend and then summarize what should be inspected next.",
+      }],
+      tools: [repositoryTool()],
+      tool_choice: { type: "auto" },
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`POST /v1/messages failed: ${response.status} ${await response.text()}`);
+  }
+  const stream = await response.text();
+  for (const event of ["event: message_start", "event: content_block_start", "event: message_delta", "event: message_stop"]) {
+    if (!stream.includes(event)) {
+      throw new Error(`Messages stream is missing ${event}:\n${stream}`);
+    }
+  }
+  console.log("Streaming Messages: passed");
+}
+
+function repositoryTool() {
+  return {
+    name: "inspect_repository",
+    description: "Inspect one repository area.",
+    input_schema: {
+      type: "object",
+      properties: {
+        area: { type: "string" },
+      },
+      required: ["area"],
+    },
+  };
+}
+
+function anthropicHeaders() {
+  return {
+    authorization: `Bearer ${apiKey}`,
+    "anthropic-version": "2023-06-01",
+    "content-type": "application/json",
+  };
+}
+
+async function responseJSON(response, label) {
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`${label} failed: ${response.status} ${body}`);
+  }
+  try {
+    return JSON.parse(body);
+  } catch {
+    throw new Error(`${label} returned invalid JSON: ${body}`);
+  }
+}
+
+function loadDotEnv(path) {
+  if (!existsSync(path)) return;
+  const lines = readFileSync(path, "utf8").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq < 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const raw = trimmed.slice(eq + 1).trim();
+    if (!key || process.env[key] !== undefined) continue;
+    process.env[key] = stripEnvQuotes(raw);
+  }
+}
+
+function stripEnvQuotes(value) {
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function normalizeHostURL(value) {
+  return value.replace(/\/+$/, "").replace(/\/v1$/, "");
+}
+
+function maskKey(value) {
+  if (value.length <= 10) return "***";
+  return `${value.slice(0, 6)}...${value.slice(-4)}`;
+}


### PR DESCRIPTION
> PR title format: `<type>[optional scope][!]: <short summary>` in English, max 72 characters.
> Common types include `feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `style`, and `revert`. Use a lowercase imperative summary without a trailing period.

## Summary

Expose an Anthropic Messages-compatible gateway so local Claude Code can use TokenHub project keys and model routing without changing the existing OpenAI-compatible API.

## Related Issue

N/A

## Changes

- Add `/v1/messages` and `/v1/messages/count_tokens` with Bearer and `x-api-key` authentication, model discovery fields, Anthropic-native passthrough, and OpenAI-compatible request/response/SSE conversion.
- Support text, URL/base64 images, client tools, parallel tool calls, tool results, usage/cache accounting, safe route fallback, and provider-resource accounting.
- Add focused, race, SDK, and opt-in live Claude Code tests; sanitize child-process environments so upstream credentials are never inherited.
- Add Claude Code and Anthropic Messages Quick Start examples plus synchronized English, Simplified Chinese, and Japanese documentation.
- Keep `feature-dev` optional by recording design decisions in task context unless durable documentation is explicitly requested; restore the frontend source-line gate with fixed baselines for existing oversized files.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor or maintenance
- [x] Documentation
- [ ] Deployment or configuration

## Verification

- [x] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [x] Frontend: `npm run typecheck` and `npm run build`
- [x] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/server -run 'AnthropicMessages|CompatibleAnthropicRoutes|LiveCommandEnvironment|ClaudeCode' -count=1`
- `npm run typecheck`
- `npm run build`
- `node --check sdk/test-anthropic-messages.mjs`
- `git diff --check`
- Live Ark-backed E2E: vision input, SDK model discovery/token counting/streaming tools, and a six-turn Claude Code repository-understanding query.
- Browser regression: verified the `/gateway` Quick Start examples and responsive layout.
- Three independent `feature-dev` review rounds; the final review reported no findings.
- Docker Compose rendering was not run because this change adds no deployment configuration.

### Claude Code through TokenHub

<img width="990" height="470" alt="claude-code-tokenhub-e2e-mr" src="https://github.com/user-attachments/assets/68d1950d-7e65-4cfb-9e8d-0ab25f029251" />

The screenshot uses a temporary in-memory TokenHub key; no upstream credential is shown or persisted.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: Additive only. Existing OpenAI-compatible routes and contracts are unchanged; Anthropic Messages routes are new.
- Security or credential-handling impact: Requests use project-scoped TokenHub keys. Upstream credentials remain server-side, live child processes receive a strict environment whitelist, and incompatible routes are skipped without provider penalties or synthetic attempt logs.
- Database, environment, or deployment impact: No migration, persistent environment variable, or deployment change. SDK examples add only client-side variables for the smoke test.
- Rollout and rollback considerations: Deploy normally. Reverting this commit removes the additive routes and UI/docs examples; existing OpenAI-compatible clients are unaffected.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
