### PR TITLE
fix(gateway): convert tools and stream incrementally on Anthropic/Gemini

### DIFF
--- a/backend/internal/server/chat_stream_encoder.go
+++ b/backend/internal/server/chat_stream_encoder.go
@@ -1,0 +1,356 @@
+package server
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// openAIChatStreamEncoder renders provider-agnostic streaming events as OpenAI
+// chat.completion.chunk frames. Provider decoders own their wire-format state
+// machines and call into this encoder, so the OpenAI-facing output shape is
+// defined in exactly one place.
+//
+// The encoder flushes after every frame. Without an explicit flush net/http
+// buffers the response and a genuinely incremental upstream would still reach
+// the client as one late burst.
+type openAIChatStreamEncoder struct {
+	writer       io.Writer
+	id           string
+	model        string
+	created      int64
+	includeUsage bool
+
+	roleSent  bool
+	finalized bool
+	toolSlots int
+}
+
+type streamFlusher interface{ Flush() }
+
+// streamUsageRequested reports whether the client asked for the trailing
+// usage-only chunk via stream_options.include_usage.
+func streamUsageRequested(req ChatCompletionRequest) bool {
+	if req.StreamOptions == nil {
+		return false
+	}
+	value, ok := req.StreamOptions["include_usage"].(bool)
+	return ok && value
+}
+
+func newOpenAIChatStreamEncoder(w io.Writer, model string, includeUsage bool) *openAIChatStreamEncoder {
+	return &openAIChatStreamEncoder{
+		writer:       w,
+		id:           NewID("chatcmpl"),
+		model:        model,
+		created:      time.Now().Unix(),
+		includeUsage: includeUsage,
+	}
+}
+
+// NextToolSlot allocates a dense OpenAI tool_calls index. Provider block
+// indexes are not usable directly: Anthropic interleaves thinking and text
+// blocks with tool_use blocks, so its content index is sparse from OpenAI's
+// perspective.
+func (e *openAIChatStreamEncoder) NextToolSlot() int {
+	slot := e.toolSlots
+	e.toolSlots++
+	return slot
+}
+
+func (e *openAIChatStreamEncoder) EmitRole() error {
+	if e.roleSent {
+		return nil
+	}
+	e.roleSent = true
+	return e.emitDelta(map[string]any{"role": "assistant"})
+}
+
+func (e *openAIChatStreamEncoder) EmitText(delta string) error {
+	if delta == "" {
+		return nil
+	}
+	if err := e.EmitRole(); err != nil {
+		return err
+	}
+	return e.emitDelta(map[string]any{"content": delta})
+}
+
+func (e *openAIChatStreamEncoder) EmitReasoning(delta string) error {
+	if delta == "" {
+		return nil
+	}
+	if err := e.EmitRole(); err != nil {
+		return err
+	}
+	return e.emitDelta(map[string]any{"reasoning_content": delta})
+}
+
+// EmitReasoningSignature forwards the provider's opaque continuation blob. It is
+// emitted as a standalone delta so clients can associate it with the reasoning
+// content that preceded it.
+func (e *openAIChatStreamEncoder) EmitReasoningSignature(provider string, signature string) error {
+	if signature == "" {
+		return nil
+	}
+	if err := e.EmitRole(); err != nil {
+		return err
+	}
+	return e.emitDelta(map[string]any{"reasoning_signature": encodeProviderSignature(provider, signature)})
+}
+
+func (e *openAIChatStreamEncoder) EmitRedactedReasoning(data string) error {
+	if data == "" {
+		return nil
+	}
+	if err := e.EmitRole(); err != nil {
+		return err
+	}
+	return e.emitDelta(map[string]any{"redacted_reasoning_content": data})
+}
+
+func (e *openAIChatStreamEncoder) EmitToolCallStart(slot int, id string, name string) error {
+	if err := e.EmitRole(); err != nil {
+		return err
+	}
+	call := map[string]any{
+		"index":    slot,
+		"id":       id,
+		"type":     "function",
+		"function": map[string]any{"name": name, "arguments": ""},
+	}
+	return e.emitDelta(map[string]any{"tool_calls": []any{call}})
+}
+
+func (e *openAIChatStreamEncoder) EmitToolCallArguments(slot int, delta string) error {
+	if delta == "" {
+		return nil
+	}
+	call := map[string]any{
+		"index":    slot,
+		"function": map[string]any{"arguments": delta},
+	}
+	return e.emitDelta(map[string]any{"tool_calls": []any{call}})
+}
+
+// EmitToolCallSignature attaches provider continuation data to a tool call.
+// Gemini binds its thought signature to the function call rather than to the
+// message, so it travels alongside the tool call instead of the reasoning text.
+func (e *openAIChatStreamEncoder) EmitToolCallSignature(slot int, provider string, signature string) error {
+	if signature == "" {
+		return nil
+	}
+	call := map[string]any{
+		"index":             slot,
+		"thought_signature": encodeProviderSignature(provider, signature),
+	}
+	return e.emitDelta(map[string]any{"tool_calls": []any{call}})
+}
+
+// Finalize writes the terminal frames exactly once, in the order OpenAI
+// clients expect: the finish_reason chunk, an optional usage-only chunk, then
+// the [DONE] sentinel.
+func (e *openAIChatStreamEncoder) Finalize(finishReason string, usage Usage) error {
+	if e.finalized {
+		return nil
+	}
+	e.finalized = true
+	if err := e.EmitRole(); err != nil {
+		return err
+	}
+	if finishReason == "" {
+		finishReason = "stop"
+	}
+	frame := e.newFrame()
+	frame["choices"] = []any{map[string]any{
+		"index":         0,
+		"delta":         map[string]any{},
+		"finish_reason": finishReason,
+	}}
+	if err := e.writeFrame(frame); err != nil {
+		return err
+	}
+	if e.includeUsage {
+		usageFrame := e.newFrame()
+		usageFrame["choices"] = []any{}
+		usageFrame["usage"] = usage
+		if err := e.writeFrame(usageFrame); err != nil {
+			return err
+		}
+	}
+	if err := e.write("data: [DONE]\n\n"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Abort marks the stream as terminated without emitting a completion sentinel.
+// A client must not see [DONE] for a stream that failed midway.
+func (e *openAIChatStreamEncoder) Abort() {
+	e.finalized = true
+}
+
+func (e *openAIChatStreamEncoder) emitDelta(delta map[string]any) error {
+	frame := e.newFrame()
+	frame["choices"] = []any{map[string]any{
+		"index":         0,
+		"delta":         delta,
+		"finish_reason": nil,
+	}}
+	return e.writeFrame(frame)
+}
+
+func (e *openAIChatStreamEncoder) newFrame() map[string]any {
+	frame := map[string]any{
+		"id":      e.id,
+		"object":  "chat.completion.chunk",
+		"created": e.created,
+		"model":   e.model,
+	}
+	if e.includeUsage {
+		// OpenAI sets usage to null on every chunk but the final usage-only one.
+		frame["usage"] = nil
+	}
+	return frame
+}
+
+func (e *openAIChatStreamEncoder) writeFrame(frame map[string]any) error {
+	payload, err := json.Marshal(frame)
+	if err != nil {
+		return err
+	}
+	return e.write("data: " + string(payload) + "\n\n")
+}
+
+func (e *openAIChatStreamEncoder) write(payload string) error {
+	if _, err := io.WriteString(e.writer, payload); err != nil {
+		return err
+	}
+	if flusher, ok := e.writer.(streamFlusher); ok {
+		flusher.Flush()
+	}
+	return nil
+}
+
+// serverSentEvent is one decoded SSE frame.
+type serverSentEvent struct {
+	Event string
+	Data  string
+}
+
+// maxSSEEventBytes bounds a single decoded event. bufio.Scanner's 64 KiB
+// default is too small for reasoning and tool-argument frames, but an unbounded
+// reader lets a faulty or hostile upstream grow one event until the process runs
+// out of memory.
+const maxSSEEventBytes = 8 << 20
+
+// sseDecoder reads Server-Sent Events without the 64 KiB ceiling bufio.Scanner
+// imposes by default.
+type sseDecoder struct {
+	reader *bufio.Reader
+}
+
+func newSSEDecoder(r io.Reader) *sseDecoder {
+	return &sseDecoder{reader: bufio.NewReader(r)}
+}
+
+// Next returns the next event, or io.EOF once the stream is exhausted.
+func (d *sseDecoder) Next() (serverSentEvent, error) {
+	var (
+		event serverSentEvent
+		data  []string
+		seen  bool
+		size  int
+	)
+	for {
+		line, err := d.readLine(&size)
+		if err != nil && err != io.EOF {
+			return serverSentEvent{}, err
+		}
+		if line != "" {
+			trimmed := strings.TrimRight(line, "\r\n")
+			switch {
+			case trimmed == "":
+				// Blank line terminates the frame. Ignore stray separators
+				// between frames.
+				if seen {
+					event.Data = strings.Join(data, "\n")
+					return event, nil
+				}
+			case strings.HasPrefix(trimmed, ":"):
+				// Comment/heartbeat line.
+				seen = true
+			default:
+				name, value := splitSSEField(trimmed)
+				seen = true
+				switch name {
+				case "event":
+					event.Event = value
+				case "data":
+					data = append(data, value)
+				default:
+					// id/retry and unknown fields are not meaningful here.
+				}
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				if seen {
+					event.Data = strings.Join(data, "\n")
+					return event, nil
+				}
+				return serverSentEvent{}, io.EOF
+			}
+			return serverSentEvent{}, err
+		}
+	}
+}
+
+// readLine reads one line while charging its bytes against the event budget.
+// bufio.Reader.ReadString would allocate the whole line before returning, so a
+// line that never terminates could exhaust memory before any limit was checked.
+// ReadSlice hands back bounded chunks, letting the budget stop the read early.
+func (d *sseDecoder) readLine(size *int) (string, error) {
+	var builder strings.Builder
+	for {
+		chunk, err := d.reader.ReadSlice('\n')
+		*size += len(chunk)
+		if *size > maxSSEEventBytes {
+			return "", invalidProviderResponseError("provider sent a stream event that exceeds the size limit")
+		}
+		builder.Write(chunk)
+		if err == bufio.ErrBufferFull {
+			continue
+		}
+		return builder.String(), err
+	}
+}
+
+func splitSSEField(line string) (string, string) {
+	colon := strings.Index(line, ":")
+	if colon < 0 {
+		return line, ""
+	}
+	name := line[:colon]
+	value := line[colon+1:]
+	// A single leading space after the colon is part of the framing.
+	value = strings.TrimPrefix(value, " ")
+	return name, value
+}
+
+// decodeSSEData unmarshals an event payload, rejecting malformed frames rather
+// than skipping them: a dropped frame silently truncates the response.
+func decodeSSEData(event serverSentEvent) (map[string]any, error) {
+	payload := strings.TrimSpace(event.Data)
+	if payload == "" {
+		return nil, nil
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(payload), &decoded); err != nil {
+		return nil, invalidProviderResponseError(fmt.Sprintf("provider sent a malformed stream event: %v", err))
+	}
+	return decoded, nil
+}

--- a/backend/internal/server/chat_stream_encoder_test.go
+++ b/backend/internal/server/chat_stream_encoder_test.go
@@ -1,0 +1,277 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// recordingWriter captures frames and counts flushes so tests can assert that
+// output actually reaches the client incrementally.
+type recordingWriter struct {
+	builder strings.Builder
+	flushes int
+	failAt  int
+	writes  int
+}
+
+func (w *recordingWriter) Write(data []byte) (int, error) {
+	w.writes++
+	if w.failAt > 0 && w.writes >= w.failAt {
+		return 0, errors.New("downstream write failed")
+	}
+	return w.builder.Write(data)
+}
+
+func (w *recordingWriter) Flush() { w.flushes++ }
+
+func (w *recordingWriter) frames(t *testing.T) []map[string]any {
+	t.Helper()
+	var frames []map[string]any
+	for _, block := range strings.Split(w.builder.String(), "\n\n") {
+		payload := strings.TrimPrefix(strings.TrimSpace(block), "data: ")
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		var frame map[string]any
+		if err := json.Unmarshal([]byte(payload), &frame); err != nil {
+			t.Fatalf("frame is not valid JSON: %v (%q)", err, payload)
+		}
+		frames = append(frames, frame)
+	}
+	return frames
+}
+
+func frameDelta(t *testing.T, frame map[string]any) map[string]any {
+	t.Helper()
+	choices, _ := frame["choices"].([]any)
+	if len(choices) == 0 {
+		return nil
+	}
+	choice, _ := choices[0].(map[string]any)
+	delta, _ := choice["delta"].(map[string]any)
+	return delta
+}
+
+func TestStreamEncoderEmitsRoleThenTextAndFlushesEachFrame(t *testing.T) {
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+
+	if err := encoder.EmitText("Hel"); err != nil {
+		t.Fatalf("EmitText: %v", err)
+	}
+	if err := encoder.EmitText("lo"); err != nil {
+		t.Fatalf("EmitText: %v", err)
+	}
+	if err := encoder.Finalize("stop", Usage{}); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+
+	frames := writer.frames(t)
+	if len(frames) != 4 {
+		t.Fatalf("expected role + 2 text + finish frames, got %d", len(frames))
+	}
+	if role, _ := frameDelta(t, frames[0])["role"].(string); role != "assistant" {
+		t.Fatalf("first frame must announce the assistant role, got %v", frames[0])
+	}
+	if content, _ := frameDelta(t, frames[1])["content"].(string); content != "Hel" {
+		t.Fatalf("unexpected first text delta: %v", frames[1])
+	}
+	// Without a flush per frame net/http buffers the response and the stream
+	// only reaches the client at the end.
+	if writer.flushes != writer.writes {
+		t.Fatalf("expected one flush per write, got %d flushes for %d writes", writer.flushes, writer.writes)
+	}
+	if !strings.HasSuffix(writer.builder.String(), "data: [DONE]\n\n") {
+		t.Fatalf("stream must end with the [DONE] sentinel")
+	}
+}
+
+func TestStreamEncoderOmitsUsageChunkUnlessRequested(t *testing.T) {
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	if err := encoder.Finalize("stop", Usage{PromptTokens: 3, CompletionTokens: 4}); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	for _, frame := range writer.frames(t) {
+		if _, present := frame["usage"]; present {
+			t.Fatalf("usage must be absent when include_usage was not requested: %v", frame)
+		}
+	}
+}
+
+func TestStreamEncoderEmitsTrailingUsageChunkWhenRequested(t *testing.T) {
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", true)
+	if err := encoder.EmitText("hi"); err != nil {
+		t.Fatalf("EmitText: %v", err)
+	}
+	if err := encoder.Finalize("stop", Usage{PromptTokens: 3, CompletionTokens: 4, TotalTokens: 7}); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+
+	frames := writer.frames(t)
+	final := frames[len(frames)-1]
+	choices, _ := final["choices"].([]any)
+	if len(choices) != 0 {
+		t.Fatalf("the usage chunk must carry an empty choices array, got %v", final)
+	}
+	usage, _ := final["usage"].(map[string]any)
+	if usage == nil {
+		t.Fatalf("expected a usage payload on the final chunk, got %v", final)
+	}
+	// Every preceding chunk carries an explicit null usage.
+	for _, frame := range frames[:len(frames)-1] {
+		value, present := frame["usage"]
+		if !present || value != nil {
+			t.Fatalf("non-final chunks must carry usage:null, got %v", frame)
+		}
+	}
+}
+
+func TestStreamEncoderAbortSuppressesDoneSentinel(t *testing.T) {
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	if err := encoder.EmitText("partial"); err != nil {
+		t.Fatalf("EmitText: %v", err)
+	}
+	encoder.Abort()
+	if err := encoder.Finalize("stop", Usage{}); err != nil {
+		t.Fatalf("Finalize after Abort must be a no-op: %v", err)
+	}
+	if strings.Contains(writer.builder.String(), "[DONE]") {
+		t.Fatalf("an aborted stream must not tell the client it completed")
+	}
+}
+
+func TestStreamEncoderAssignsDenseToolSlots(t *testing.T) {
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+
+	first := encoder.NextToolSlot()
+	second := encoder.NextToolSlot()
+	if first != 0 || second != 1 {
+		t.Fatalf("tool slots must be dense and zero-based, got %d and %d", first, second)
+	}
+	if err := encoder.EmitToolCallStart(second, "call_2", "beta"); err != nil {
+		t.Fatalf("EmitToolCallStart: %v", err)
+	}
+	if err := encoder.EmitToolCallArguments(second, `{"a":1}`); err != nil {
+		t.Fatalf("EmitToolCallArguments: %v", err)
+	}
+
+	frames := writer.frames(t)
+	last := frameDelta(t, frames[len(frames)-1])
+	calls, _ := last["tool_calls"].([]any)
+	call, _ := calls[0].(map[string]any)
+	if index, _ := call["index"].(float64); int(index) != 1 {
+		t.Fatalf("tool call must report its dense index, got %v", call)
+	}
+}
+
+func TestStreamEncoderPropagatesWriteErrors(t *testing.T) {
+	writer := &recordingWriter{failAt: 2}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	// The role frame succeeds, the text frame fails.
+	if err := encoder.EmitText("boom"); err == nil {
+		t.Fatalf("expected the downstream write error to propagate")
+	}
+}
+
+func TestSSEDecoderHandlesFramingVariants(t *testing.T) {
+	// CRLF line endings, a comment heartbeat, a multi-line data payload and a
+	// named event all appear in real provider streams.
+	raw := ": heartbeat\r\n" +
+		"event: message_start\r\n" +
+		"data: {\"type\":\r\n" +
+		"data: \"message_start\"}\r\n" +
+		"\r\n" +
+		"event: message_stop\n" +
+		"data: {\"type\":\"message_stop\"}\n\n"
+
+	decoder := newSSEDecoder(strings.NewReader(raw))
+
+	first, err := decoder.Next()
+	if err != nil {
+		t.Fatalf("first event: %v", err)
+	}
+	if first.Event != "message_start" {
+		t.Fatalf("expected the named event, got %q", first.Event)
+	}
+	payload, err := decodeSSEData(first)
+	if err != nil {
+		t.Fatalf("multi-line data must reassemble into valid JSON: %v", err)
+	}
+	if payload["type"] != "message_start" {
+		t.Fatalf("unexpected payload: %v", payload)
+	}
+
+	second, err := decoder.Next()
+	if err != nil {
+		t.Fatalf("second event: %v", err)
+	}
+	if second.Event != "message_stop" {
+		t.Fatalf("expected message_stop, got %q", second.Event)
+	}
+
+	if _, err := decoder.Next(); err != io.EOF {
+		t.Fatalf("expected EOF after the last frame, got %v", err)
+	}
+}
+
+func TestSSEDecoderHandlesEventsLargerThanScannerLimit(t *testing.T) {
+	// bufio.Scanner caps tokens at 64 KiB by default; reasoning and tool
+	// argument frames routinely exceed that.
+	large := strings.Repeat("x", 128*1024)
+	raw := "data: {\"text\":\"" + large + "\"}\n\n"
+
+	event, err := newSSEDecoder(strings.NewReader(raw)).Next()
+	if err != nil {
+		t.Fatalf("large event: %v", err)
+	}
+	payload, err := decodeSSEData(event)
+	if err != nil {
+		t.Fatalf("decode large event: %v", err)
+	}
+	if text, _ := payload["text"].(string); len(text) != len(large) {
+		t.Fatalf("large payload was truncated: got %d bytes", len(text))
+	}
+}
+
+func TestSSEDecoderRejectsMalformedJSON(t *testing.T) {
+	event, err := newSSEDecoder(strings.NewReader("data: {not json}\n\n")).Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	// Skipping a malformed frame would silently truncate the response, so it
+	// must surface as an upstream error instead.
+	if _, err := decodeSSEData(event); err == nil {
+		t.Fatalf("expected malformed event data to be rejected")
+	}
+}
+
+func TestSSEDecoderReturnsFinalFrameWithoutTrailingBlankLine(t *testing.T) {
+	event, err := newSSEDecoder(strings.NewReader("data: {\"a\":1}")).Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	payload, err := decodeSSEData(event)
+	if err != nil {
+		t.Fatalf("decodeSSEData: %v", err)
+	}
+	if payload["a"].(float64) != 1 {
+		t.Fatalf("unexpected payload: %v", payload)
+	}
+}
+
+func TestStreamUsageRequested(t *testing.T) {
+	if streamUsageRequested(ChatCompletionRequest{}) {
+		t.Fatalf("usage must not be reported without stream_options")
+	}
+	req := ChatCompletionRequest{StreamOptions: map[string]any{"include_usage": true}}
+	if !streamUsageRequested(req) {
+		t.Fatalf("include_usage=true must request the usage chunk")
+	}
+}

--- a/backend/internal/server/provider_anthropic_convert.go
+++ b/backend/internal/server/provider_anthropic_convert.go
@@ -1,0 +1,442 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Conversion between OpenAI Chat Completions and the Anthropic Messages wire
+// format. Both the streaming and non-streaming adapter paths share these
+// functions so the two cannot drift apart.
+
+const anthropicDefaultMaxTokens = 1024
+
+// buildAnthropicRequest renders an OpenAI chat request as an Anthropic Messages
+// request body.
+func buildAnthropicRequest(providerModel string, req ChatCompletionRequest, reasoningEffort *string) (map[string]any, error) {
+	system, messages, err := anthropicMessagesFromChat(req.Messages)
+	if err != nil {
+		return nil, err
+	}
+
+	maxTokens := req.MaxTokens
+	if maxTokens <= 0 {
+		// Anthropic requires an explicit positive max_tokens; 0 carries special
+		// prompt-cache semantics and must not be used as a default.
+		maxTokens = anthropicDefaultMaxTokens
+	}
+
+	payload := map[string]any{
+		"model":      providerModel,
+		"max_tokens": maxTokens,
+		"messages":   messages,
+	}
+	if len(system) > 0 {
+		payload["system"] = system
+	}
+	if req.Temperature != nil {
+		payload["temperature"] = *req.Temperature
+	}
+	if req.TopP != nil {
+		payload["top_p"] = *req.TopP
+	}
+	if stop := anthropicStopSequences(req.Stop); len(stop) > 0 {
+		payload["stop_sequences"] = stop
+	}
+	if reasoningEffort != nil {
+		payload["output_config"] = map[string]any{"effort": *reasoningEffort}
+	}
+
+	tools, err := parseChatTools(req.Tools)
+	if err != nil {
+		return nil, err
+	}
+	choice, err := parseChatToolChoice(req.ToolChoice)
+	if err != nil {
+		return nil, err
+	}
+	if len(tools) > 0 {
+		if choice.Mode == "function" && !toolNameDeclared(tools, choice.Name) {
+			return nil, unsupportedContentError(fmt.Sprintf("tool_choice names %q which is not present in tools", choice.Name))
+		}
+		payload["tools"] = anthropicToolDefinitions(tools)
+		// tool_choice "none" keeps the tool definitions in place. Dropping them
+		// would change the tool system prompt, token usage and prompt-cache
+		// prefix, so it is not an equivalent rewrite.
+		payload["tool_choice"] = anthropicToolChoice(choice, req.ParallelToolCalls)
+	}
+	return payload, nil
+}
+
+func toolNameDeclared(tools []chatToolDefinition, name string) bool {
+	for _, tool := range tools {
+		if tool.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func anthropicToolDefinitions(tools []chatToolDefinition) []map[string]any {
+	converted := make([]map[string]any, 0, len(tools))
+	for _, tool := range tools {
+		entry := map[string]any{
+			"name":         tool.Name,
+			"input_schema": tool.Parameters,
+		}
+		if tool.Description != "" {
+			entry["description"] = tool.Description
+		}
+		if tool.Strict {
+			// strict is a top-level tool field in Anthropic, not part of the schema.
+			entry["strict"] = true
+		}
+		converted = append(converted, entry)
+	}
+	return converted
+}
+
+func anthropicToolChoice(choice chatToolChoice, parallelToolCalls *bool) map[string]any {
+	converted := map[string]any{}
+	switch choice.Mode {
+	case "required":
+		converted["type"] = "any"
+	case "none":
+		converted["type"] = "none"
+	case "function":
+		converted["type"] = "tool"
+		converted["name"] = choice.Name
+	default:
+		converted["type"] = "auto"
+	}
+	if parallelToolCalls != nil && !*parallelToolCalls {
+		// Anthropic expects this inside tool_choice, not at the request root.
+		converted["disable_parallel_tool_use"] = true
+	}
+	return converted
+}
+
+func anthropicStopSequences(value any) []string {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case string:
+		if typed == "" {
+			return nil
+		}
+		return []string{typed}
+	case []any:
+		sequences := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if text, ok := item.(string); ok && text != "" {
+				sequences = append(sequences, text)
+			}
+		}
+		return sequences
+	default:
+		return nil
+	}
+}
+
+// anthropicMessagesFromChat splits OpenAI messages into the Anthropic top-level
+// system prompt and the user/assistant turn list.
+func anthropicMessagesFromChat(messages []ChatMessage) ([]map[string]any, []map[string]any, error) {
+	var (
+		system         []map[string]any
+		converted      []map[string]any
+		pendingResults []map[string]any
+	)
+
+	// Tool results must arrive in a single user turn that immediately follows
+	// the assistant turn holding the matching tool_use blocks.
+	flushResults := func() {
+		if len(pendingResults) == 0 {
+			return
+		}
+		converted = append(converted, map[string]any{"role": "user", "content": pendingResults})
+		pendingResults = nil
+	}
+
+	for _, message := range messages {
+		switch message.Role {
+		case "system", "developer":
+			flushResults()
+			parts, err := parseChatContent(message.Content)
+			if err != nil {
+				return nil, nil, err
+			}
+			if text := contentPartsText(parts); text != "" {
+				system = append(system, map[string]any{"type": "text", "text": text})
+			}
+		case "tool":
+			result, err := anthropicToolResultBlock(message)
+			if err != nil {
+				return nil, nil, err
+			}
+			pendingResults = append(pendingResults, result)
+		case "assistant":
+			flushResults()
+			blocks, err := anthropicAssistantBlocks(message)
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(blocks) == 0 {
+				continue
+			}
+			converted = append(converted, map[string]any{"role": "assistant", "content": blocks})
+		default:
+			flushResults()
+			blocks, err := anthropicUserBlocks(message)
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(blocks) == 0 {
+				continue
+			}
+			converted = append(converted, map[string]any{"role": "user", "content": blocks})
+		}
+	}
+	flushResults()
+	return system, converted, nil
+}
+
+func anthropicToolResultBlock(message ChatMessage) (map[string]any, error) {
+	if message.ToolCallID == "" {
+		return nil, unsupportedContentError("tool messages must carry tool_call_id")
+	}
+	parts, err := parseChatContent(message.Content)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"type":        "tool_result",
+		"tool_use_id": message.ToolCallID,
+		"content":     contentPartsText(parts),
+	}, nil
+}
+
+// anthropicAssistantBlocks rebuilds an assistant turn. Block order matters:
+// thinking blocks must precede text, which must precede tool_use.
+func anthropicAssistantBlocks(message ChatMessage) ([]map[string]any, error) {
+	blocks := make([]map[string]any, 0, 3)
+
+	if block := anthropicThinkingBlock(message); block != nil {
+		blocks = append(blocks, block)
+	}
+	if data := strings.TrimSpace(message.RedactedReasoningContent); data != "" {
+		blocks = append(blocks, map[string]any{"type": "redacted_thinking", "data": data})
+	}
+
+	parts, err := parseChatContent(message.Content)
+	if err != nil {
+		return nil, err
+	}
+	if text := contentPartsText(parts); text != "" {
+		blocks = append(blocks, map[string]any{"type": "text", "text": text})
+	}
+
+	calls, err := parseChatToolCalls(message.ToolCalls)
+	if err != nil {
+		return nil, err
+	}
+	for _, call := range calls {
+		if call.ID == "" {
+			return nil, unsupportedContentError("assistant tool calls must carry an id")
+		}
+		blocks = append(blocks, map[string]any{
+			"type":  "tool_use",
+			"id":    call.ID,
+			"name":  call.Name,
+			"input": call.Arguments,
+		})
+	}
+	return blocks, nil
+}
+
+// anthropicThinkingBlock reconstructs a thinking block only when the client
+// echoed back a signature this provider minted. A thinking block with a missing
+// or foreign signature is rejected by Anthropic with HTTP 400, so the block is
+// dropped instead: losing reasoning continuity is recoverable, a failed request
+// is not.
+//
+// The signature alone gates reconstruction. Models that omit the thinking text
+// still return a signed block that must be replayed verbatim, so an empty
+// thinking string is valid as long as the signature checks out.
+func anthropicThinkingBlock(message ChatMessage) map[string]any {
+	signature, ok := decodeProviderSignature(anthropicSignatureProvider, message.ReasoningSignature)
+	if !ok {
+		return nil
+	}
+	return map[string]any{
+		"type":      "thinking",
+		"thinking":  message.ReasoningContent,
+		"signature": signature,
+	}
+}
+
+func anthropicUserBlocks(message ChatMessage) ([]map[string]any, error) {
+	parts, err := parseChatContent(message.Content)
+	if err != nil {
+		return nil, err
+	}
+	blocks := make([]map[string]any, 0, len(parts))
+	for _, part := range parts {
+		switch part.Kind {
+		case chatContentText:
+			if part.Text == "" {
+				continue
+			}
+			blocks = append(blocks, map[string]any{"type": "text", "text": part.Text})
+		case chatContentImageURL:
+			blocks = append(blocks, map[string]any{
+				"type":   "image",
+				"source": map[string]any{"type": "url", "url": part.URL},
+			})
+		case chatContentImageB64:
+			blocks = append(blocks, map[string]any{
+				"type": "image",
+				"source": map[string]any{
+					"type":       "base64",
+					"media_type": part.MediaType,
+					"data":       part.Data,
+				},
+			})
+		}
+	}
+	return blocks, nil
+}
+
+// anthropicChatResponse converts an Anthropic Messages response body into an
+// OpenAI chat completion object.
+func anthropicChatResponse(body map[string]any, model string, usage Usage) (map[string]any, error) {
+	content, _ := body["content"].([]any)
+
+	var (
+		textParts []string
+		reasoning []string
+		signature string
+		redacted  string
+		toolCalls []any
+	)
+
+	for _, item := range content {
+		block, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		switch blockType, _ := block["type"].(string); blockType {
+		case "text":
+			if text, ok := block["text"].(string); ok {
+				textParts = append(textParts, text)
+			}
+		case "thinking":
+			if text, ok := block["thinking"].(string); ok {
+				reasoning = append(reasoning, text)
+			}
+			if value, ok := block["signature"].(string); ok && value != "" {
+				signature = value
+			}
+		case "redacted_thinking":
+			if data, ok := block["data"].(string); ok {
+				redacted = data
+			}
+		case "tool_use":
+			id, _ := block["id"].(string)
+			name, _ := block["name"].(string)
+			toolCalls = append(toolCalls, map[string]any{
+				"id":   id,
+				"type": "function",
+				"function": map[string]any{
+					"name":      name,
+					"arguments": encodeToolCallArguments(block["input"]),
+				},
+			})
+		}
+	}
+
+	message := map[string]any{"role": "assistant"}
+	if len(textParts) > 0 {
+		message["content"] = strings.Join(textParts, "")
+	} else {
+		// A tool-only turn has no text; null distinguishes it from an empty reply.
+		message["content"] = nil
+	}
+	if len(reasoning) > 0 {
+		message["reasoning_content"] = strings.Join(reasoning, "")
+	}
+	if signature != "" {
+		message["reasoning_signature"] = encodeProviderSignature(anthropicSignatureProvider, signature)
+	}
+	if redacted != "" {
+		message["redacted_reasoning_content"] = redacted
+	}
+	if len(toolCalls) > 0 {
+		message["tool_calls"] = toolCalls
+	}
+
+	stopReason, _ := body["stop_reason"].(string)
+	finishReason, err := anthropicFinishReason(stopReason, len(toolCalls) > 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"id":      NewID("chatcmpl"),
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   model,
+		"choices": []map[string]any{{
+			"index":         0,
+			"message":       message,
+			"finish_reason": finishReason,
+		}},
+		"usage": usage,
+	}, nil
+}
+
+// anthropicFinishReason maps a stop reason. Unknown values are surfaced as an
+// upstream error rather than being flattened to "stop", which would report a
+// truncated or refused generation as a normal completion.
+func anthropicFinishReason(stopReason string, hasToolCalls bool) (string, error) {
+	switch stopReason {
+	case "tool_use":
+		return "tool_calls", nil
+	case "pause_turn":
+		// A paused server-tool loop expects the assistant content to be replayed
+		// verbatim so the provider can resume it. That is not something an
+		// OpenAI-shaped client can do, and reporting tool_calls would tell the
+		// client to run a tool that was never requested.
+		return "", unsupportedCapabilityError("provider paused a server-side tool loop, which this route cannot resume")
+	case "end_turn", "stop_sequence":
+		if hasToolCalls {
+			return "tool_calls", nil
+		}
+		return "stop", nil
+	case "max_tokens", "model_context_window_exceeded":
+		return "length", nil
+	case "refusal":
+		return "content_filter", nil
+	case "":
+		// Streaming responses report the stop reason in message_delta; a
+		// non-streaming body without one is still in flight or malformed.
+		if hasToolCalls {
+			return "tool_calls", nil
+		}
+		return "stop", nil
+	default:
+		return "", invalidProviderResponseError(fmt.Sprintf("provider returned an unrecognized stop_reason %q", stopReason))
+	}
+}
+
+// anthropicRequestJSON renders the request payload, used by both adapter paths.
+func anthropicRequestJSON(payload map[string]any, stream bool) (map[string]any, error) {
+	if stream {
+		payload["stream"] = true
+	}
+	if _, err := json.Marshal(payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}

--- a/backend/internal/server/provider_anthropic_convert_test.go
+++ b/backend/internal/server/provider_anthropic_convert_test.go
@@ -1,0 +1,799 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+func mustBuildAnthropic(t *testing.T, req ChatCompletionRequest) map[string]any {
+	t.Helper()
+	payload, err := buildAnthropicRequest("claude-test", req, nil)
+	if err != nil {
+		t.Fatalf("buildAnthropicRequest: %v", err)
+	}
+	return payload
+}
+
+func TestAnthropicRequestMapsToolDefinitions(t *testing.T) {
+	payload := mustBuildAnthropic(t, ChatCompletionRequest{
+		Messages: []ChatMessage{{Role: "user", Content: "weather?"}},
+		Tools: []any{map[string]any{
+			"type": "function",
+			"function": map[string]any{
+				"name":        "get_weather",
+				"description": "Look up weather",
+				"parameters":  map[string]any{"type": "object", "properties": map[string]any{}},
+			},
+		}},
+	})
+
+	tools, _ := payload["tools"].([]map[string]any)
+	if len(tools) != 1 {
+		t.Fatalf("expected one tool, got %v", payload["tools"])
+	}
+	if tools[0]["name"] != "get_weather" {
+		t.Fatalf("tool name was not forwarded: %v", tools[0])
+	}
+	if _, ok := tools[0]["input_schema"]; !ok {
+		t.Fatalf("OpenAI parameters must map to Anthropic input_schema: %v", tools[0])
+	}
+}
+
+func TestAnthropicRequestFillsMissingToolSchema(t *testing.T) {
+	payload := mustBuildAnthropic(t, ChatCompletionRequest{
+		Messages: []ChatMessage{{Role: "user", Content: "hi"}},
+		Tools: []any{map[string]any{
+			"function": map[string]any{"name": "ping"},
+		}},
+	})
+	tools, _ := payload["tools"].([]map[string]any)
+	schema, _ := tools[0]["input_schema"].(map[string]any)
+	// Anthropic rejects a null schema, so an empty object stands in.
+	if schema["type"] != "object" {
+		t.Fatalf("missing parameters must become an empty object schema, got %v", tools[0])
+	}
+}
+
+func TestAnthropicRequestRejectsInvalidToolName(t *testing.T) {
+	_, err := buildAnthropicRequest("claude-test", ChatCompletionRequest{
+		Messages: []ChatMessage{{Role: "user", Content: "hi"}},
+		Tools: []any{map[string]any{
+			"function": map[string]any{"name": "bad name!"},
+		}},
+	}, nil)
+	if err == nil {
+		t.Fatalf("expected a tool name outside the permitted character set to be rejected")
+	}
+}
+
+func TestAnthropicToolChoiceNoneKeepsToolDefinitions(t *testing.T) {
+	payload := mustBuildAnthropic(t, ChatCompletionRequest{
+		Messages:   []ChatMessage{{Role: "user", Content: "hi"}},
+		Tools:      []any{map[string]any{"function": map[string]any{"name": "ping"}}},
+		ToolChoice: "none",
+	})
+	// Dropping the tools instead would change the tool system prompt, token
+	// usage and prompt-cache prefix, so it is not an equivalent rewrite.
+	if _, ok := payload["tools"]; !ok {
+		t.Fatalf("tool_choice=none must keep the tool definitions in place")
+	}
+	choice, _ := payload["tool_choice"].(map[string]any)
+	if choice["type"] != "none" {
+		t.Fatalf("expected tool_choice type none, got %v", choice)
+	}
+}
+
+func TestAnthropicToolChoiceVariants(t *testing.T) {
+	cases := []struct {
+		name     string
+		choice   any
+		wantType string
+		wantName string
+	}{
+		{"auto", "auto", "auto", ""},
+		{"required", "required", "any", ""},
+		{"function", map[string]any{"type": "function", "function": map[string]any{"name": "ping"}}, "tool", "ping"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			payload := mustBuildAnthropic(t, ChatCompletionRequest{
+				Messages:   []ChatMessage{{Role: "user", Content: "hi"}},
+				Tools:      []any{map[string]any{"function": map[string]any{"name": "ping"}}},
+				ToolChoice: testCase.choice,
+			})
+			choice, _ := payload["tool_choice"].(map[string]any)
+			if choice["type"] != testCase.wantType {
+				t.Fatalf("expected type %q, got %v", testCase.wantType, choice)
+			}
+			if testCase.wantName != "" && choice["name"] != testCase.wantName {
+				t.Fatalf("expected name %q, got %v", testCase.wantName, choice)
+			}
+		})
+	}
+}
+
+func TestAnthropicToolChoiceRejectsUndeclaredFunction(t *testing.T) {
+	_, err := buildAnthropicRequest("claude-test", ChatCompletionRequest{
+		Messages:   []ChatMessage{{Role: "user", Content: "hi"}},
+		Tools:      []any{map[string]any{"function": map[string]any{"name": "ping"}}},
+		ToolChoice: map[string]any{"type": "function", "function": map[string]any{"name": "absent"}},
+	}, nil)
+	if err == nil {
+		t.Fatalf("expected tool_choice naming an undeclared tool to be rejected")
+	}
+}
+
+func TestAnthropicDisablesParallelToolUseInsideToolChoice(t *testing.T) {
+	disabled := false
+	payload := mustBuildAnthropic(t, ChatCompletionRequest{
+		Messages:          []ChatMessage{{Role: "user", Content: "hi"}},
+		Tools:             []any{map[string]any{"function": map[string]any{"name": "ping"}}},
+		ParallelToolCalls: &disabled,
+	})
+	choice, _ := payload["tool_choice"].(map[string]any)
+	// Anthropic expects this inside tool_choice, not at the request root.
+	if choice["disable_parallel_tool_use"] != true {
+		t.Fatalf("expected disable_parallel_tool_use inside tool_choice, got %v", choice)
+	}
+	if _, present := payload["disable_parallel_tool_use"]; present {
+		t.Fatalf("disable_parallel_tool_use must not appear at the request root")
+	}
+}
+
+func TestAnthropicRequestLiftsSystemToTopLevel(t *testing.T) {
+	payload := mustBuildAnthropic(t, ChatCompletionRequest{
+		Messages: []ChatMessage{
+			{Role: "system", Content: "be brief"},
+			{Role: "user", Content: "hi"},
+		},
+	})
+	if _, ok := payload["system"]; !ok {
+		t.Fatalf("system guidance must become the top-level system field")
+	}
+	messages, _ := payload["messages"].([]map[string]any)
+	for _, message := range messages {
+		if message["role"] == "system" {
+			t.Fatalf("Anthropic messages must not contain a system role: %v", messages)
+		}
+	}
+}
+
+func TestAnthropicRequestConvertsToolCallsAndMergesResults(t *testing.T) {
+	payload := mustBuildAnthropic(t, ChatCompletionRequest{
+		Messages: []ChatMessage{
+			{Role: "user", Content: "weather in both cities?"},
+			{Role: "assistant", Content: "checking", ToolCalls: []any{
+				map[string]any{"id": "call_1", "type": "function", "function": map[string]any{"name": "get_weather", "arguments": `{"city":"BJ"}`}},
+				map[string]any{"id": "call_2", "type": "function", "function": map[string]any{"name": "get_weather", "arguments": `{"city":"SH"}`}},
+			}},
+			{Role: "tool", ToolCallID: "call_1", Content: "sunny"},
+			{Role: "tool", ToolCallID: "call_2", Content: "rainy"},
+		},
+	})
+
+	messages, _ := payload["messages"].([]map[string]any)
+	if len(messages) != 3 {
+		t.Fatalf("expected user, assistant and a single merged tool-result turn, got %d", len(messages))
+	}
+
+	assistant := messages[1]
+	blocks, _ := assistant["content"].([]map[string]any)
+	if len(blocks) != 3 {
+		t.Fatalf("assistant turn must keep its text block alongside both tool_use blocks: %v", blocks)
+	}
+	if blocks[0]["type"] != "text" {
+		t.Fatalf("text must precede tool_use blocks: %v", blocks)
+	}
+	toolUse := blocks[1]
+	input, _ := toolUse["input"].(map[string]any)
+	// OpenAI encodes arguments as a JSON string; Anthropic needs a decoded object.
+	if input["city"] != "BJ" {
+		t.Fatalf("tool arguments must be decoded into an object, got %v", toolUse)
+	}
+
+	results := messages[2]
+	if results["role"] != "user" {
+		t.Fatalf("tool results must be delivered in a user turn: %v", results)
+	}
+	resultBlocks, _ := results["content"].([]map[string]any)
+	if len(resultBlocks) != 2 {
+		t.Fatalf("parallel tool results must be merged into one turn, got %d", len(resultBlocks))
+	}
+	if resultBlocks[0]["tool_use_id"] != "call_1" {
+		t.Fatalf("tool_use_id must be preserved: %v", resultBlocks[0])
+	}
+}
+
+func TestAnthropicRequestRejectsToolCallWithInvalidArguments(t *testing.T) {
+	_, err := buildAnthropicRequest("claude-test", ChatCompletionRequest{
+		Messages: []ChatMessage{
+			{Role: "assistant", ToolCalls: []any{
+				map[string]any{"id": "call_1", "function": map[string]any{"name": "ping", "arguments": `{"truncated":`}},
+			}},
+		},
+	}, nil)
+	if err == nil {
+		t.Fatalf("truncated tool arguments must be rejected rather than forwarded")
+	}
+}
+
+func TestAnthropicRequestConvertsImageContent(t *testing.T) {
+	payload := mustBuildAnthropic(t, ChatCompletionRequest{
+		Messages: []ChatMessage{{Role: "user", Content: []any{
+			map[string]any{"type": "text", "text": "what is this?"},
+			map[string]any{"type": "image_url", "image_url": map[string]any{"url": "data:image/png;base64,AAAA"}},
+			map[string]any{"type": "image_url", "image_url": map[string]any{"url": "https://example.com/a.png"}},
+		}}},
+	})
+	messages, _ := payload["messages"].([]map[string]any)
+	blocks, _ := messages[0]["content"].([]map[string]any)
+	if len(blocks) != 3 {
+		t.Fatalf("expected text plus two image blocks, got %v", blocks)
+	}
+	base64Source, _ := blocks[1]["source"].(map[string]any)
+	if base64Source["type"] != "base64" || base64Source["media_type"] != "image/png" || base64Source["data"] != "AAAA" {
+		t.Fatalf("data URI must map to a base64 image source: %v", base64Source)
+	}
+	urlSource, _ := blocks[2]["source"].(map[string]any)
+	if urlSource["type"] != "url" || urlSource["url"] != "https://example.com/a.png" {
+		t.Fatalf("http image URLs must map to a url image source: %v", urlSource)
+	}
+}
+
+func TestAnthropicRequestRejectsUnsupportedContentPart(t *testing.T) {
+	_, err := buildAnthropicRequest("claude-test", ChatCompletionRequest{
+		Messages: []ChatMessage{{Role: "user", Content: []any{
+			map[string]any{"type": "input_audio", "input_audio": map[string]any{"data": "AAAA"}},
+		}}},
+	}, nil)
+	if err == nil {
+		t.Fatalf("unsupported modalities must be rejected instead of silently dropped")
+	}
+}
+
+func TestAnthropicRebuildsThinkingOnlyWithMatchingSignature(t *testing.T) {
+	build := func(signature string) []map[string]any {
+		payload := mustBuildAnthropic(t, ChatCompletionRequest{
+			Messages: []ChatMessage{{
+				Role:               "assistant",
+				Content:            "answer",
+				ReasoningContent:   "deliberation",
+				ReasoningSignature: signature,
+			}},
+		})
+		messages, _ := payload["messages"].([]map[string]any)
+		blocks, _ := messages[0]["content"].([]map[string]any)
+		return blocks
+	}
+
+	withSignature := build(encodeProviderSignature(anthropicSignatureProvider, "sig-abc"))
+	if withSignature[0]["type"] != "thinking" || withSignature[0]["signature"] != "sig-abc" {
+		t.Fatalf("a matching signature must rebuild the thinking block: %v", withSignature)
+	}
+
+	// A signature minted by another provider cannot be replayed: Anthropic
+	// rejects the request outright, so the block is dropped instead.
+	foreign := build(encodeProviderSignature(geminiSignatureProvider, "sig-abc"))
+	for _, block := range foreign {
+		if block["type"] == "thinking" {
+			t.Fatalf("a foreign signature must not produce a thinking block: %v", foreign)
+		}
+	}
+
+	missing := build("")
+	for _, block := range missing {
+		if block["type"] == "thinking" {
+			t.Fatalf("a missing signature must not produce a thinking block: %v", missing)
+		}
+	}
+}
+
+func TestAnthropicResponseRestoresToolCallsAndReasoning(t *testing.T) {
+	body := map[string]any{
+		"content": []any{
+			map[string]any{"type": "thinking", "thinking": "hmm", "signature": "sig-1"},
+			map[string]any{"type": "text", "text": "calling"},
+			map[string]any{"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": map[string]any{"city": "BJ"}},
+		},
+		"stop_reason": "tool_use",
+	}
+	converted, err := anthropicChatResponse(body, "model-x", Usage{})
+	if err != nil {
+		t.Fatalf("anthropicChatResponse: %v", err)
+	}
+	choices, _ := converted["choices"].([]map[string]any)
+	if choices[0]["finish_reason"] != "tool_calls" {
+		t.Fatalf("stop_reason tool_use must map to finish_reason tool_calls: %v", choices[0])
+	}
+	message, _ := choices[0]["message"].(map[string]any)
+	if message["reasoning_content"] != "hmm" {
+		t.Fatalf("thinking text must surface as reasoning_content: %v", message)
+	}
+	signature, _ := message["reasoning_signature"].(string)
+	if !strings.HasPrefix(signature, anthropicSignatureProvider+":") {
+		t.Fatalf("the signature must be tagged with its originating provider: %v", message)
+	}
+	calls, _ := message["tool_calls"].([]any)
+	call, _ := calls[0].(map[string]any)
+	function, _ := call["function"].(map[string]any)
+	arguments, _ := function["arguments"].(string)
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(arguments), &decoded); err != nil {
+		t.Fatalf("tool call arguments must be a JSON string: %v", err)
+	}
+	if decoded["city"] != "BJ" {
+		t.Fatalf("tool input was not preserved: %v", decoded)
+	}
+}
+
+func TestAnthropicResponseUsesNullContentForToolOnlyTurn(t *testing.T) {
+	body := map[string]any{
+		"content":     []any{map[string]any{"type": "tool_use", "id": "t", "name": "ping", "input": map[string]any{}}},
+		"stop_reason": "tool_use",
+	}
+	converted, _ := anthropicChatResponse(body, "model-x", Usage{})
+	choices, _ := converted["choices"].([]map[string]any)
+	message, _ := choices[0]["message"].(map[string]any)
+	if message["content"] != nil {
+		t.Fatalf("a tool-only turn must report null content, got %v", message["content"])
+	}
+}
+
+func TestAnthropicFinishReasonMapping(t *testing.T) {
+	cases := map[string]string{
+		"end_turn":                      "stop",
+		"stop_sequence":                 "stop",
+		"max_tokens":                    "length",
+		"model_context_window_exceeded": "length",
+		"tool_use":                      "tool_calls",
+		"refusal":                       "content_filter",
+	}
+	for stopReason, want := range cases {
+		got, err := anthropicFinishReason(stopReason, false)
+		if err != nil {
+			t.Fatalf("%s: %v", stopReason, err)
+		}
+		if got != want {
+			t.Fatalf("%s: expected %q, got %q", stopReason, want, got)
+		}
+	}
+
+	// pause_turn means a server-side tool loop paused and expects the assistant
+	// content to be replayed verbatim. Reporting tool_calls would tell the client
+	// to run a tool that was never requested.
+	if _, err := anthropicFinishReason("pause_turn", false); err == nil {
+		t.Fatalf("pause_turn must not be presented as a client tool call")
+	}
+
+	// An unrecognized value must not be flattened to "stop": that would report a
+	// truncated or refused generation as a normal completion.
+	if _, err := anthropicFinishReason("something_new", false); err == nil {
+		t.Fatalf("unknown stop reasons must surface as an upstream error")
+	}
+}
+
+func TestAnthropicRebuildsSignedThinkingBlockWithEmptyText(t *testing.T) {
+	// Models may return a signed thinking block with no visible text. The block
+	// still has to be replayed verbatim, so the signature alone gates rebuilding.
+	payload := mustBuildAnthropic(t, ChatCompletionRequest{
+		Messages: []ChatMessage{{
+			Role:               "assistant",
+			Content:            "answer",
+			ReasoningSignature: encodeProviderSignature(anthropicSignatureProvider, "sig-empty"),
+		}},
+	})
+	messages, _ := payload["messages"].([]map[string]any)
+	blocks, _ := messages[0]["content"].([]map[string]any)
+	if blocks[0]["type"] != "thinking" || blocks[0]["signature"] != "sig-empty" {
+		t.Fatalf("a signed block with empty thinking text must still be replayed: %v", blocks)
+	}
+}
+
+func TestAnthropicStreamRejectsTruncatedStream(t *testing.T) {
+	// The connection drops after partial content and before message_stop.
+	raw := strings.Join([]string{
+		`data: {"type":"message_start","message":{"usage":{"input_tokens":4}}}`,
+		``,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hel"}}`,
+		``,
+		``,
+	}, "\n")
+
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	if _, err := streamAnthropicChat(strings.NewReader(raw), encoder); err == nil {
+		t.Fatalf("a stream that ends before message_stop must be reported as truncated")
+	}
+	if strings.Contains(writer.builder.String(), "[DONE]") {
+		t.Fatalf("a truncated stream must not be presented to the client as complete")
+	}
+}
+
+func TestAnthropicStreamRejectsUnopenedToolBlockArguments(t *testing.T) {
+	raw := strings.Join([]string{
+		`data: {"type":"message_start","message":{"usage":{"input_tokens":1}}}`,
+		``,
+		`data: {"type":"content_block_delta","index":7,"delta":{"type":"input_json_delta","partial_json":"{}"}}`,
+		``,
+		``,
+	}, "\n")
+
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	// Routing this to an arbitrary slot would corrupt an unrelated tool call.
+	if _, err := streamAnthropicChat(strings.NewReader(raw), encoder); err == nil {
+		t.Fatalf("tool arguments for an unopened block must be rejected")
+	}
+}
+
+func TestAnthropicStreamRejectsTruncatedToolArguments(t *testing.T) {
+	raw := strings.Join([]string{
+		`data: {"type":"message_start","message":{"usage":{"input_tokens":1}}}`,
+		``,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"a","name":"ping"}}`,
+		``,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"a\":"}}`,
+		``,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		``,
+	}, "\n")
+
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	// Arguments that never became valid JSON are unusable, and the truncation is
+	// invisible once the fragments have already been forwarded.
+	if _, err := streamAnthropicChat(strings.NewReader(raw), encoder); err == nil {
+		t.Fatalf("tool arguments that do not parse must be rejected")
+	}
+}
+
+func TestSSEDecoderRejectsOversizedEvent(t *testing.T) {
+	// A single unbounded event would otherwise grow until the process runs out
+	// of memory. The payload deliberately has no newline: the limit must trip
+	// while reading, not after the whole line has been allocated.
+	reader := io.LimitReader(neverEndingReader{}, int64(maxSSEEventBytes)*4)
+	if _, err := newSSEDecoder(reader).Next(); err == nil {
+		t.Fatalf("an unterminated event beyond the size limit must be rejected")
+	}
+}
+
+// neverEndingReader emits a stream that never contains a newline.
+type neverEndingReader struct{}
+
+func (neverEndingReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'x'
+	}
+	return len(p), nil
+}
+
+func TestAnthropicStreamRejectsMissingOrInvalidBlockIndex(t *testing.T) {
+	cases := map[string]string{
+		"missing index":     `data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"x"}}`,
+		"non-numeric index": `data: {"type":"content_block_delta","index":"0","delta":{"type":"text_delta","text":"x"}}`,
+	}
+	for name, event := range cases {
+		t.Run(name, func(t *testing.T) {
+			raw := strings.Join([]string{
+				`data: {"type":"message_start","message":{"usage":{"input_tokens":1}}}`,
+				``,
+				event,
+				``,
+				``,
+			}, "\n")
+			encoder := newOpenAIChatStreamEncoder(&recordingWriter{}, "model-x", false)
+			// Defaulting a bad index to 0 would misroute deltas into the first block.
+			if _, err := streamAnthropicChat(strings.NewReader(raw), encoder); err == nil {
+				t.Fatalf("expected the malformed index to be rejected")
+			}
+		})
+	}
+}
+
+func TestAnthropicStreamRejectsReopenedToolBlock(t *testing.T) {
+	raw := strings.Join([]string{
+		`data: {"type":"message_start","message":{"usage":{"input_tokens":1}}}`,
+		``,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"a","name":"ping"}}`,
+		``,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"b","name":"ping"}}`,
+		``,
+		``,
+	}, "\n")
+	encoder := newOpenAIChatStreamEncoder(&recordingWriter{}, "model-x", false)
+	if _, err := streamAnthropicChat(strings.NewReader(raw), encoder); err == nil {
+		t.Fatalf("reopening a content block must be rejected")
+	}
+}
+
+func TestAnthropicStreamRejectsMessageStopWithOpenToolBlock(t *testing.T) {
+	raw := strings.Join([]string{
+		`data: {"type":"message_start","message":{"usage":{"input_tokens":1}}}`,
+		``,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"a","name":"ping"}}`,
+		``,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{}"}}`,
+		``,
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}`,
+		``,
+		`data: {"type":"message_stop"}`,
+		``,
+		``,
+	}, "\n")
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	// The block never closed, so its arguments were never validated.
+	if _, err := streamAnthropicChat(strings.NewReader(raw), encoder); err == nil {
+		t.Fatalf("an unterminated tool block must be rejected")
+	}
+	if strings.Contains(writer.builder.String(), "[DONE]") {
+		t.Fatalf("a stream with an unterminated tool call must not be reported as complete")
+	}
+}
+
+func TestAnthropicStreamEmitsEmptyObjectForArgumentlessTool(t *testing.T) {
+	// A tool taking no arguments produces no partial_json deltas.
+	raw := strings.Join([]string{
+		`data: {"type":"message_start","message":{"usage":{"input_tokens":1}}}`,
+		``,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"a","name":"now"}}`,
+		``,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}`,
+		``,
+		`data: {"type":"message_stop"}`,
+		``,
+		``,
+	}, "\n")
+
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	if _, err := streamAnthropicChat(strings.NewReader(raw), encoder); err != nil {
+		t.Fatalf("streamAnthropicChat: %v", err)
+	}
+
+	var arguments strings.Builder
+	for _, frame := range writer.frames(t) {
+		calls, ok := frameDelta(t, frame)["tool_calls"].([]any)
+		if !ok {
+			continue
+		}
+		for _, item := range calls {
+			call, _ := item.(map[string]any)
+			if function, ok := call["function"].(map[string]any); ok {
+				if value, ok := function["arguments"].(string); ok {
+					arguments.WriteString(value)
+				}
+			}
+		}
+	}
+	// An empty arguments string is not parsable by the client.
+	if arguments.String() != "{}" {
+		t.Fatalf("an argumentless tool call must yield {}, got %q", arguments.String())
+	}
+}
+
+func TestAnthropicStreamConvertsTextAndToolArguments(t *testing.T) {
+	// Anthropic content indexes are sparse from OpenAI's perspective: index 0 is
+	// a thinking block and index 1 is text, so the tool at index 2 must still be
+	// reported as tool_calls[0].
+	raw := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":1}}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking"}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"pondering"}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig-"}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"tail"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"text"}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Hi"}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_1","name":"ping"}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"a\":"}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"1}"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":2}`,
+		``,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":7}}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+		``,
+	}, "\n")
+
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	usage, err := streamAnthropicChat(strings.NewReader(raw), encoder)
+	if err != nil {
+		t.Fatalf("streamAnthropicChat: %v", err)
+	}
+
+	var (
+		reasoning   strings.Builder
+		text        strings.Builder
+		arguments   strings.Builder
+		signature   string
+		toolIndexes []int
+		finish      string
+	)
+	for _, frame := range writer.frames(t) {
+		choices, _ := frame["choices"].([]any)
+		if len(choices) == 0 {
+			continue
+		}
+		choice, _ := choices[0].(map[string]any)
+		if reason, ok := choice["finish_reason"].(string); ok && reason != "" {
+			finish = reason
+		}
+		delta, _ := choice["delta"].(map[string]any)
+		if value, ok := delta["reasoning_content"].(string); ok {
+			reasoning.WriteString(value)
+		}
+		if value, ok := delta["reasoning_signature"].(string); ok {
+			signature = value
+		}
+		if value, ok := delta["content"].(string); ok {
+			text.WriteString(value)
+		}
+		if calls, ok := delta["tool_calls"].([]any); ok {
+			for _, item := range calls {
+				call, _ := item.(map[string]any)
+				index, _ := call["index"].(float64)
+				toolIndexes = append(toolIndexes, int(index))
+				if function, ok := call["function"].(map[string]any); ok {
+					if value, ok := function["arguments"].(string); ok {
+						arguments.WriteString(value)
+					}
+				}
+			}
+		}
+	}
+
+	if reasoning.String() != "pondering" {
+		t.Fatalf("thinking deltas must surface as reasoning_content, got %q", reasoning.String())
+	}
+	if signature != encodeProviderSignature(anthropicSignatureProvider, "sig-tail") {
+		t.Fatalf("signature fragments must be concatenated and tagged, got %q", signature)
+	}
+	if text.String() != "Hi" {
+		t.Fatalf("unexpected text: %q", text.String())
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(arguments.String()), &decoded); err != nil {
+		t.Fatalf("partial_json fragments must reassemble into valid JSON: %v (%q)", err, arguments.String())
+	}
+	for _, index := range toolIndexes {
+		if index != 0 {
+			t.Fatalf("the only tool call must be reported at dense index 0, saw %d", index)
+		}
+	}
+	if finish != "tool_calls" {
+		t.Fatalf("expected finish_reason tool_calls, got %q", finish)
+	}
+	// message_start reports input 10 / output 1, message_delta reports a
+	// cumulative output of 7. Summing would yield 8.
+	if usage.CompletionTokens != 7 {
+		t.Fatalf("streaming usage is a cumulative snapshot, expected 7 output tokens, got %d", usage.CompletionTokens)
+	}
+	if usage.PromptTokens != 10 {
+		t.Fatalf("expected the input token count to be retained, got %d", usage.PromptTokens)
+	}
+}
+
+func TestAnthropicStreamAssignsDenseIndexesToParallelToolCalls(t *testing.T) {
+	raw := strings.Join([]string{
+		`data: {"type":"message_start","message":{"usage":{"input_tokens":1}}}`,
+		``,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"a","name":"first"}}`,
+		``,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{}"}}`,
+		``,
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"b","name":"second"}}`,
+		``,
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"x\":2}"}}`,
+		``,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`data: {"type":"content_block_stop","index":1}`,
+		``,
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}`,
+		``,
+		`data: {"type":"message_stop"}`,
+		``,
+		``,
+	}, "\n")
+
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	if _, err := streamAnthropicChat(strings.NewReader(raw), encoder); err != nil {
+		t.Fatalf("streamAnthropicChat: %v", err)
+	}
+
+	// Arguments must not bleed between concurrent tool calls.
+	arguments := map[int]*strings.Builder{}
+	for _, frame := range writer.frames(t) {
+		delta := frameDelta(t, frame)
+		calls, ok := delta["tool_calls"].([]any)
+		if !ok {
+			continue
+		}
+		for _, item := range calls {
+			call, _ := item.(map[string]any)
+			index := int(call["index"].(float64))
+			if arguments[index] == nil {
+				arguments[index] = &strings.Builder{}
+			}
+			if function, ok := call["function"].(map[string]any); ok {
+				if value, ok := function["arguments"].(string); ok {
+					arguments[index].WriteString(value)
+				}
+			}
+		}
+	}
+	if len(arguments) != 2 {
+		t.Fatalf("expected two distinct tool slots, got %d", len(arguments))
+	}
+	if arguments[0].String() != "{}" {
+		t.Fatalf("first tool arguments were polluted: %q", arguments[0].String())
+	}
+	if arguments[1].String() != `{"x":2}` {
+		t.Fatalf("second tool arguments were polluted: %q", arguments[1].String())
+	}
+}
+
+func TestAnthropicStreamSurfacesMidStreamError(t *testing.T) {
+	raw := strings.Join([]string{
+		`data: {"type":"message_start","message":{"usage":{"input_tokens":1}}}`,
+		``,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}`,
+		``,
+		`data: {"type":"error","error":{"type":"overloaded_error","message":"upstream overloaded"}}`,
+		``,
+		``,
+	}, "\n")
+
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	if _, err := streamAnthropicChat(strings.NewReader(raw), encoder); err == nil {
+		t.Fatalf("a mid-stream error event must surface as an error")
+	}
+	// The client already received content, so it must not be told the stream
+	// completed successfully.
+	if strings.Contains(writer.builder.String(), "[DONE]") {
+		t.Fatalf("a failed stream must not emit the completion sentinel")
+	}
+}
+
+func TestAnthropicStreamRejectsEmptyStream(t *testing.T) {
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	if _, err := streamAnthropicChat(strings.NewReader(""), encoder); err == nil {
+		t.Fatalf("a stream that closes before sending content must be an error")
+	}
+}

--- a/backend/internal/server/provider_anthropic_stream.go
+++ b/backend/internal/server/provider_anthropic_stream.go
@@ -1,0 +1,301 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// anthropicStreamDecoder translates the Anthropic Messages SSE event stream into
+// OpenAI chunk frames. It owns all Anthropic-specific state; the encoder only
+// knows how to render OpenAI frames.
+type anthropicStreamDecoder struct {
+	encoder *openAIChatStreamEncoder
+
+	// toolSlots maps an Anthropic content block index to a dense OpenAI
+	// tool_calls index. The two are not interchangeable: thinking and text
+	// blocks occupy content indexes but are not tool calls.
+	toolSlots map[int]int
+	// signatures accumulates signature_delta fragments per content block.
+	signatures map[int]*strings.Builder
+
+	// toolArguments accumulates the JSON fragments per block so the assembled
+	// arguments can be validated once the block closes. Fragments are still
+	// forwarded incrementally as they arrive.
+	toolArguments map[int]*strings.Builder
+
+	usage        map[string]any
+	stopReason   string
+	sawMessage   bool
+	sawTerminal  bool
+	hasToolCalls bool
+}
+
+func newAnthropicStreamDecoder(encoder *openAIChatStreamEncoder) *anthropicStreamDecoder {
+	return &anthropicStreamDecoder{
+		encoder:       encoder,
+		toolSlots:     map[int]int{},
+		signatures:    map[int]*strings.Builder{},
+		toolArguments: map[int]*strings.Builder{},
+		usage:         map[string]any{},
+	}
+}
+
+// streamAnthropicChat consumes the upstream SSE body and writes OpenAI chunks.
+// It returns the usage reported by the provider.
+func streamAnthropicChat(body io.Reader, encoder *openAIChatStreamEncoder) (Usage, error) {
+	decoder := newAnthropicStreamDecoder(encoder)
+	events := newSSEDecoder(body)
+	for {
+		event, err := events.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			encoder.Abort()
+			return decoder.currentUsage(), err
+		}
+		done, err := decoder.consume(event)
+		if err != nil {
+			encoder.Abort()
+			return decoder.currentUsage(), err
+		}
+		if done {
+			break
+		}
+	}
+	usage := decoder.currentUsage()
+	if !decoder.sawMessage {
+		encoder.Abort()
+		return usage, invalidProviderResponseError("provider closed the stream before sending any content")
+	}
+	if !decoder.sawTerminal {
+		// An Anthropic stream always ends with message_stop. Reaching EOF without
+		// it means the connection dropped mid-generation; reporting a normal
+		// completion would hand the client a silently truncated answer.
+		encoder.Abort()
+		return usage, invalidProviderResponseError("provider closed the stream before completing the message")
+	}
+	if len(decoder.toolArguments) > 0 {
+		// A tool block that never closed leaves its arguments unvalidated, so the
+		// client would receive a tool call it cannot execute.
+		encoder.Abort()
+		return usage, invalidProviderResponseError("provider ended the message with an unterminated tool call")
+	}
+	finishReason, err := anthropicFinishReason(decoder.stopReason, decoder.hasToolCalls)
+	if err != nil {
+		encoder.Abort()
+		return usage, err
+	}
+	if err := encoder.Finalize(finishReason, usage); err != nil {
+		return usage, err
+	}
+	return usage, nil
+}
+
+// consume handles one SSE event. The boolean result reports stream completion.
+func (d *anthropicStreamDecoder) consume(event serverSentEvent) (bool, error) {
+	payload, err := decodeSSEData(event)
+	if err != nil {
+		return false, err
+	}
+	if payload == nil {
+		return false, nil
+	}
+	eventType := event.Event
+	if eventType == "" {
+		eventType, _ = payload["type"].(string)
+	}
+
+	switch eventType {
+	case "message_start":
+		d.sawMessage = true
+		if message, ok := payload["message"].(map[string]any); ok {
+			d.mergeUsage(message["usage"])
+		}
+		return false, d.encoder.EmitRole()
+	case "content_block_start":
+		return false, d.handleBlockStart(payload)
+	case "content_block_delta":
+		return false, d.handleBlockDelta(payload)
+	case "content_block_stop":
+		return false, d.handleBlockStop(payload)
+	case "message_delta":
+		if delta, ok := payload["delta"].(map[string]any); ok {
+			if reason, ok := delta["stop_reason"].(string); ok && reason != "" {
+				d.stopReason = reason
+			}
+		}
+		d.mergeUsage(payload["usage"])
+		return false, nil
+	case "message_stop":
+		d.sawTerminal = true
+		return true, nil
+	case "error":
+		return false, anthropicStreamError(payload)
+	case "ping":
+		return false, nil
+	default:
+		// Anthropic adds event types over time; ignoring unknown ones keeps the
+		// stream usable instead of failing on a forward-compatible addition.
+		return false, nil
+	}
+}
+
+func (d *anthropicStreamDecoder) handleBlockStart(payload map[string]any) error {
+	index, err := blockIndex(payload)
+	if err != nil {
+		return err
+	}
+	block, _ := payload["content_block"].(map[string]any)
+	if block == nil {
+		return nil
+	}
+	switch blockType, _ := block["type"].(string); blockType {
+	case "tool_use":
+		if _, exists := d.toolSlots[index]; exists {
+			return invalidProviderResponseError(fmt.Sprintf("provider reopened content block %d", index))
+		}
+		id, _ := block["id"].(string)
+		name, _ := block["name"].(string)
+		slot := d.encoder.NextToolSlot()
+		d.toolSlots[index] = slot
+		d.toolArguments[index] = &strings.Builder{}
+		d.hasToolCalls = true
+		return d.encoder.EmitToolCallStart(slot, id, name)
+	case "redacted_thinking":
+		data, _ := block["data"].(string)
+		return d.encoder.EmitRedactedReasoning(data)
+	default:
+		return nil
+	}
+}
+
+func (d *anthropicStreamDecoder) handleBlockDelta(payload map[string]any) error {
+	index, err := blockIndex(payload)
+	if err != nil {
+		return err
+	}
+	delta, _ := payload["delta"].(map[string]any)
+	if delta == nil {
+		return nil
+	}
+	switch deltaType, _ := delta["type"].(string); deltaType {
+	case "text_delta":
+		text, _ := delta["text"].(string)
+		return d.encoder.EmitText(text)
+	case "thinking_delta":
+		text, _ := delta["thinking"].(string)
+		return d.encoder.EmitReasoning(text)
+	case "signature_delta":
+		signature, _ := delta["signature"].(string)
+		if signature == "" {
+			return nil
+		}
+		builder, ok := d.signatures[index]
+		if !ok {
+			builder = &strings.Builder{}
+			d.signatures[index] = builder
+		}
+		builder.WriteString(signature)
+		return nil
+	case "input_json_delta":
+		slot, ok := d.toolSlots[index]
+		if !ok {
+			// Forwarding this against an arbitrary slot would corrupt an
+			// unrelated tool call's arguments.
+			return invalidProviderResponseError(fmt.Sprintf("provider sent tool arguments for unopened content block %d", index))
+		}
+		partial, _ := delta["partial_json"].(string)
+		if builder, ok := d.toolArguments[index]; ok {
+			builder.WriteString(partial)
+		}
+		return d.encoder.EmitToolCallArguments(slot, partial)
+	default:
+		// citations_delta and future delta types carry no OpenAI equivalent.
+		return nil
+	}
+}
+
+func (d *anthropicStreamDecoder) handleBlockStop(payload map[string]any) error {
+	index, err := blockIndex(payload)
+	if err != nil {
+		return err
+	}
+
+	// A tool call whose arguments do not parse is unusable to the client, and
+	// the truncation is invisible once the fragments have been forwarded.
+	if builder, ok := d.toolArguments[index]; ok {
+		delete(d.toolArguments, index)
+		arguments := strings.TrimSpace(builder.String())
+		if arguments == "" {
+			// A tool taking no arguments produces no partial_json deltas, but
+			// Anthropic still guarantees an object. Emitting nothing would leave
+			// the client with an empty, unparsable arguments string.
+			arguments = "{}"
+			if slot, ok := d.toolSlots[index]; ok {
+				if err := d.encoder.EmitToolCallArguments(slot, arguments); err != nil {
+					return err
+				}
+			}
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(arguments), &decoded); err != nil {
+			return invalidProviderResponseError(fmt.Sprintf("provider sent tool arguments that are not a JSON object: %v", err))
+		}
+	}
+
+	builder, ok := d.signatures[index]
+	if !ok || builder.Len() == 0 {
+		return nil
+	}
+	delete(d.signatures, index)
+	return d.encoder.EmitReasoningSignature(anthropicSignatureProvider, builder.String())
+}
+
+// blockIndex reads a content block index, rejecting events that omit it.
+// Defaulting a missing index to 0 would misroute deltas into the first block.
+func blockIndex(payload map[string]any) (int, error) {
+	value, present := payload["index"]
+	if !present {
+		return 0, invalidProviderResponseError("provider sent a content block event without an index")
+	}
+	number, ok := value.(float64)
+	if !ok {
+		return 0, invalidProviderResponseError("provider sent a non-numeric content block index")
+	}
+	return int(number), nil
+}
+
+// mergeUsage applies a usage snapshot. Anthropic reports cumulative totals, so
+// fields are overwritten rather than summed.
+func (d *anthropicStreamDecoder) mergeUsage(value any) {
+	usage, ok := value.(map[string]any)
+	if !ok {
+		return
+	}
+	for key, item := range usage {
+		if item == nil {
+			continue
+		}
+		d.usage[key] = item
+	}
+}
+
+func (d *anthropicStreamDecoder) currentUsage() Usage {
+	return anthropicUsage(map[string]any{"usage": d.usage})
+}
+
+func anthropicStreamError(payload map[string]any) error {
+	detail, _ := payload["error"].(map[string]any)
+	message, _ := detail["message"].(string)
+	if message == "" {
+		message = "provider reported a stream error"
+	}
+	code, _ := detail["type"].(string)
+	if code == "" {
+		code = "provider_stream_error"
+	}
+	return NewHTTPError(502, code, fmt.Sprintf("Anthropic stream error: %s", message))
+}

--- a/backend/internal/server/provider_chat_convert.go
+++ b/backend/internal/server/provider_chat_convert.go
@@ -1,0 +1,379 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Shared helpers for converting OpenAI Chat Completions payloads to and from
+// provider-native wire formats. Anthropic and Gemini both need the same
+// normalization of message content, tool definitions and reasoning metadata, so
+// the logic lives here instead of being duplicated per adapter.
+
+// chatContentKind enumerates the content part types TokenHub can forward to a
+// non-OpenAI provider. Anything outside this set is rejected explicitly rather
+// than silently dropped.
+type chatContentKind string
+
+const (
+	chatContentText     chatContentKind = "text"
+	chatContentImageURL chatContentKind = "image_url"
+	chatContentImageB64 chatContentKind = "image_base64"
+)
+
+// chatContentPart is the normalized form of one OpenAI content array element.
+type chatContentPart struct {
+	Kind      chatContentKind
+	Text      string
+	URL       string
+	MediaType string
+	Data      string
+}
+
+// parseChatContent normalizes an OpenAI message content value. Content may be a
+// plain string or an array of typed parts.
+func parseChatContent(content any) ([]chatContentPart, error) {
+	switch typed := content.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		if typed == "" {
+			return nil, nil
+		}
+		return []chatContentPart{{Kind: chatContentText, Text: typed}}, nil
+	case []any:
+		parts := make([]chatContentPart, 0, len(typed))
+		for _, item := range typed {
+			asMap, ok := item.(map[string]any)
+			if !ok {
+				return nil, unsupportedContentError("content array entries must be objects")
+			}
+			part, err := parseChatContentPart(asMap)
+			if err != nil {
+				return nil, err
+			}
+			parts = append(parts, part)
+		}
+		return parts, nil
+	default:
+		return nil, unsupportedContentError("message content must be a string or an array of content parts")
+	}
+}
+
+func parseChatContentPart(part map[string]any) (chatContentPart, error) {
+	partType, _ := part["type"].(string)
+	switch partType {
+	case "text", "input_text":
+		text, _ := part["text"].(string)
+		return chatContentPart{Kind: chatContentText, Text: text}, nil
+	case "image_url":
+		return parseChatImagePart(part)
+	case "":
+		if text, ok := part["text"].(string); ok {
+			return chatContentPart{Kind: chatContentText, Text: text}, nil
+		}
+		return chatContentPart{}, unsupportedContentError("content part is missing a type")
+	default:
+		return chatContentPart{}, unsupportedContentError(fmt.Sprintf("content part type %q is not supported by this provider", partType))
+	}
+}
+
+func parseChatImagePart(part map[string]any) (chatContentPart, error) {
+	var raw string
+	switch typed := part["image_url"].(type) {
+	case string:
+		raw = typed
+	case map[string]any:
+		raw, _ = typed["url"].(string)
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return chatContentPart{}, unsupportedContentError("image_url content part is missing a url")
+	}
+	if strings.HasPrefix(raw, "data:") {
+		mediaType, data, err := parseDataURI(raw)
+		if err != nil {
+			return chatContentPart{}, err
+		}
+		return chatContentPart{Kind: chatContentImageB64, MediaType: mediaType, Data: data}, nil
+	}
+	if !strings.HasPrefix(raw, "http://") && !strings.HasPrefix(raw, "https://") {
+		return chatContentPart{}, unsupportedContentError("image_url must be an http(s) URL or a data URI")
+	}
+	return chatContentPart{Kind: chatContentImageURL, URL: raw}, nil
+}
+
+// parseDataURI splits a base64 data URI into its media type and payload.
+func parseDataURI(value string) (string, string, error) {
+	remainder := strings.TrimPrefix(value, "data:")
+	separator := strings.Index(remainder, ",")
+	if separator < 0 {
+		return "", "", unsupportedContentError("data URI is missing a comma separator")
+	}
+	meta := remainder[:separator]
+	payload := remainder[separator+1:]
+	if !strings.Contains(meta, ";base64") {
+		return "", "", unsupportedContentError("only base64 data URIs are supported")
+	}
+	mediaType := strings.TrimSpace(strings.SplitN(meta, ";", 2)[0])
+	if mediaType == "" {
+		return "", "", unsupportedContentError("data URI is missing a media type")
+	}
+	if payload == "" {
+		return "", "", unsupportedContentError("data URI payload is empty")
+	}
+	return mediaType, payload, nil
+}
+
+// contentPartsText joins the text parts of a normalized content value.
+func contentPartsText(parts []chatContentPart) string {
+	segments := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part.Kind == chatContentText && part.Text != "" {
+			segments = append(segments, part.Text)
+		}
+	}
+	return strings.Join(segments, "")
+}
+
+func unsupportedContentError(detail string) error {
+	return NewHTTPError(http.StatusBadRequest, "unsupported_content_block", detail)
+}
+
+func unsupportedCapabilityError(detail string) error {
+	return NewHTTPError(http.StatusNotImplemented, "provider_capability_not_supported", detail)
+}
+
+func invalidProviderResponseError(detail string) error {
+	return NewHTTPError(http.StatusBadGateway, "provider_invalid_response", detail)
+}
+
+// chatToolDefinition is the normalized form of one OpenAI tool entry.
+type chatToolDefinition struct {
+	Name        string
+	Description string
+	Parameters  map[string]any
+	Strict      bool
+}
+
+// parseChatTools normalizes request tools. OpenAI nests the schema under
+// "function"; both Anthropic and Gemini expect a flattened shape.
+func parseChatTools(value any) ([]chatToolDefinition, error) {
+	if value == nil {
+		return nil, nil
+	}
+	entries, ok := value.([]any)
+	if !ok {
+		return nil, unsupportedContentError("tools must be an array")
+	}
+	tools := make([]chatToolDefinition, 0, len(entries))
+	for _, entry := range entries {
+		asMap, ok := entry.(map[string]any)
+		if !ok {
+			return nil, unsupportedContentError("tool entries must be objects")
+		}
+		if toolType, _ := asMap["type"].(string); toolType != "" && toolType != "function" {
+			return nil, unsupportedCapabilityError(fmt.Sprintf("tool type %q is not supported by this provider", toolType))
+		}
+		function, ok := asMap["function"].(map[string]any)
+		if !ok {
+			return nil, unsupportedContentError("tool entries must contain a function object")
+		}
+		name, _ := function["name"].(string)
+		if err := validateToolName(name); err != nil {
+			return nil, err
+		}
+		description, _ := function["description"].(string)
+		parameters, _ := function["parameters"].(map[string]any)
+		if parameters == nil {
+			// Both providers require an object schema; null is rejected upstream.
+			parameters = map[string]any{"type": "object", "properties": map[string]any{}}
+		}
+		strict, _ := function["strict"].(bool)
+		tools = append(tools, chatToolDefinition{
+			Name:        name,
+			Description: description,
+			Parameters:  parameters,
+			Strict:      strict,
+		})
+	}
+	return tools, nil
+}
+
+// validateToolName enforces the character set both providers accept.
+func validateToolName(name string) error {
+	if name == "" {
+		return unsupportedContentError("tool function name is required")
+	}
+	if len(name) > 64 {
+		return unsupportedContentError(fmt.Sprintf("tool function name %q exceeds 64 characters", name))
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+		default:
+			return unsupportedContentError(fmt.Sprintf("tool function name %q contains unsupported characters", name))
+		}
+	}
+	return nil
+}
+
+// chatToolChoice is the normalized form of the OpenAI tool_choice field.
+type chatToolChoice struct {
+	Mode string // "auto", "required", "none" or "function"
+	Name string // set when Mode is "function"
+}
+
+func parseChatToolChoice(value any) (chatToolChoice, error) {
+	switch typed := value.(type) {
+	case nil:
+		return chatToolChoice{Mode: "auto"}, nil
+	case string:
+		switch typed {
+		case "auto", "required", "none":
+			return chatToolChoice{Mode: typed}, nil
+		default:
+			return chatToolChoice{}, unsupportedContentError(fmt.Sprintf("tool_choice %q is not supported", typed))
+		}
+	case map[string]any:
+		choiceType, _ := typed["type"].(string)
+		if choiceType != "function" {
+			return chatToolChoice{}, unsupportedCapabilityError(fmt.Sprintf("tool_choice type %q is not supported by this provider", choiceType))
+		}
+		function, _ := typed["function"].(map[string]any)
+		name, _ := function["name"].(string)
+		if name == "" {
+			return chatToolChoice{}, unsupportedContentError("tool_choice function name is required")
+		}
+		return chatToolChoice{Mode: "function", Name: name}, nil
+	default:
+		return chatToolChoice{}, unsupportedContentError("tool_choice must be a string or an object")
+	}
+}
+
+// chatToolCall is the normalized form of one assistant tool call.
+type chatToolCall struct {
+	ID        string
+	Name      string
+	Arguments map[string]any
+	// Signature carries provider-scoped continuation data (Gemini thought
+	// signatures). Empty when the client did not echo it back.
+	Signature string
+}
+
+// parseChatToolCalls normalizes assistant tool_calls. OpenAI encodes arguments
+// as a JSON string; providers expect a decoded object.
+func parseChatToolCalls(value any) ([]chatToolCall, error) {
+	if value == nil {
+		return nil, nil
+	}
+	entries, ok := anySlice(value)
+	if !ok {
+		return nil, unsupportedContentError("tool_calls must be an array")
+	}
+	calls := make([]chatToolCall, 0, len(entries))
+	for _, entry := range entries {
+		asMap, ok := entry.(map[string]any)
+		if !ok {
+			return nil, unsupportedContentError("tool_calls entries must be objects")
+		}
+		id, _ := asMap["id"].(string)
+		function, ok := asMap["function"].(map[string]any)
+		if !ok {
+			return nil, unsupportedContentError("tool_calls entries must contain a function object")
+		}
+		name, _ := function["name"].(string)
+		if name == "" {
+			return nil, unsupportedContentError("tool_calls entries must contain a function name")
+		}
+		arguments := map[string]any{}
+		if raw, _ := function["arguments"].(string); strings.TrimSpace(raw) != "" {
+			if err := json.Unmarshal([]byte(raw), &arguments); err != nil {
+				return nil, unsupportedContentError(fmt.Sprintf("tool call %q has invalid JSON arguments", name))
+			}
+		}
+		signature, _ := asMap["thought_signature"].(string)
+		calls = append(calls, chatToolCall{ID: id, Name: name, Arguments: arguments, Signature: signature})
+	}
+	return calls, nil
+}
+
+// encodeToolCallArguments renders a provider tool input back to the JSON string
+// OpenAI clients expect.
+func encodeToolCallArguments(input any) string {
+	if input == nil {
+		return "{}"
+	}
+	encoded, err := json.Marshal(input)
+	if err != nil {
+		return "{}"
+	}
+	return string(encoded)
+}
+
+// Provider-scoped reasoning signatures.
+//
+// The OpenAI Chat Completions schema has no field for a provider's opaque
+// reasoning continuation data, so TokenHub exposes it through extension fields.
+// Values are prefixed with the originating provider so a signature minted by one
+// provider is never replayed to another; a mismatch degrades to dropping the
+// reasoning block rather than failing the request.
+const (
+	anthropicSignatureProvider = "anthropic"
+	geminiSignatureProvider    = "gemini"
+)
+
+// withoutGatewayExtensions strips the TokenHub-only reasoning fields from a
+// request before it is forwarded verbatim to an OpenAI-compatible upstream.
+//
+// These fields exist to carry Anthropic and Gemini continuation data across the
+// OpenAI-shaped surface. They are not part of the OpenAI schema, and strict
+// implementations reject unknown message fields, so forwarding them would break
+// requests that worked before the fields existed.
+func withoutGatewayExtensions(req ChatCompletionRequest) ChatCompletionRequest {
+	needsCopy := false
+	for _, message := range req.Messages {
+		if message.ReasoningContent != "" || message.ReasoningSignature != "" || message.RedactedReasoningContent != "" {
+			needsCopy = true
+			break
+		}
+	}
+	if !needsCopy {
+		return req
+	}
+	messages := make([]ChatMessage, len(req.Messages))
+	copy(messages, req.Messages)
+	for index := range messages {
+		messages[index].ReasoningContent = ""
+		messages[index].ReasoningSignature = ""
+		messages[index].RedactedReasoningContent = ""
+	}
+	req.Messages = messages
+	return req
+}
+
+func encodeProviderSignature(provider string, raw string) string {
+	if raw == "" {
+		return ""
+	}
+	return provider + ":" + raw
+}
+
+// decodeProviderSignature returns the opaque payload when the value was minted
+// by the same provider. The second result reports whether the value is usable.
+func decodeProviderSignature(provider string, value string) (string, bool) {
+	if value == "" {
+		return "", false
+	}
+	prefix := provider + ":"
+	if !strings.HasPrefix(value, prefix) {
+		return "", false
+	}
+	payload := strings.TrimPrefix(value, prefix)
+	if payload == "" {
+		return "", false
+	}
+	return payload, true
+}

--- a/backend/internal/server/provider_chat_convert_test.go
+++ b/backend/internal/server/provider_chat_convert_test.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWithoutGatewayExtensionsStripsReasoningFields(t *testing.T) {
+	req := ChatCompletionRequest{Messages: []ChatMessage{
+		{Role: "user", Content: "hi"},
+		{
+			Role:                     "assistant",
+			Content:                  "answer",
+			ReasoningContent:         "thinking",
+			ReasoningSignature:       "anthropic:sig",
+			RedactedReasoningContent: "opaque",
+		},
+	}}
+
+	sanitized := withoutGatewayExtensions(req)
+
+	for _, message := range sanitized.Messages {
+		if message.ReasoningContent != "" || message.ReasoningSignature != "" || message.RedactedReasoningContent != "" {
+			t.Fatalf("gateway extension fields must not survive: %+v", message)
+		}
+	}
+	// The caller's slice must not be mutated; the same request is reused across
+	// failover attempts to other routes.
+	if req.Messages[1].ReasoningContent != "thinking" {
+		t.Fatalf("the original request was mutated: %+v", req.Messages[1])
+	}
+}
+
+func TestOpenAICompatibleAdapterDoesNotForwardGatewayExtensions(t *testing.T) {
+	var received map[string]any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&received)
+		w.Header().Set("content-type", "application/json")
+		io.WriteString(w, `{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{}}`)
+	}))
+	defer upstream.Close()
+
+	adapter := OpenAICompatibleAdapter{Client: upstream.Client()}
+	provider := Provider{BaseURL: upstream.URL, APIKey: "test-key"}
+
+	_, _, err := adapter.Chat(context.Background(), provider, "model-x", ChatCompletionRequest{
+		Model: "model-x",
+		Messages: []ChatMessage{{
+			Role:                     "assistant",
+			Content:                  "answer",
+			ReasoningContent:         "thinking",
+			ReasoningSignature:       "anthropic:sig",
+			RedactedReasoningContent: "opaque",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	messages, _ := received["messages"].([]any)
+	message, _ := messages[0].(map[string]any)
+	// These fields are not part of the OpenAI schema; strict upstreams reject
+	// unknown message fields outright.
+	for _, field := range []string{"reasoning_content", "reasoning_signature", "redacted_reasoning_content"} {
+		if _, present := message[field]; present {
+			t.Fatalf("%s must not be forwarded to an OpenAI-compatible upstream: %v", field, message)
+		}
+	}
+	if message["content"] != "answer" {
+		t.Fatalf("the message body must otherwise be forwarded unchanged: %v", message)
+	}
+}
+
+func TestParseDataURIRejectsUnsupportedForms(t *testing.T) {
+	cases := map[string]string{
+		"missing comma": "data:image/png;base64",
+		"not base64":    "data:image/png,rawbytes",
+		"empty payload": "data:image/png;base64,",
+		"no media type": "data:;base64,AAAA",
+	}
+	for name, value := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := parseDataURI(value); err == nil {
+				t.Fatalf("expected %q to be rejected", value)
+			}
+		})
+	}
+}
+
+func TestParseChatContentRejectsNonObjectParts(t *testing.T) {
+	if _, err := parseChatContent([]any{"bare string"}); err == nil {
+		t.Fatalf("content array entries must be objects")
+	}
+}
+
+func TestProviderSignatureRoundTrip(t *testing.T) {
+	encoded := encodeProviderSignature(anthropicSignatureProvider, "payload")
+
+	if decoded, ok := decodeProviderSignature(anthropicSignatureProvider, encoded); !ok || decoded != "payload" {
+		t.Fatalf("a signature must decode for the provider that minted it, got %q ok=%v", decoded, ok)
+	}
+	// Replaying one provider's blob to another is rejected upstream, so it must
+	// not survive decoding.
+	if _, ok := decodeProviderSignature(geminiSignatureProvider, encoded); ok {
+		t.Fatalf("a signature must not decode for a different provider")
+	}
+	if _, ok := decodeProviderSignature(anthropicSignatureProvider, "unprefixed"); ok {
+		t.Fatalf("an untagged signature must not be accepted")
+	}
+	if encodeProviderSignature(anthropicSignatureProvider, "") != "" {
+		t.Fatalf("an empty signature must stay empty")
+	}
+}

--- a/backend/internal/server/provider_gemini_convert.go
+++ b/backend/internal/server/provider_gemini_convert.go
@@ -1,0 +1,468 @@
+package server
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Conversion between OpenAI Chat Completions and the Gemini generateContent
+// wire format, shared by the streaming and non-streaming adapter paths.
+
+// buildGeminiRequest renders an OpenAI chat request as a Gemini
+// generateContent request body.
+func buildGeminiRequest(providerModel string, req ChatCompletionRequest) (map[string]any, error) {
+	if req.ParallelToolCalls != nil && !*req.ParallelToolCalls {
+		// Gemini has no generateContent equivalent for disabling parallel tool
+		// calls. Silently ignoring it would let a client believe a constraint
+		// was applied when it was not.
+		return nil, unsupportedCapabilityError("Gemini does not support parallel_tool_calls=false")
+	}
+
+	systemParts, contents, err := geminiContentsFromChat(req.Messages)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := map[string]any{"contents": contents}
+	if len(systemParts) > 0 {
+		// System guidance belongs in the top-level systemInstruction. Folding it
+		// into a user turn changes how the model weighs it.
+		payload["systemInstruction"] = map[string]any{"parts": systemParts}
+	}
+
+	generationConfig := map[string]any{}
+	if req.MaxTokens > 0 {
+		generationConfig["maxOutputTokens"] = req.MaxTokens
+	}
+	if req.Temperature != nil {
+		generationConfig["temperature"] = *req.Temperature
+	}
+	if req.TopP != nil {
+		generationConfig["topP"] = *req.TopP
+	}
+	if stop := anthropicStopSequences(req.Stop); len(stop) > 0 {
+		generationConfig["stopSequences"] = stop
+	}
+	if effort := normalizedReasoningEffort(req.ReasoningEffort); effort != nil {
+		if thinkingConfig, supported := geminiThinkingConfig(providerModel, *effort); supported {
+			generationConfig["thinkingConfig"] = thinkingConfig
+		}
+	}
+	if len(generationConfig) > 0 {
+		payload["generationConfig"] = generationConfig
+	}
+
+	tools, err := parseChatTools(req.Tools)
+	if err != nil {
+		return nil, err
+	}
+	choice, err := parseChatToolChoice(req.ToolChoice)
+	if err != nil {
+		return nil, err
+	}
+	if len(tools) > 0 {
+		if choice.Mode == "function" && !toolNameDeclared(tools, choice.Name) {
+			return nil, unsupportedContentError(fmt.Sprintf("tool_choice names %q which is not present in tools", choice.Name))
+		}
+		payload["tools"] = []map[string]any{{"functionDeclarations": geminiToolDeclarations(tools)}}
+		payload["toolConfig"] = map[string]any{"functionCallingConfig": geminiFunctionCallingConfig(choice)}
+	}
+	return payload, nil
+}
+
+func geminiToolDeclarations(tools []chatToolDefinition) []map[string]any {
+	declarations := make([]map[string]any, 0, len(tools))
+	for _, tool := range tools {
+		entry := map[string]any{"name": tool.Name}
+		// "parameters" is a narrow OpenAPI Schema subset. Schemas using JSON
+		// Schema constructs OpenAPI lacks must go through parametersJsonSchema
+		// or the provider rejects an otherwise valid OpenAI tool definition.
+		if schemaNeedsJSONSchema(tool.Parameters) {
+			entry["parametersJsonSchema"] = tool.Parameters
+		} else {
+			entry["parameters"] = tool.Parameters
+		}
+		if tool.Description != "" {
+			entry["description"] = tool.Description
+		}
+		declarations = append(declarations, entry)
+	}
+	return declarations
+}
+
+// openAPISchemaKeywords is the field set Gemini's "parameters" accepts. It is an
+// allowlist on purpose: JSON Schema keeps growing, so a blacklist would silently
+// route new constructs into a field that cannot express them.
+var openAPISchemaKeywords = map[string]struct{}{
+	"type":             {},
+	"format":           {},
+	"title":            {},
+	"description":      {},
+	"nullable":         {},
+	"enum":             {},
+	"properties":       {},
+	"required":         {},
+	"items":            {},
+	"anyOf":            {},
+	"default":          {},
+	"example":          {},
+	"minimum":          {},
+	"maximum":          {},
+	"minLength":        {},
+	"maxLength":        {},
+	"minItems":         {},
+	"maxItems":         {},
+	"minProperties":    {},
+	"maxProperties":    {},
+	"pattern":          {},
+	"propertyOrdering": {},
+}
+
+// schemaNeedsJSONSchema reports whether a tool schema uses constructs the
+// OpenAPI Schema subset cannot carry, in which case it must travel through
+// parametersJsonSchema instead.
+//
+// Both the keyword names and their value shapes matter: OpenAPI models `type`
+// as a single enum value and `enum` as a list of strings, so JSON Schema forms
+// such as {"type": ["string", "null"]} need the richer field even though the
+// keyword itself is recognized.
+//
+// Only fields that actually carry schemas are recursed into. Annotation fields
+// such as `example` and `default` hold arbitrary JSON, and walking them would
+// mistake ordinary data keys for unsupported schema keywords.
+func schemaNeedsJSONSchema(value any) bool {
+	schema, ok := value.(map[string]any)
+	if !ok {
+		return true
+	}
+	for key, item := range schema {
+		if _, supported := openAPISchemaKeywords[key]; !supported {
+			return true
+		}
+		switch key {
+		case "type":
+			if _, ok := item.(string); !ok {
+				return true
+			}
+		case "enum":
+			values, ok := item.([]any)
+			if !ok {
+				return true
+			}
+			for _, entry := range values {
+				if _, ok := entry.(string); !ok {
+					return true
+				}
+			}
+		case "properties":
+			members, ok := item.(map[string]any)
+			if !ok {
+				return true
+			}
+			for _, member := range members {
+				if schemaNeedsJSONSchema(member) {
+					return true
+				}
+			}
+		case "items":
+			if schemaNeedsJSONSchema(item) {
+				return true
+			}
+		case "anyOf":
+			entries, ok := item.([]any)
+			if !ok {
+				return true
+			}
+			for _, entry := range entries {
+				if schemaNeedsJSONSchema(entry) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func geminiFunctionCallingConfig(choice chatToolChoice) map[string]any {
+	switch choice.Mode {
+	case "required":
+		return map[string]any{"mode": "ANY"}
+	case "none":
+		return map[string]any{"mode": "NONE"}
+	case "function":
+		return map[string]any{"mode": "ANY", "allowedFunctionNames": []string{choice.Name}}
+	default:
+		return map[string]any{"mode": "AUTO"}
+	}
+}
+
+// geminiContentsFromChat splits OpenAI messages into systemInstruction parts and
+// the contents turn list.
+func geminiContentsFromChat(messages []ChatMessage) ([]map[string]any, []map[string]any, error) {
+	var (
+		systemParts    []map[string]any
+		contents       []map[string]any
+		pendingResults []map[string]any
+	)
+
+	flushResults := func() {
+		if len(pendingResults) == 0 {
+			return
+		}
+		contents = append(contents, map[string]any{"role": "user", "parts": pendingResults})
+		pendingResults = nil
+	}
+
+	// Function responses reference the call by name, which OpenAI only carries
+	// on the assistant turn, so remember the id to name mapping as we go.
+	toolNames := map[string]string{}
+
+	for _, message := range messages {
+		switch message.Role {
+		case "system", "developer":
+			flushResults()
+			parts, err := parseChatContent(message.Content)
+			if err != nil {
+				return nil, nil, err
+			}
+			if text := contentPartsText(parts); text != "" {
+				systemParts = append(systemParts, map[string]any{"text": text})
+			}
+		case "tool":
+			part, err := geminiFunctionResponsePart(message, toolNames)
+			if err != nil {
+				return nil, nil, err
+			}
+			pendingResults = append(pendingResults, part)
+		case "assistant":
+			flushResults()
+			parts, err := geminiAssistantParts(message, toolNames)
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(parts) == 0 {
+				continue
+			}
+			contents = append(contents, map[string]any{"role": "model", "parts": parts})
+		default:
+			flushResults()
+			parts, err := geminiUserParts(message)
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(parts) == 0 {
+				continue
+			}
+			contents = append(contents, map[string]any{"role": "user", "parts": parts})
+		}
+	}
+	flushResults()
+	return systemParts, contents, nil
+}
+
+func geminiFunctionResponsePart(message ChatMessage, toolNames map[string]string) (map[string]any, error) {
+	if message.ToolCallID == "" {
+		return nil, unsupportedContentError("tool messages must carry tool_call_id")
+	}
+	name := toolNames[message.ToolCallID]
+	if name == "" {
+		name = message.Name
+	}
+	if name == "" {
+		return nil, unsupportedContentError(fmt.Sprintf("cannot resolve the function name for tool_call_id %q", message.ToolCallID))
+	}
+	parts, err := parseChatContent(message.Content)
+	if err != nil {
+		return nil, err
+	}
+	response := map[string]any{
+		"id":   message.ToolCallID,
+		"name": name,
+		// Gemini requires an object; tool output is opaque text to the gateway.
+		"response": map[string]any{"result": contentPartsText(parts)},
+	}
+	return map[string]any{"functionResponse": response}, nil
+}
+
+func geminiAssistantParts(message ChatMessage, toolNames map[string]string) ([]map[string]any, error) {
+	parts := make([]map[string]any, 0, 2)
+
+	contentParts, err := parseChatContent(message.Content)
+	if err != nil {
+		return nil, err
+	}
+	if text := contentPartsText(contentParts); text != "" {
+		parts = append(parts, map[string]any{"text": text})
+	}
+
+	calls, err := parseChatToolCalls(message.ToolCalls)
+	if err != nil {
+		return nil, err
+	}
+	for _, call := range calls {
+		if call.ID != "" {
+			toolNames[call.ID] = call.Name
+		}
+		functionCall := map[string]any{
+			"name": call.Name,
+			"args": call.Arguments,
+		}
+		if call.ID != "" {
+			// The matching functionResponse references this id. Replaying the
+			// call without it leaves the result pointing at a call Gemini cannot
+			// find, which it rejects.
+			functionCall["id"] = call.ID
+		}
+		part := map[string]any{"functionCall": functionCall}
+		// The thought signature is only usable if this provider minted it.
+		// Replaying another provider's blob would be rejected upstream.
+		if signature, ok := decodeProviderSignature(geminiSignatureProvider, call.Signature); ok {
+			part["thoughtSignature"] = signature
+		}
+		parts = append(parts, part)
+	}
+	return parts, nil
+}
+
+func geminiUserParts(message ChatMessage) ([]map[string]any, error) {
+	contentParts, err := parseChatContent(message.Content)
+	if err != nil {
+		return nil, err
+	}
+	parts := make([]map[string]any, 0, len(contentParts))
+	for _, part := range contentParts {
+		switch part.Kind {
+		case chatContentText:
+			if part.Text == "" {
+				continue
+			}
+			parts = append(parts, map[string]any{"text": part.Text})
+		case chatContentImageB64:
+			parts = append(parts, map[string]any{
+				"inlineData": map[string]any{"mimeType": part.MediaType, "data": part.Data},
+			})
+		case chatContentImageURL:
+			// Gemini's fileData only accepts URIs it already hosts, so an
+			// arbitrary http(s) image URL cannot be forwarded.
+			return nil, unsupportedCapabilityError("Gemini requires inline image data; pass the image as a base64 data URI instead of an http(s) URL")
+		}
+	}
+	return parts, nil
+}
+
+// geminiChatResponse converts a Gemini generateContent response body into an
+// OpenAI chat completion object.
+func geminiChatResponse(body map[string]any, model string, usage Usage) (map[string]any, error) {
+	candidates, _ := body["candidates"].([]any)
+	if len(candidates) == 0 {
+		if reason := geminiPromptBlockReason(body); reason != "" {
+			return nil, NewHTTPError(400, "content_filter", fmt.Sprintf("Gemini blocked the prompt: %s", reason))
+		}
+		return nil, invalidProviderResponseError("Gemini returned no candidates")
+	}
+	candidate, _ := candidates[0].(map[string]any)
+	content, _ := candidate["content"].(map[string]any)
+	parts, _ := content["parts"].([]any)
+
+	var (
+		textParts []string
+		reasoning []string
+		toolCalls []any
+	)
+	for index, item := range parts {
+		part, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if call, ok := part["functionCall"].(map[string]any); ok {
+			name, _ := call["name"].(string)
+			id, _ := call["id"].(string)
+			if id == "" {
+				// Gemini does not always mint an id; clients still need a stable
+				// handle to correlate the result with.
+				id = fmt.Sprintf("call_%s_%d", NewID("gemini"), index)
+			}
+			entry := map[string]any{
+				"id":   id,
+				"type": "function",
+				"function": map[string]any{
+					"name":      name,
+					"arguments": encodeToolCallArguments(call["args"]),
+				},
+			}
+			if signature, ok := part["thoughtSignature"].(string); ok && signature != "" {
+				entry["thought_signature"] = encodeProviderSignature(geminiSignatureProvider, signature)
+			}
+			toolCalls = append(toolCalls, entry)
+			continue
+		}
+		text, _ := part["text"].(string)
+		if text == "" {
+			continue
+		}
+		if thought, _ := part["thought"].(bool); thought {
+			reasoning = append(reasoning, text)
+			continue
+		}
+		textParts = append(textParts, text)
+	}
+
+	message := map[string]any{"role": "assistant"}
+	if len(textParts) > 0 {
+		message["content"] = strings.Join(textParts, "")
+	} else {
+		message["content"] = nil
+	}
+	if len(reasoning) > 0 {
+		message["reasoning_content"] = strings.Join(reasoning, "")
+	}
+	if len(toolCalls) > 0 {
+		message["tool_calls"] = toolCalls
+	}
+
+	finishReason, _ := candidate["finishReason"].(string)
+	mapped, err := geminiFinishReason(finishReason, len(toolCalls) > 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"id":      NewID("chatcmpl"),
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   model,
+		"choices": []map[string]any{{
+			"index":         0,
+			"message":       message,
+			"finish_reason": mapped,
+		}},
+		"usage": usage,
+	}, nil
+}
+
+func geminiPromptBlockReason(body map[string]any) string {
+	feedback, _ := body["promptFeedback"].(map[string]any)
+	reason, _ := feedback["blockReason"].(string)
+	return reason
+}
+
+// geminiFinishReason maps a Gemini finish reason. Protocol-level failures are
+// reported as upstream errors instead of being flattened into a normal stop.
+func geminiFinishReason(reason string, hasToolCalls bool) (string, error) {
+	switch reason {
+	case "STOP", "":
+		if hasToolCalls {
+			return "tool_calls", nil
+		}
+		return "stop", nil
+	case "MAX_TOKENS":
+		return "length", nil
+	case "SAFETY", "RECITATION", "BLOCKLIST", "PROHIBITED_CONTENT", "SPII", "IMAGE_SAFETY":
+		return "content_filter", nil
+	case "MALFORMED_FUNCTION_CALL", "UNEXPECTED_TOOL_CALL", "MISSING_THOUGHT_SIGNATURE", "MALFORMED_RESPONSE":
+		return "", invalidProviderResponseError(fmt.Sprintf("Gemini reported a protocol failure: %s", reason))
+	default:
+		return "", invalidProviderResponseError(fmt.Sprintf("Gemini returned an unrecognized finishReason %q", reason))
+	}
+}

--- a/backend/internal/server/provider_gemini_convert_test.go
+++ b/backend/internal/server/provider_gemini_convert_test.go
@@ -1,0 +1,501 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+func mustBuildGemini(t *testing.T, req ChatCompletionRequest) map[string]any {
+	t.Helper()
+	payload, err := buildGeminiRequest("gemini-test", req)
+	if err != nil {
+		t.Fatalf("buildGeminiRequest: %v", err)
+	}
+	return payload
+}
+
+func TestGeminiRequestUsesSystemInstruction(t *testing.T) {
+	payload := mustBuildGemini(t, ChatCompletionRequest{
+		Messages: []ChatMessage{
+			{Role: "system", Content: "be brief"},
+			{Role: "user", Content: "hi"},
+		},
+	})
+
+	instruction, ok := payload["systemInstruction"].(map[string]any)
+	if !ok {
+		t.Fatalf("system guidance must map to the top-level systemInstruction, got %v", payload)
+	}
+	parts, _ := instruction["parts"].([]map[string]any)
+	if len(parts) != 1 || parts[0]["text"] != "be brief" {
+		t.Fatalf("unexpected systemInstruction payload: %v", instruction)
+	}
+
+	// Disguising system guidance as a user turn changes how the model weighs it.
+	contents, _ := payload["contents"].([]map[string]any)
+	if len(contents) != 1 {
+		t.Fatalf("expected only the user turn in contents, got %d", len(contents))
+	}
+	userParts, _ := contents[0]["parts"].([]map[string]any)
+	if userParts[0]["text"] != "hi" {
+		t.Fatalf("system text must not leak into the user turn: %v", contents[0])
+	}
+}
+
+func TestGeminiRequestRejectsDisabledParallelToolCalls(t *testing.T) {
+	disabled := false
+	_, err := buildGeminiRequest("gemini-test", ChatCompletionRequest{
+		Messages:          []ChatMessage{{Role: "user", Content: "hi"}},
+		ParallelToolCalls: &disabled,
+	})
+	// Gemini has no generateContent equivalent; silently ignoring the flag would
+	// let a client believe a constraint was applied when it was not.
+	if err == nil {
+		t.Fatalf("expected parallel_tool_calls=false to be rejected for Gemini")
+	}
+	if AsHTTPError(err).Code != "provider_capability_not_supported" {
+		t.Fatalf("unexpected error code: %v", AsHTTPError(err).Code)
+	}
+}
+
+func TestGeminiRequestMapsToolsAndToolConfig(t *testing.T) {
+	payload := mustBuildGemini(t, ChatCompletionRequest{
+		Messages:   []ChatMessage{{Role: "user", Content: "hi"}},
+		Tools:      []any{map[string]any{"function": map[string]any{"name": "ping", "description": "p"}}},
+		ToolChoice: "required",
+	})
+	tools, _ := payload["tools"].([]map[string]any)
+	declarations, _ := tools[0]["functionDeclarations"].([]map[string]any)
+	if declarations[0]["name"] != "ping" {
+		t.Fatalf("tool must map to a functionDeclaration: %v", tools)
+	}
+	config, _ := payload["toolConfig"].(map[string]any)
+	calling, _ := config["functionCallingConfig"].(map[string]any)
+	if calling["mode"] != "ANY" {
+		t.Fatalf("tool_choice=required must map to mode ANY, got %v", calling)
+	}
+}
+
+func TestGeminiToolChoiceFunctionRestrictsAllowedNames(t *testing.T) {
+	payload := mustBuildGemini(t, ChatCompletionRequest{
+		Messages:   []ChatMessage{{Role: "user", Content: "hi"}},
+		Tools:      []any{map[string]any{"function": map[string]any{"name": "ping"}}},
+		ToolChoice: map[string]any{"type": "function", "function": map[string]any{"name": "ping"}},
+	})
+	config, _ := payload["toolConfig"].(map[string]any)
+	calling, _ := config["functionCallingConfig"].(map[string]any)
+	allowed, _ := calling["allowedFunctionNames"].([]string)
+	if calling["mode"] != "ANY" || len(allowed) != 1 || allowed[0] != "ping" {
+		t.Fatalf("a named tool_choice must restrict allowedFunctionNames: %v", calling)
+	}
+}
+
+func TestGeminiRequestBuildsFunctionResponseWithIDAndName(t *testing.T) {
+	payload := mustBuildGemini(t, ChatCompletionRequest{
+		Messages: []ChatMessage{
+			{Role: "user", Content: "weather?"},
+			{Role: "assistant", ToolCalls: []any{
+				map[string]any{"id": "call_1", "function": map[string]any{"name": "get_weather", "arguments": `{"city":"BJ"}`}},
+			}},
+			{Role: "tool", ToolCallID: "call_1", Content: "sunny"},
+		},
+	})
+	contents, _ := payload["contents"].([]map[string]any)
+	if contents[1]["role"] != "model" {
+		t.Fatalf("assistant turns must use the model role: %v", contents[1])
+	}
+	resultParts, _ := contents[2]["parts"].([]map[string]any)
+	response, _ := resultParts[0]["functionResponse"].(map[string]any)
+	if response["id"] != "call_1" || response["name"] != "get_weather" {
+		t.Fatalf("functionResponse must carry the matching id and name: %v", response)
+	}
+	// Gemini requires an object payload, not a bare string.
+	if _, ok := response["response"].(map[string]any); !ok {
+		t.Fatalf("functionResponse response must be an object: %v", response)
+	}
+}
+
+func TestGeminiRequestConvertsInlineImageAndRejectsRemoteURL(t *testing.T) {
+	payload := mustBuildGemini(t, ChatCompletionRequest{
+		Messages: []ChatMessage{{Role: "user", Content: []any{
+			map[string]any{"type": "image_url", "image_url": map[string]any{"url": "data:image/jpeg;base64,BBBB"}},
+		}}},
+	})
+	contents, _ := payload["contents"].([]map[string]any)
+	parts, _ := contents[0]["parts"].([]map[string]any)
+	inline, _ := parts[0]["inlineData"].(map[string]any)
+	if inline["mimeType"] != "image/jpeg" || inline["data"] != "BBBB" {
+		t.Fatalf("data URIs must map to inlineData: %v", parts[0])
+	}
+
+	// Gemini's fileData only accepts URIs it already hosts, so an arbitrary
+	// image URL cannot be forwarded and must not be silently dropped.
+	_, err := buildGeminiRequest("gemini-test", ChatCompletionRequest{
+		Messages: []ChatMessage{{Role: "user", Content: []any{
+			map[string]any{"type": "image_url", "image_url": map[string]any{"url": "https://example.com/a.png"}},
+		}}},
+	})
+	if err == nil {
+		t.Fatalf("expected a remote image URL to be rejected for Gemini")
+	}
+}
+
+func TestGeminiRequestForwardsMatchingThoughtSignature(t *testing.T) {
+	build := func(signature string) map[string]any {
+		payload := mustBuildGemini(t, ChatCompletionRequest{
+			Messages: []ChatMessage{{Role: "assistant", ToolCalls: []any{
+				map[string]any{
+					"id":                "call_1",
+					"function":          map[string]any{"name": "ping", "arguments": "{}"},
+					"thought_signature": signature,
+				},
+			}}},
+		})
+		contents, _ := payload["contents"].([]map[string]any)
+		parts, _ := contents[0]["parts"].([]map[string]any)
+		return parts[0]
+	}
+
+	matching := build(encodeProviderSignature(geminiSignatureProvider, "thought-1"))
+	if matching["thoughtSignature"] != "thought-1" {
+		t.Fatalf("a matching signature must be replayed verbatim: %v", matching)
+	}
+
+	foreign := build(encodeProviderSignature(anthropicSignatureProvider, "thought-1"))
+	if _, present := foreign["thoughtSignature"]; present {
+		t.Fatalf("another provider's signature must not be replayed: %v", foreign)
+	}
+}
+
+func TestGeminiResponsePreservesNativeToolCallID(t *testing.T) {
+	body := map[string]any{
+		"candidates": []any{map[string]any{
+			"content": map[string]any{"parts": []any{
+				map[string]any{"functionCall": map[string]any{"id": "native-id", "name": "ping", "args": map[string]any{"a": 1}}},
+			}},
+			"finishReason": "STOP",
+		}},
+	}
+	converted, err := geminiChatResponse(body, "model-x", Usage{})
+	if err != nil {
+		t.Fatalf("geminiChatResponse: %v", err)
+	}
+	choices, _ := converted["choices"].([]map[string]any)
+	message, _ := choices[0]["message"].(map[string]any)
+	calls, _ := message["tool_calls"].([]any)
+	call, _ := calls[0].(map[string]any)
+	if call["id"] != "native-id" {
+		t.Fatalf("a provider-supplied tool call id must be preserved, got %v", call["id"])
+	}
+	if choices[0]["finish_reason"] != "tool_calls" {
+		t.Fatalf("STOP with a function call must map to tool_calls: %v", choices[0])
+	}
+}
+
+func TestGeminiResponseGeneratesToolCallIDWhenAbsent(t *testing.T) {
+	body := map[string]any{
+		"candidates": []any{map[string]any{
+			"content":      map[string]any{"parts": []any{map[string]any{"functionCall": map[string]any{"name": "ping"}}}},
+			"finishReason": "STOP",
+		}},
+	}
+	converted, _ := geminiChatResponse(body, "model-x", Usage{})
+	choices, _ := converted["choices"].([]map[string]any)
+	message, _ := choices[0]["message"].(map[string]any)
+	calls, _ := message["tool_calls"].([]any)
+	call, _ := calls[0].(map[string]any)
+	if id, _ := call["id"].(string); id == "" {
+		t.Fatalf("clients need a handle to correlate results with, got an empty id")
+	}
+}
+
+func TestGeminiResponseSeparatesThoughtParts(t *testing.T) {
+	body := map[string]any{
+		"candidates": []any{map[string]any{
+			"content": map[string]any{"parts": []any{
+				map[string]any{"text": "internal", "thought": true},
+				map[string]any{"text": "answer"},
+			}},
+			"finishReason": "STOP",
+		}},
+	}
+	converted, _ := geminiChatResponse(body, "model-x", Usage{})
+	choices, _ := converted["choices"].([]map[string]any)
+	message, _ := choices[0]["message"].(map[string]any)
+	if message["reasoning_content"] != "internal" {
+		t.Fatalf("thought parts must surface as reasoning_content: %v", message)
+	}
+	if message["content"] != "answer" {
+		t.Fatalf("thought text must not leak into the answer: %v", message)
+	}
+}
+
+func TestGeminiFinishReasonMapping(t *testing.T) {
+	safe := map[string]string{
+		"STOP":       "stop",
+		"MAX_TOKENS": "length",
+	}
+	for reason, want := range safe {
+		got, err := geminiFinishReason(reason, false)
+		if err != nil {
+			t.Fatalf("%s: %v", reason, err)
+		}
+		if got != want {
+			t.Fatalf("%s: expected %q, got %q", reason, want, got)
+		}
+	}
+
+	for _, reason := range []string{"SAFETY", "RECITATION", "BLOCKLIST", "PROHIBITED_CONTENT", "SPII"} {
+		got, err := geminiFinishReason(reason, false)
+		if err != nil {
+			t.Fatalf("%s: %v", reason, err)
+		}
+		if got != "content_filter" {
+			t.Fatalf("%s must map to content_filter, got %q", reason, got)
+		}
+	}
+
+	// Protocol failures must not be reported as a normal completion.
+	for _, reason := range []string{"MALFORMED_FUNCTION_CALL", "UNEXPECTED_TOOL_CALL", "MALFORMED_RESPONSE", "SOMETHING_NEW"} {
+		if _, err := geminiFinishReason(reason, false); err == nil {
+			t.Fatalf("%s must surface as an upstream error", reason)
+		}
+	}
+}
+
+func TestGeminiResponseSurfacesPromptBlock(t *testing.T) {
+	body := map[string]any{
+		"candidates":     []any{},
+		"promptFeedback": map[string]any{"blockReason": "SAFETY"},
+	}
+	_, err := geminiChatResponse(body, "model-x", Usage{})
+	if err == nil {
+		t.Fatalf("a blocked prompt must surface as an error rather than an empty reply")
+	}
+	if AsHTTPError(err).Code != "content_filter" {
+		t.Fatalf("unexpected error code: %v", AsHTTPError(err).Code)
+	}
+}
+
+func TestGeminiStreamEmitsCompleteToolArgumentsInOneDelta(t *testing.T) {
+	// Gemini does not stream partial tool arguments: each functionCall part
+	// arrives as a complete JSON object.
+	raw := strings.Join([]string{
+		`data: {"candidates":[{"content":{"parts":[{"text":"Hel"}]}}]}`,
+		``,
+		`data: {"candidates":[{"content":{"parts":[{"text":"lo"}]}}]}`,
+		``,
+		`data: {"candidates":[{"content":{"parts":[{"functionCall":{"id":"c1","name":"ping","args":{"a":1}},"thoughtSignature":"ts-1"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":9,"totalTokenCount":14}}`,
+		``,
+		``,
+	}, "\n")
+
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	usage, err := streamGeminiChat(strings.NewReader(raw), encoder)
+	if err != nil {
+		t.Fatalf("streamGeminiChat: %v", err)
+	}
+
+	var (
+		text          strings.Builder
+		argumentParts []string
+		signature     string
+		finish        string
+	)
+	for _, frame := range writer.frames(t) {
+		choices, _ := frame["choices"].([]any)
+		if len(choices) == 0 {
+			continue
+		}
+		choice, _ := choices[0].(map[string]any)
+		if reason, ok := choice["finish_reason"].(string); ok && reason != "" {
+			finish = reason
+		}
+		delta, _ := choice["delta"].(map[string]any)
+		if value, ok := delta["content"].(string); ok {
+			text.WriteString(value)
+		}
+		calls, ok := delta["tool_calls"].([]any)
+		if !ok {
+			continue
+		}
+		for _, item := range calls {
+			call, _ := item.(map[string]any)
+			if value, ok := call["thought_signature"].(string); ok {
+				signature = value
+			}
+			function, ok := call["function"].(map[string]any)
+			if !ok {
+				continue
+			}
+			if value, ok := function["arguments"].(string); ok && value != "" {
+				argumentParts = append(argumentParts, value)
+			}
+		}
+	}
+
+	if text.String() != "Hello" {
+		t.Fatalf("streamed text must concatenate, got %q", text.String())
+	}
+	if len(argumentParts) != 1 || argumentParts[0] != `{"a":1}` {
+		t.Fatalf("Gemini tool arguments must arrive as a single complete delta, got %v", argumentParts)
+	}
+	if signature != encodeProviderSignature(geminiSignatureProvider, "ts-1") {
+		t.Fatalf("thought signature must be tagged with its provider, got %q", signature)
+	}
+	if finish != "tool_calls" {
+		t.Fatalf("expected finish_reason tool_calls, got %q", finish)
+	}
+	if usage.PromptTokens != 5 || usage.CompletionTokens != 9 {
+		t.Fatalf("unexpected usage: %+v", usage)
+	}
+}
+
+func TestGeminiRequestReplaysToolCallIDAlongsideResponse(t *testing.T) {
+	payload := mustBuildGemini(t, ChatCompletionRequest{
+		Messages: []ChatMessage{
+			{Role: "assistant", ToolCalls: []any{
+				map[string]any{"id": "call_1", "function": map[string]any{"name": "ping", "arguments": "{}"}},
+			}},
+			{Role: "tool", ToolCallID: "call_1", Content: "pong"},
+		},
+	})
+	contents, _ := payload["contents"].([]map[string]any)
+	modelParts, _ := contents[0]["parts"].([]map[string]any)
+	call, _ := modelParts[0]["functionCall"].(map[string]any)
+	resultParts, _ := contents[1]["parts"].([]map[string]any)
+	response, _ := resultParts[0]["functionResponse"].(map[string]any)
+
+	// The response references the call by id; replaying the call without one
+	// leaves the result pointing at a call the provider cannot find.
+	if call["id"] != "call_1" {
+		t.Fatalf("the assistant tool call must keep its id: %v", call)
+	}
+	if response["id"] != call["id"] {
+		t.Fatalf("call and response ids must match: %v vs %v", call["id"], response["id"])
+	}
+}
+
+func TestGeminiToolSchemaSelectsFieldByComplexity(t *testing.T) {
+	simple := mustBuildGemini(t, ChatCompletionRequest{
+		Messages: []ChatMessage{{Role: "user", Content: "hi"}},
+		Tools: []any{map[string]any{"function": map[string]any{
+			"name":       "ping",
+			"parameters": map[string]any{"type": "object", "properties": map[string]any{"a": map[string]any{"type": "string"}}},
+		}}},
+	})
+	tools, _ := simple["tools"].([]map[string]any)
+	declarations, _ := tools[0]["functionDeclarations"].([]map[string]any)
+	if _, ok := declarations[0]["parameters"]; !ok {
+		t.Fatalf("a plain schema should use the OpenAPI parameters field: %v", declarations[0])
+	}
+
+	// $defs/$ref cannot be expressed by the OpenAPI Schema subset that the
+	// "parameters" field accepts, so a valid OpenAI tool would be rejected.
+	complex := mustBuildGemini(t, ChatCompletionRequest{
+		Messages: []ChatMessage{{Role: "user", Content: "hi"}},
+		Tools: []any{map[string]any{"function": map[string]any{
+			"name": "ping",
+			"parameters": map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"a": map[string]any{"$ref": "#/$defs/A"}},
+				"$defs":      map[string]any{"A": map[string]any{"type": "string"}},
+			},
+		}}},
+	})
+	tools, _ = complex["tools"].([]map[string]any)
+	declarations, _ = tools[0]["functionDeclarations"].([]map[string]any)
+	if _, ok := declarations[0]["parametersJsonSchema"]; !ok {
+		t.Fatalf("a JSON Schema construct must use parametersJsonSchema: %v", declarations[0])
+	}
+	if _, ok := declarations[0]["parameters"]; ok {
+		t.Fatalf("the two schema fields are mutually exclusive: %v", declarations[0])
+	}
+}
+
+func TestGeminiSchemaRoutingChecksValueShapes(t *testing.T) {
+	cases := []struct {
+		name      string
+		schema    map[string]any
+		needsJSON bool
+		rationale string
+	}{
+		{
+			name:      "plain object",
+			schema:    map[string]any{"type": "object", "properties": map[string]any{"a": map[string]any{"type": "string"}}},
+			needsJSON: false,
+			rationale: "a plain OpenAPI schema must not be pushed to the richer field",
+		},
+		{
+			name:      "type union",
+			schema:    map[string]any{"type": []any{"string", "null"}},
+			needsJSON: true,
+			rationale: "OpenAPI models type as a single value, not a union",
+		},
+		{
+			name:      "non-string enum",
+			schema:    map[string]any{"type": "integer", "enum": []any{float64(1), float64(2)}},
+			needsJSON: true,
+			rationale: "OpenAPI enum is a list of strings",
+		},
+		{
+			name:      "type union nested under properties",
+			schema:    map[string]any{"type": "object", "properties": map[string]any{"a": map[string]any{"type": []any{"string", "null"}}}},
+			needsJSON: true,
+			rationale: "nested schemas must be inspected too",
+		},
+		{
+			name:      "arbitrary example payload",
+			schema:    map[string]any{"type": "object", "example": map[string]any{"city": "Beijing"}},
+			needsJSON: false,
+			rationale: "annotation values hold data, not schema keywords",
+		},
+		{
+			name:      "nested items",
+			schema:    map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+			needsJSON: false,
+			rationale: "a simple array schema is expressible in OpenAPI",
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := schemaNeedsJSONSchema(testCase.schema); got != testCase.needsJSON {
+				t.Fatalf("%s: expected needsJSONSchema=%v, got %v", testCase.rationale, testCase.needsJSON, got)
+			}
+		})
+	}
+}
+
+func TestGeminiStreamRejectsTruncatedStream(t *testing.T) {
+	// Gemini leaves finishReason empty while generation is in progress.
+	raw := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hel\"}]}}]}\n\n"
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	if _, err := streamGeminiChat(strings.NewReader(raw), encoder); err == nil {
+		t.Fatalf("a stream that ends without a finish reason must be reported as truncated")
+	}
+	if strings.Contains(writer.builder.String(), "[DONE]") {
+		t.Fatalf("a truncated stream must not be presented to the client as complete")
+	}
+}
+
+func TestGeminiStreamRejectsEmptyStream(t *testing.T) {
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	if _, err := streamGeminiChat(strings.NewReader(""), encoder); err == nil {
+		t.Fatalf("a stream that closes before sending content must be an error")
+	}
+}
+
+func TestGeminiStreamSurfacesErrorPayload(t *testing.T) {
+	raw := "data: {\"error\":{\"message\":\"quota exhausted\"}}\n\n"
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+	if _, err := streamGeminiChat(strings.NewReader(raw), encoder); err == nil {
+		t.Fatalf("an error payload must surface as an error")
+	}
+	if strings.Contains(writer.builder.String(), "[DONE]") {
+		t.Fatalf("a failed stream must not emit the completion sentinel")
+	}
+}

--- a/backend/internal/server/provider_gemini_stream.go
+++ b/backend/internal/server/provider_gemini_stream.go
@@ -1,0 +1,160 @@
+package server
+
+import (
+	"fmt"
+	"io"
+)
+
+// geminiStreamDecoder translates Gemini's streamGenerateContent SSE output into
+// OpenAI chunk frames.
+//
+// Unlike Anthropic, Gemini does not stream partial tool arguments: each
+// functionCall part arrives as a complete JSON object. The arguments are
+// therefore emitted in a single delta rather than being reassembled.
+type geminiStreamDecoder struct {
+	encoder *openAIChatStreamEncoder
+
+	usage        map[string]any
+	finishReason string
+	sawCandidate bool
+	hasToolCalls bool
+	toolIndex    int
+}
+
+func newGeminiStreamDecoder(encoder *openAIChatStreamEncoder) *geminiStreamDecoder {
+	return &geminiStreamDecoder{encoder: encoder, usage: map[string]any{}}
+}
+
+// streamGeminiChat consumes the upstream SSE body and writes OpenAI chunks.
+func streamGeminiChat(body io.Reader, encoder *openAIChatStreamEncoder) (Usage, error) {
+	decoder := newGeminiStreamDecoder(encoder)
+	events := newSSEDecoder(body)
+	for {
+		event, err := events.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			encoder.Abort()
+			return decoder.currentUsage(), err
+		}
+		if err := decoder.consume(event); err != nil {
+			encoder.Abort()
+			return decoder.currentUsage(), err
+		}
+	}
+	usage := decoder.currentUsage()
+	if !decoder.sawCandidate {
+		encoder.Abort()
+		return usage, invalidProviderResponseError("provider closed the stream before sending any content")
+	}
+	if decoder.finishReason == "" {
+		// Gemini leaves finishReason empty while generation is still in
+		// progress. Reaching EOF without one means the connection dropped, and
+		// reporting a normal stop would hide the truncation from the client.
+		encoder.Abort()
+		return usage, invalidProviderResponseError("provider closed the stream before reporting a finish reason")
+	}
+	finishReason, err := geminiFinishReason(decoder.finishReason, decoder.hasToolCalls)
+	if err != nil {
+		encoder.Abort()
+		return usage, err
+	}
+	if err := encoder.Finalize(finishReason, usage); err != nil {
+		return usage, err
+	}
+	return usage, nil
+}
+
+func (d *geminiStreamDecoder) consume(event serverSentEvent) error {
+	payload, err := decodeSSEData(event)
+	if err != nil {
+		return err
+	}
+	if payload == nil {
+		return nil
+	}
+	if detail, ok := payload["error"].(map[string]any); ok {
+		message, _ := detail["message"].(string)
+		if message == "" {
+			message = "provider reported a stream error"
+		}
+		return NewHTTPError(502, "provider_stream_error", fmt.Sprintf("Gemini stream error: %s", message))
+	}
+	if usage, ok := payload["usageMetadata"].(map[string]any); ok {
+		// Gemini reports cumulative counters; keep the latest snapshot.
+		for key, value := range usage {
+			if value != nil {
+				d.usage[key] = value
+			}
+		}
+	}
+
+	candidates, _ := payload["candidates"].([]any)
+	if len(candidates) == 0 {
+		if reason := geminiPromptBlockReason(payload); reason != "" {
+			return NewHTTPError(400, "content_filter", fmt.Sprintf("Gemini blocked the prompt: %s", reason))
+		}
+		return nil
+	}
+	candidate, _ := candidates[0].(map[string]any)
+	if candidate == nil {
+		return nil
+	}
+	d.sawCandidate = true
+	if reason, ok := candidate["finishReason"].(string); ok && reason != "" {
+		d.finishReason = reason
+	}
+	if err := d.encoder.EmitRole(); err != nil {
+		return err
+	}
+
+	content, _ := candidate["content"].(map[string]any)
+	parts, _ := content["parts"].([]any)
+	for _, item := range parts {
+		part, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if err := d.consumePart(part); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *geminiStreamDecoder) consumePart(part map[string]any) error {
+	if call, ok := part["functionCall"].(map[string]any); ok {
+		name, _ := call["name"].(string)
+		id, _ := call["id"].(string)
+		slot := d.encoder.NextToolSlot()
+		if id == "" {
+			id = fmt.Sprintf("call_%s_%d", NewID("gemini"), slot)
+		}
+		d.hasToolCalls = true
+		d.toolIndex++
+		if err := d.encoder.EmitToolCallStart(slot, id, name); err != nil {
+			return err
+		}
+		if err := d.encoder.EmitToolCallArguments(slot, encodeToolCallArguments(call["args"])); err != nil {
+			return err
+		}
+		if signature, ok := part["thoughtSignature"].(string); ok && signature != "" {
+			return d.encoder.EmitToolCallSignature(slot, geminiSignatureProvider, signature)
+		}
+		return nil
+	}
+
+	text, _ := part["text"].(string)
+	if text == "" {
+		return nil
+	}
+	if thought, _ := part["thought"].(bool); thought {
+		return d.encoder.EmitReasoning(text)
+	}
+	return d.encoder.EmitText(text)
+}
+
+func (d *geminiStreamDecoder) currentUsage() Usage {
+	return geminiUsage(map[string]any{"usageMetadata": d.usage})
+}

--- a/backend/internal/server/provider_stream_adapter_test.go
+++ b/backend/internal/server/provider_stream_adapter_test.go
@@ -1,0 +1,211 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blockingWriter reports each frame as it is written so a test can prove the
+// stream is delivered incrementally rather than buffered until completion.
+type blockingWriter struct {
+	mu     sync.Mutex
+	frames []string
+	notify chan string
+}
+
+func newBlockingWriter() *blockingWriter {
+	return &blockingWriter{notify: make(chan string, 32)}
+}
+
+func (w *blockingWriter) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	w.frames = append(w.frames, string(data))
+	w.mu.Unlock()
+	w.notify <- string(data)
+	return len(data), nil
+}
+
+func (w *blockingWriter) Flush() {}
+
+func TestAnthropicAdapterStreamsIncrementally(t *testing.T) {
+	release := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode upstream request: %v", err)
+		}
+		if payload["stream"] != true {
+			t.Errorf("the adapter must ask the provider for a stream, got %v", payload["stream"])
+		}
+		w.Header().Set("content-type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+
+		io.WriteString(w, "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":4}}}\n\n")
+		io.WriteString(w, "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"first\"}}\n\n")
+		flusher.Flush()
+
+		// Hold the rest of the response back; the client must already have the
+		// first chunk. A buffered implementation would deadlock this test.
+		<-release
+
+		io.WriteString(w, "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"second\"}}\n\n")
+		io.WriteString(w, "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":6}}\n\n")
+		io.WriteString(w, "data: {\"type\":\"message_stop\"}\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	adapter := AnthropicAdapter{Client: upstream.Client()}
+	provider := Provider{BaseURL: upstream.URL, APIKey: "test-key"}
+	writer := newBlockingWriter()
+
+	var (
+		usage Usage
+		err   error
+		done  = make(chan struct{})
+	)
+	go func() {
+		defer close(done)
+		usage, err = adapter.ChatStream(context.Background(), provider, "claude-test",
+			ChatCompletionRequest{Model: "model-x", Messages: []ChatMessage{{Role: "user", Content: "hi"}}}, writer)
+	}()
+
+	// Wait for the first content frame to reach the writer while the upstream
+	// response is still open.
+	deadline := time.After(5 * time.Second)
+	sawFirst := false
+	for !sawFirst {
+		select {
+		case frame := <-writer.notify:
+			if strings.Contains(frame, "first") {
+				sawFirst = true
+			}
+		case <-deadline:
+			t.Fatalf("the first content chunk was not delivered before the upstream response completed")
+		}
+	}
+
+	close(release)
+	<-done
+
+	if err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+	if usage.PromptTokens != 4 || usage.CompletionTokens != 6 {
+		t.Fatalf("unexpected usage: %+v", usage)
+	}
+
+	writer.mu.Lock()
+	combined := strings.Join(writer.frames, "")
+	writer.mu.Unlock()
+	if !strings.HasSuffix(combined, "data: [DONE]\n\n") {
+		t.Fatalf("a completed stream must end with the [DONE] sentinel")
+	}
+}
+
+func TestGeminiAdapterStreamRequestTargetsSSEEndpoint(t *testing.T) {
+	var captured *http.Request
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Clone(r.Context())
+		w.Header().Set("content-type", "text/event-stream")
+		io.WriteString(w, "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hi\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":2,\"candidatesTokenCount\":3}}\n\n")
+	}))
+	defer upstream.Close()
+
+	adapter := GeminiAdapter{Client: upstream.Client()}
+	provider := Provider{BaseURL: upstream.URL, APIKey: "secret-key"}
+	writer := &recordingWriter{}
+
+	usage, err := adapter.ChatStream(context.Background(), provider, "gemini-test",
+		ChatCompletionRequest{Model: "model-x", Messages: []ChatMessage{{Role: "user", Content: "hi"}}}, writer)
+	if err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+
+	if captured == nil {
+		t.Fatalf("upstream never received a request")
+	}
+	query := captured.URL.Query()
+	// The action already carries a query string, so the API key has to be
+	// appended with the right separator or authentication silently breaks.
+	if query.Get("alt") != "sse" {
+		t.Fatalf("streaming must request the SSE transport, got %q", captured.URL.RawQuery)
+	}
+	if query.Get("key") != "secret-key" {
+		t.Fatalf("the API key must survive alongside the alt parameter, got %q", captured.URL.RawQuery)
+	}
+	if !strings.Contains(captured.URL.Path, ":streamGenerateContent") {
+		t.Fatalf("unexpected upstream path: %q", captured.URL.Path)
+	}
+	if usage.PromptTokens != 2 || usage.CompletionTokens != 3 {
+		t.Fatalf("unexpected usage: %+v", usage)
+	}
+}
+
+func TestAnthropicAdapterChatConvertsToolCalls(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		json.NewDecoder(r.Body).Decode(&payload)
+		if _, present := payload["tools"]; !present {
+			t.Errorf("tools must reach the provider, got %v", payload)
+		}
+		w.Header().Set("content-type", "application/json")
+		io.WriteString(w, `{"content":[{"type":"tool_use","id":"toolu_1","name":"ping","input":{"a":1}}],`+
+			`"stop_reason":"tool_use","usage":{"input_tokens":3,"output_tokens":5}}`)
+	}))
+	defer upstream.Close()
+
+	adapter := AnthropicAdapter{Client: upstream.Client()}
+	provider := Provider{BaseURL: upstream.URL, APIKey: "test-key"}
+
+	response, usage, err := adapter.Chat(context.Background(), provider, "claude-test", ChatCompletionRequest{
+		Model:    "model-x",
+		Messages: []ChatMessage{{Role: "user", Content: "hi"}},
+		Tools:    []any{map[string]any{"function": map[string]any{"name": "ping"}}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	body, _ := response.(map[string]any)
+	choices, _ := body["choices"].([]map[string]any)
+	message, _ := choices[0]["message"].(map[string]any)
+	if _, present := message["tool_calls"]; !present {
+		t.Fatalf("the provider tool_use block must surface as tool_calls: %v", message)
+	}
+	if usage.PromptTokens != 3 || usage.CompletionTokens != 5 {
+		t.Fatalf("unexpected usage: %+v", usage)
+	}
+}
+
+func TestAnthropicAdapterPropagatesUpstreamHTTPError(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		io.WriteString(w, `{"error":{"type":"rate_limit_error","message":"slow down"}}`)
+	}))
+	defer upstream.Close()
+
+	adapter := AnthropicAdapter{Client: upstream.Client()}
+	provider := Provider{BaseURL: upstream.URL, APIKey: "test-key"}
+	writer := &recordingWriter{}
+
+	_, err := adapter.ChatStream(context.Background(), provider, "claude-test",
+		ChatCompletionRequest{Model: "model-x", Messages: []ChatMessage{{Role: "user", Content: "hi"}}}, writer)
+	if err == nil {
+		t.Fatalf("expected the upstream error to propagate")
+	}
+	// Nothing was written, so the caller is still free to fail over to another route.
+	if writer.builder.Len() != 0 {
+		t.Fatalf("a pre-stream failure must not write anything to the client: %q", writer.builder.String())
+	}
+	if status := AsHTTPError(err).Status; status != http.StatusTooManyRequests {
+		t.Fatalf("expected the upstream status to be preserved, got %d", status)
+	}
+}

--- a/backend/internal/server/providers.go
+++ b/backend/internal/server/providers.go
@@ -165,6 +165,7 @@ type OpenAICompatibleAdapter struct {
 }
 
 func (a OpenAICompatibleAdapter) Chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
+	req = withoutGatewayExtensions(req)
 	req.Model = providerModel
 	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
 	var body map[string]any
@@ -175,6 +176,7 @@ func (a OpenAICompatibleAdapter) Chat(ctx context.Context, provider Provider, pr
 }
 
 func (a OpenAICompatibleAdapter) ChatStream(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest, w io.Writer) (Usage, error) {
+	req = withoutGatewayExtensions(req)
 	req.Model = providerModel
 	req.Stream = true
 	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
@@ -271,6 +273,7 @@ type AzureOpenAIAdapter struct {
 }
 
 func (a AzureOpenAIAdapter) Chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
+	req = withoutGatewayExtensions(req)
 	req.Model = providerModel
 	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
 	var body map[string]any
@@ -281,6 +284,7 @@ func (a AzureOpenAIAdapter) Chat(ctx context.Context, provider Provider, provide
 }
 
 func (a AzureOpenAIAdapter) ChatStream(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest, w io.Writer) (Usage, error) {
+	req = withoutGatewayExtensions(req)
 	req.Model = providerModel
 	req.Stream = true
 	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
@@ -354,42 +358,44 @@ type AnthropicAdapter struct {
 	Client *http.Client
 }
 
-func (a AnthropicAdapter) Chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
+func (a AnthropicAdapter) buildRequest(providerModel string, req ChatCompletionRequest) (map[string]any, error) {
 	reasoningEffort := normalizedReasoningEffort(req.ReasoningEffort)
 	if reasoningEffort != nil && !anthropicReasoningEffortSupported(providerModel, *reasoningEffort) {
 		reasoningEffort = nil
 	}
-	payload := anthropicPayload(providerModel, req.Messages, req.MaxTokens, reasoningEffort)
+	return buildAnthropicRequest(providerModel, req, reasoningEffort)
+}
+
+func (a AnthropicAdapter) Chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
+	payload, err := a.buildRequest(providerModel, req)
+	if err != nil {
+		return nil, Usage{}, err
+	}
 	var body map[string]any
 	if err := a.doJSON(ctx, provider, "/v1/messages", payload, &body); err != nil {
 		return nil, Usage{}, err
 	}
-	text := anthropicText(body)
 	usage := anthropicUsage(body)
-	return chatResponse(req.Model, text, usage), usage, nil
+	converted, err := anthropicChatResponse(body, req.Model, usage)
+	if err != nil {
+		return nil, usage, err
+	}
+	return converted, usage, nil
 }
 
 func (a AnthropicAdapter) ChatStream(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest, w io.Writer) (Usage, error) {
-	resp, usage, err := a.Chat(ctx, provider, providerModel, req)
+	payload, err := a.buildRequest(providerModel, req)
 	if err != nil {
 		return Usage{}, err
 	}
-	text := ""
-	if asMap, ok := resp.(map[string]any); ok {
-		text = choiceText(asMap)
-	}
-	payload, _ := json.Marshal(map[string]any{
-		"id":      NewID("chatcmpl"),
-		"object":  "chat.completion.chunk",
-		"created": time.Now().Unix(),
-		"model":   req.Model,
-		"choices": []map[string]any{{"index": 0, "delta": map[string]any{"content": text}, "finish_reason": nil}},
-	})
-	if _, err := fmt.Fprintf(w, "data: %s\n\n", payload); err != nil {
+	payload["stream"] = true
+	resp, err := a.doRaw(ctx, provider, "/v1/messages", payload)
+	if err != nil {
 		return Usage{}, err
 	}
-	_, err = io.WriteString(w, "data: [DONE]\n\n")
-	return usage, err
+	defer resp.Body.Close()
+	encoder := newOpenAIChatStreamEncoder(w, req.Model, streamUsageRequested(req))
+	return streamAnthropicChat(resp.Body, encoder)
 }
 
 func (a AnthropicAdapter) Responses(ctx context.Context, provider Provider, providerModel string, req ResponsesRequest) (any, Usage, error) {
@@ -415,16 +421,25 @@ func (a AnthropicAdapter) Embeddings(ctx context.Context, provider Provider, pro
 }
 
 func (a AnthropicAdapter) doJSON(ctx context.Context, provider Provider, endpoint string, payload any, target any) error {
+	resp, err := a.doRaw(ctx, provider, endpoint, payload)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+func (a AnthropicAdapter) doRaw(ctx context.Context, provider Provider, endpoint string, payload any) (*http.Response, error) {
 	if provider.BaseURL == "" {
 		provider.BaseURL = "https://api.anthropic.com"
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(provider.BaseURL, "/")+endpoint, bytes.NewReader(body))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	version := provider.Options["anthropic_version"]
 	if version == "" {
@@ -439,14 +454,14 @@ func (a AnthropicAdapter) doJSON(ctx context.Context, provider Provider, endpoin
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
+		defer resp.Body.Close()
 		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return newProviderHTTPError(resp.StatusCode, data)
+		return nil, newProviderHTTPError(resp.StatusCode, data)
 	}
-	return json.NewDecoder(resp.Body).Decode(target)
+	return resp, nil
 }
 
 type GeminiAdapter struct {
@@ -454,37 +469,34 @@ type GeminiAdapter struct {
 }
 
 func (a GeminiAdapter) Chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
-	payload := geminiPayload(req.Messages, req.MaxTokens, providerModel, req.ReasoningEffort)
+	payload, err := buildGeminiRequest(providerModel, req)
+	if err != nil {
+		return nil, Usage{}, err
+	}
 	var body map[string]any
 	if err := a.doJSON(ctx, provider, providerModel, ":generateContent", payload, &body); err != nil {
 		return nil, Usage{}, err
 	}
-	text := geminiText(body)
 	usage := geminiUsage(body)
-	return chatResponse(req.Model, text, usage), usage, nil
+	converted, err := geminiChatResponse(body, req.Model, usage)
+	if err != nil {
+		return nil, usage, err
+	}
+	return converted, usage, nil
 }
 
 func (a GeminiAdapter) ChatStream(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest, w io.Writer) (Usage, error) {
-	resp, usage, err := a.Chat(ctx, provider, providerModel, req)
+	payload, err := buildGeminiRequest(providerModel, req)
 	if err != nil {
 		return Usage{}, err
 	}
-	text := ""
-	if asMap, ok := resp.(map[string]any); ok {
-		text = choiceText(asMap)
-	}
-	payload, _ := json.Marshal(map[string]any{
-		"id":      NewID("chatcmpl"),
-		"object":  "chat.completion.chunk",
-		"created": time.Now().Unix(),
-		"model":   req.Model,
-		"choices": []map[string]any{{"index": 0, "delta": map[string]any{"content": text}, "finish_reason": nil}},
-	})
-	if _, err := fmt.Fprintf(w, "data: %s\n\n", payload); err != nil {
+	resp, err := a.doRaw(ctx, provider, providerModel, ":streamGenerateContent?alt=sse", payload)
+	if err != nil {
 		return Usage{}, err
 	}
-	_, err = io.WriteString(w, "data: [DONE]\n\n")
-	return usage, err
+	defer resp.Body.Close()
+	encoder := newOpenAIChatStreamEncoder(w, req.Model, streamUsageRequested(req))
+	return streamGeminiChat(resp.Body, encoder)
 }
 
 func (a GeminiAdapter) Responses(ctx context.Context, provider Provider, providerModel string, req ResponsesRequest) (any, Usage, error) {
@@ -534,17 +546,39 @@ func (a GeminiAdapter) Embeddings(ctx context.Context, provider Provider, provid
 }
 
 func (a GeminiAdapter) doJSON(ctx context.Context, provider Provider, model string, action string, payload any, target any) error {
+	resp, err := a.doRaw(ctx, provider, model, action, payload)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+// doRaw issues a Gemini request. The action may already carry a query string
+// (streaming uses ":streamGenerateContent?alt=sse"), so the API key separator is
+// chosen accordingly.
+func (a GeminiAdapter) doRaw(ctx context.Context, provider Provider, model string, action string, payload any) (*http.Response, error) {
 	if provider.BaseURL == "" {
 		provider.BaseURL = "https://generativelanguage.googleapis.com/v1beta"
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	u := fmt.Sprintf("%s/models/%s%s?key=%s", strings.TrimRight(provider.BaseURL, "/"), url.PathEscape(model), action, url.QueryEscape(provider.APIKey))
+	separator := "?"
+	if strings.Contains(action, "?") {
+		separator = "&"
+	}
+	u := fmt.Sprintf("%s/models/%s%s%skey=%s",
+		strings.TrimRight(provider.BaseURL, "/"),
+		url.PathEscape(model),
+		action,
+		separator,
+		url.QueryEscape(provider.APIKey),
+	)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	req.Header.Set("content-type", "application/json")
 	client := a.Client
@@ -553,77 +587,14 @@ func (a GeminiAdapter) doJSON(ctx context.Context, provider Provider, model stri
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
+		defer resp.Body.Close()
 		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return newProviderHTTPError(resp.StatusCode, data)
+		return nil, newProviderHTTPError(resp.StatusCode, data)
 	}
-	return json.NewDecoder(resp.Body).Decode(target)
-}
-
-func anthropicPayload(model string, messages []ChatMessage, maxTokens int, reasoningEffort *string) map[string]any {
-	if maxTokens <= 0 {
-		maxTokens = 1024
-	}
-	system := []string{}
-	converted := []map[string]any{}
-	for _, message := range messages {
-		if message.Role == "system" {
-			system = append(system, contentToText(message.Content))
-			continue
-		}
-		role := message.Role
-		if role == "assistant" {
-			role = "assistant"
-		} else {
-			role = "user"
-		}
-		converted = append(converted, map[string]any{"role": role, "content": contentToText(message.Content)})
-	}
-	payload := map[string]any{
-		"model":      model,
-		"max_tokens": maxTokens,
-		"messages":   converted,
-	}
-	if len(system) > 0 {
-		payload["system"] = strings.Join(system, "\n")
-	}
-	if reasoningEffort != nil {
-		payload["output_config"] = map[string]any{"effort": *reasoningEffort}
-	}
-	return payload
-}
-
-func geminiPayload(messages []ChatMessage, maxTokens int, model string, reasoningEffort *string) map[string]any {
-	contents := []map[string]any{}
-	for _, message := range messages {
-		role := "user"
-		if message.Role == "assistant" {
-			role = "model"
-		}
-		if message.Role == "system" {
-			contents = append(contents, map[string]any{"role": "user", "parts": []map[string]any{{"text": contentToText(message.Content)}}})
-			continue
-		}
-		contents = append(contents, map[string]any{"role": role, "parts": []map[string]any{{"text": contentToText(message.Content)}}})
-	}
-	payload := map[string]any{"contents": contents}
-	generationConfig := map[string]any{}
-	if maxTokens > 0 {
-		generationConfig["maxOutputTokens"] = maxTokens
-	}
-	if effort := normalizedReasoningEffort(reasoningEffort); effort != nil {
-		thinkingConfig, supported := geminiThinkingConfig(model, *effort)
-		if supported {
-			generationConfig["thinkingConfig"] = thinkingConfig
-		}
-	}
-	if len(generationConfig) > 0 {
-		payload["generationConfig"] = generationConfig
-	}
-	return payload
+	return resp, nil
 }
 
 func responsesReasoningEffort(req ResponsesRequest) *string {
@@ -837,21 +808,6 @@ func geminiVariantIs(variant string, family string) bool {
 	return variant == family || strings.HasPrefix(variant, family+"-")
 }
 
-func anthropicText(body map[string]any) string {
-	content, _ := body["content"].([]any)
-	parts := []string{}
-	for _, item := range content {
-		asMap, ok := item.(map[string]any)
-		if !ok {
-			continue
-		}
-		if text, ok := asMap["text"].(string); ok {
-			parts = append(parts, text)
-		}
-	}
-	return strings.Join(parts, "")
-}
-
 func anthropicUsage(body map[string]any) Usage {
 	usageMap, _ := body["usage"].(map[string]any)
 	uncachedInputTokens := int64FromAny(usageMap["input_tokens"])
@@ -864,27 +820,6 @@ func anthropicUsage(body map[string]any) Usage {
 	}
 	usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
 	return usage
-}
-
-func geminiText(body map[string]any) string {
-	candidates, _ := body["candidates"].([]any)
-	if len(candidates) == 0 {
-		return ""
-	}
-	candidate, _ := candidates[0].(map[string]any)
-	content, _ := candidate["content"].(map[string]any)
-	parts, _ := content["parts"].([]any)
-	text := []string{}
-	for _, part := range parts {
-		asMap, ok := part.(map[string]any)
-		if !ok {
-			continue
-		}
-		if value, ok := asMap["text"].(string); ok {
-			text = append(text, value)
-		}
-	}
-	return strings.Join(text, "")
 }
 
 func geminiUsage(body map[string]any) Usage {
@@ -975,23 +910,6 @@ func usageFromServerSentEvent(line string) (Usage, bool) {
 		return Usage{}, false
 	}
 	return usageFromMap(event), true
-}
-
-func chatResponse(model string, text string, usage Usage) map[string]any {
-	return map[string]any{
-		"id":      NewID("chatcmpl"),
-		"object":  "chat.completion",
-		"created": time.Now().Unix(),
-		"model":   model,
-		"choices": []map[string]any{
-			{
-				"index":         0,
-				"message":       map[string]any{"role": "assistant", "content": text},
-				"finish_reason": "stop",
-			},
-		},
-		"usage": usage,
-	}
 }
 
 func responseObject(model string, text string, usage Usage) map[string]any {

--- a/backend/internal/server/types.go
+++ b/backend/internal/server/types.go
@@ -532,6 +532,20 @@ type ChatMessage struct {
 	Name       string `json:"name,omitempty"`
 	ToolCallID string `json:"tool_call_id,omitempty"`
 	ToolCalls  any    `json:"tool_calls,omitempty"`
+
+	// The OpenAI Chat Completions schema has no field for a provider's chain of
+	// thought, so the fields below are TokenHub extensions. ReasoningContent
+	// follows the convention DeepSeek introduced; the signature fields carry the
+	// opaque continuation blobs Anthropic and Gemini require to be echoed back
+	// verbatim on the next turn of a multi-step tool exchange.
+	//
+	// Signatures are prefixed with the provider that minted them so one
+	// provider's blob is never replayed to another. A missing or foreign
+	// signature degrades to dropping the reasoning block rather than failing the
+	// request.
+	ReasoningContent         string `json:"reasoning_content,omitempty"`
+	ReasoningSignature       string `json:"reasoning_signature,omitempty"`
+	RedactedReasoningContent string `json:"redacted_reasoning_content,omitempty"`
 }
 
 type ReasoningOptions = ResponsesReasoning

--- a/docs/ja/user-guide.md
+++ b/docs/ja/user-guide.md
@@ -117,6 +117,33 @@ TokenHub は推論強度をベストエフォートのヒントとして扱い�
 
 Responses の推論強度は OpenAI 互換、Anthropic、Gemini の各ルートで利用できます。Azure OpenAI Responses と Responses のストリーミングは未実装で、`501 provider_capability_not_supported` を返します。
 
+## Anthropic および Gemini ルートでのツール呼び出しとマルチモーダル入力
+
+ネイティブの Anthropic または Gemini プロバイダーへルーティングされる Chat Completions リクエストでは、プレーンテキストだけでなくリクエストとレスポンスの全体が変換されます。
+
+| 機能 | Anthropic | Gemini |
+| --- | --- | --- |
+| `tools` と `tool_choice` | 対応 | 対応 |
+| Assistant の `tool_calls` と `role: "tool"` の結果 | 対応 | 対応 |
+| `parallel_tool_calls: false` | 対応 | `501 provider_capability_not_supported` |
+| 画像コンテンツパート | `http(s)` URL と base64 data URI | base64 data URI のみ |
+| ストリーミング | 逐次中継 | 逐次中継 |
+
+ストリーミングは上流のイベントを到着順に中継するため、最初のトークンまでの時間はレスポンス全体ではなくプロバイダーの応答速度を反映します。これらのルートで表現できないコンテンツ種別（音声パートなど）は破棄されず `400 unsupported_content_block` を返します。
+
+### 推論の継続
+
+Anthropic と Gemini では、複数ステップのツール呼び出しにおいて、推論ステップに付随する不透明な署名を次のターンでそのまま返す必要があります。OpenAI Chat Completions のスキーマには該当するフィールドがないため、TokenHub は拡張フィールドで返します。
+
+| フィールド | 対応するプロバイダーのデータ |
+| --- | --- |
+| `message.reasoning_content` | Anthropic の `thinking` テキスト、Gemini の thought パート |
+| `message.reasoning_signature` | Anthropic の `thinking.signature` |
+| `message.redacted_reasoning_content` | Anthropic の `redacted_thinking.data` |
+| `message.tool_calls[].thought_signature` | Gemini の `thoughtSignature` |
+
+次のリクエストの assistant メッセージでこれらのフィールドをそのまま返すと、推論の連続性が保たれます。これらを無視するクライアントでも動作します。TokenHub はプロバイダーが拒否する署名を送り返すのではなく、推論ブロックを省略します。署名には発行元プロバイダーの識別子が付与され、別のプロバイダーへ送られることはありません。
+
 ## Anthropic Messages と Claude Code
 
 TokenHub は Claude Code と Anthropic 互換クライアント向けに `POST /v1/messages` と `POST /v1/messages/count_tokens` を提供します。Project Key は Bearer Token として送信します。

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -117,6 +117,33 @@ TokenHub treats reasoning effort as a best-effort hint and does not change route
 
 Responses reasoning effort is supported on OpenAI-compatible, Anthropic, and Gemini routes. Azure OpenAI Responses and streaming Responses are not implemented; those requests return `501 provider_capability_not_supported`.
 
+## Tool calling and multimodal content on Anthropic and Gemini routes
+
+Chat Completions requests routed to a native Anthropic or Gemini provider translate the whole request and response, not only plain text.
+
+| Capability | Anthropic | Gemini |
+| --- | --- | --- |
+| `tools` and `tool_choice` | Supported | Supported |
+| Assistant `tool_calls` and `role: "tool"` results | Supported | Supported |
+| `parallel_tool_calls: false` | Supported | `501 provider_capability_not_supported` |
+| Image content parts | `http(s)` URLs and base64 data URIs | Base64 data URIs only |
+| Streaming | Incremental relay | Incremental relay |
+
+Streaming forwards upstream events as they arrive, so time to first token reflects the provider rather than the full response. Content types these routes cannot represent, such as audio parts, return `400 unsupported_content_block` instead of being dropped from the request.
+
+### Reasoning continuation
+
+Anthropic and Gemini require the opaque signature attached to a reasoning step to be echoed back verbatim on the next turn of a multi-step tool exchange. The OpenAI Chat Completions schema has no field for it, so TokenHub returns the data in extension fields:
+
+| Field | Provider data |
+| --- | --- |
+| `message.reasoning_content` | Anthropic `thinking` text, Gemini thought parts |
+| `message.reasoning_signature` | Anthropic `thinking.signature` |
+| `message.redacted_reasoning_content` | Anthropic `redacted_thinking.data` |
+| `message.tool_calls[].thought_signature` | Gemini `thoughtSignature` |
+
+Echo these fields on the assistant message of the following request to preserve reasoning continuity. Clients that ignore them still work: TokenHub omits the reasoning block rather than replaying a signature the provider would reject. Signatures are tagged with the provider that issued them and are never replayed to a different provider.
+
 ## Anthropic Messages and Claude Code
 
 TokenHub exposes `POST /v1/messages` and `POST /v1/messages/count_tokens` for Claude Code and Anthropic-compatible clients. Use a project key as a bearer token:

--- a/docs/zh-CN/user-guide.md
+++ b/docs/zh-CN/user-guide.md
@@ -117,6 +117,33 @@ TokenHub 将推理强度作为尽力应用的提示字段，不改变路由顺�
 
 Responses 推理强度支持 OpenAI 兼容、Anthropic 和 Gemini 路由。Azure OpenAI Responses 与 Responses 流式响应尚未实现，此类请求返回 `501 provider_capability_not_supported`。
 
+## Anthropic 与 Gemini 路由的工具调用与多模态内容
+
+Chat Completions 请求路由到原生 Anthropic 或 Gemini 供应商时，会完整转换请求与响应，而不仅是纯文本。
+
+| 能力 | Anthropic | Gemini |
+| --- | --- | --- |
+| `tools` 与 `tool_choice` | 支持 | 支持 |
+| Assistant `tool_calls` 与 `role: "tool"` 结果 | 支持 | 支持 |
+| `parallel_tool_calls: false` | 支持 | `501 provider_capability_not_supported` |
+| 图片内容块 | `http(s)` URL 与 base64 data URI | 仅 base64 data URI |
+| 流式 | 增量转发 | 增量转发 |
+
+流式按上游事件到达顺序逐条转发，因此首字延迟取决于供应商而非完整响应。这些路由无法表达的内容类型（例如音频块）返回 `400 unsupported_content_block`，不会被静默丢弃。
+
+### 推理连续性
+
+Anthropic 与 Gemini 要求在多轮工具调用的下一轮中，原样回传推理步骤附带的 opaque 签名。OpenAI Chat Completions 规范没有对应字段，因此 TokenHub 通过扩展字段返回：
+
+| 字段 | 对应供应商数据 |
+| --- | --- |
+| `message.reasoning_content` | Anthropic `thinking` 文本、Gemini thought 片段 |
+| `message.reasoning_signature` | Anthropic `thinking.signature` |
+| `message.redacted_reasoning_content` | Anthropic `redacted_thinking.data` |
+| `message.tool_calls[].thought_signature` | Gemini `thoughtSignature` |
+
+在后续请求的 assistant 消息中回传这些字段即可保持推理连续性。忽略这些字段的客户端同样可用：TokenHub 会省略推理块，而不会回传供应商将拒绝的签名。签名带有签发供应商的标记，绝不会被回传给其他供应商。
+
 ## Anthropic Messages 与 Claude Code
 
 TokenHub 提供 `POST /v1/messages` 和 `POST /v1/messages/count_tokens`，供 Claude Code 与 Anthropic 兼容客户端调用。项目 Key 通过 Bearer Token 发送：


### PR DESCRIPTION
## Summary

Chat Completions requests routed to a native Anthropic or Gemini provider only carried plain text, which left those routes unusable for any agent workload. Two defects caused it:

- **Tools were silently dropped.** `ChatCompletionRequest` already carried `Tools`, `ToolChoice` and `ParallelToolCalls`, but `anthropicPayload()` and `geminiPayload()` only assembled role and text (`grep -c 'Tools' providers.go` returned 0). A request with tools came back as a plausible text answer instead of a tool call — a silent semantic corruption rather than a visible failure.
- **`ChatStream` was not streaming.** It called the non-streaming path and wrapped the finished text in a single chunk, so time to first token equalled the full response time, while the registry still advertised `AdapterCapabilityChatStream`.

Response parsing was equally lossy: `anthropicText()` and `geminiText()` extracted only text, discarding `tool_use`, `functionCall`, thinking blocks and stop-reason detail.

## Related Issue

N/A

## Changes

- **Tool calling, both directions.** Tool definitions, `tool_choice`, assistant `tool_calls` and tool results, honouring each wire format's ordering rules (Anthropic requires tool results in a single user turn immediately after the assistant turn). `tool_choice: "none"` keeps the tool definitions on Anthropic: dropping them would change the tool system prompt, token usage and prompt-cache prefix.
- **Genuine incremental streaming.** A shared OpenAI chunk encoder (`chat_stream_encoder.go`) with per-provider decoders owning their event state machines. Every frame is flushed — without that `net/http` buffers the response and the relay is incremental in name only. Provider block indexes are mapped to dense OpenAI `tool_calls` indexes, since Anthropic interleaves thinking and text blocks with tool blocks.
- **Image content parts.** `http(s)` URLs and base64 data URIs for Anthropic; inline data for Gemini, which cannot forward arbitrary remote URLs. Content neither route can represent is rejected with `400 unsupported_content_block` instead of being dropped.
- **Gemini `systemInstruction` fix.** System messages were disguised as a user turn, which changes how the model weighs them. They now map to the top-level `systemInstruction`.
- **Reasoning continuation.** Anthropic and Gemini require the opaque signature attached to a reasoning step to be echoed back verbatim on the next turn of a multi-step tool exchange, and the OpenAI schema has no field for it. It travels through extension fields (`reasoning_content`, `reasoning_signature`, `redacted_reasoning_content`, `tool_calls[].thought_signature`) tagged with the issuing provider. A missing or foreign signature drops the reasoning block rather than replaying one the provider would reject, so clients that ignore the fields keep working.
- **Extension fields are stripped before OpenAI-compatible upstreams.** Adding them to `ChatMessage` made previously-discarded client input forwardable; strict OpenAI implementations reject unknown message fields.
- **Errors are no longer flattened into success.** Unrecognized stop reasons, Gemini protocol failures (`MALFORMED_FUNCTION_CALL` and similar), and streams ending before their terminal event now surface as upstream errors instead of a normal completion. Gemini safety reasons map to `content_filter`.
- Removed five superseded functions (`anthropicPayload`, `geminiPayload`, `anthropicText`, `geminiText`, `chatResponse`).
- User guide updated in English, Simplified Chinese and Japanese.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor or maintenance
- [x] Documentation
- [ ] Deployment or configuration

## Verification

- [x] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [ ] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- `gofmt -l` clean, `go vet ./...` clean, `go test ./...` passing.
- ~60 new test cases covering both providers: tool mapping and ordering, dense tool indexes across interleaved blocks, fragmented `input_json_delta` reassembly, cumulative usage snapshots (overwrite, not sum), SSE framing variants (CRLF, comments, multi-line `data`, events beyond the 64 KiB `bufio.Scanner` ceiling, unterminated events), truncated streams, malformed block indexes, and the full stop-reason / finish-reason tables.
- An adapter-level test proves the relay is incremental: the fake upstream withholds the second half of its response until the client has received the first frame, so a buffered implementation deadlocks instead of passing.
- Frontend untouched, so its checks were not run.
- **SDK smoke tests were not run**: they need live provider credentials that were not available.
- **The Anthropic and Gemini wire-protocol assumptions are covered only by in-process fixtures written from the vendor documentation.** No native Anthropic or Gemini endpoint was available, so assumptions such as `parametersJsonSchema` being accepted, `thoughtSignature` replay being accepted, and streaming `functionCall.args` arriving as one complete object remain unverified against a real provider. These are the highest-risk items in this change, since their failure mode is a rejected request rather than a degraded one.
- The OpenAI-compatible path — the gateway's main route — was regression-tested against a live upstream. That run is what surfaced the extension-field forwarding defect fixed here.
- Design and implementation were reviewed with an external model across five rounds; four P1 and six P2 findings were raised and all were fixed. Two of those findings were false-positive assertions in the new tests (a table test that had frozen an incorrect `pause_turn` mapping, and a size-limit test that only asserted the final error), which were corrected.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: request and response shapes are unchanged, but behaviour changes in four intentional ways. Requests carrying tools that previously returned plain text now return `tool_calls`. Non-image modalities that were previously dropped now return `400 unsupported_content_block`. `parallel_tool_calls: false` on Gemini now returns `501 provider_capability_not_supported` instead of being silently ignored. Gemini system messages move to `systemInstruction`, which slightly changes model behaviour for existing requests. These are corrections of silent data loss and warrant a release note.
- Security or credential-handling impact: none. Tool schemas and arguments follow the existing audit redaction path, no new log points were added, and upstream error bodies keep the existing 4096-byte truncation. A new 8 MiB per-event ceiling bounds SSE memory use; the read is chunked so the limit trips while reading rather than after a full line has been allocated.
- Database, environment, or deployment impact: none. No schema, migration, or environment variable changes.
- Rollout and rollback considerations: contained to the provider adapters and new files; rollback is a revert. Given the unverified wire-protocol assumptions above, staging these routes behind a per-provider rollout and watching for `400`s from Anthropic and Gemini is advisable before broad enablement.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable. (No environment variables changed.)
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable. (Catalog untouched.)
- [x] `git diff --check` passes.
