### PR TITLE
fix(gateway): harden provider compatibility handling

### DIFF
--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -3408,10 +3408,17 @@ func (s *Server) providerFromCreateRequest(ctx context.Context, req ProviderCrea
 		BaseURL:  firstNonEmpty(req.BaseURL, catalog.BaseURL),
 		APIKey:   req.APIKey,
 		Status:   firstNonEmpty(req.Status, StatusActive),
-		Healthy:  req.Healthy,
+		Healthy:  req.Healthy != nil && *req.Healthy,
 		Priority: req.Priority,
 		Headers:  req.Headers,
 		Options:  req.Options,
+	}
+	if _, ok := s.adapterRegistry.Describe(provider.Type); !ok {
+		return Provider{}, ProviderCatalogEntry{}, catalogSource, NewHTTPError(
+			http.StatusBadRequest,
+			"provider_adapter_missing",
+			fmt.Sprintf("Provider adapter type %q is not registered", provider.Type),
+		)
 	}
 	if provider.Priority == 0 {
 		provider.Priority = 10
@@ -3633,6 +3640,12 @@ func (s *Server) handleAdminProviderNested(w http.ResponseWriter, r *http.Reques
 				writeError(w, r, NewHTTPError(400, "invalid_request", err.Error()))
 				return
 			}
+			current, ok := s.store.GetProvider(parts[0])
+			if !ok {
+				writeError(w, r, NewHTTPError(http.StatusNotFound, "provider_not_found", "Provider not found"))
+				return
+			}
+			mergeProviderPatchRequest(&req, current)
 			provider, catalog, catalogSource, err := s.providerFromCreateRequest(r.Context(), req)
 			if err != nil {
 				writeError(w, r, err)
@@ -3726,6 +3739,34 @@ func (s *Server) handleAdminProviderResources(w http.ResponseWriter, r *http.Req
 		writeJSON(w, http.StatusCreated, resource)
 	default:
 		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
+	}
+}
+
+func mergeProviderPatchRequest(req *ProviderCreateRequest, current Provider) {
+	if req.Name == "" {
+		req.Name = current.Name
+	}
+	if req.Type == "" {
+		req.Type = current.Type
+	}
+	if req.BaseURL == "" {
+		req.BaseURL = current.BaseURL
+	}
+	if req.Status == "" {
+		req.Status = current.Status
+	}
+	if req.Healthy == nil {
+		healthy := current.Healthy
+		req.Healthy = &healthy
+	}
+	if req.Priority == 0 {
+		req.Priority = current.Priority
+	}
+	if req.Headers == nil {
+		req.Headers = current.Headers
+	}
+	if req.Options == nil {
+		req.Options = current.Options
 	}
 }
 
@@ -7155,9 +7196,27 @@ func bearerToken(r *http.Request) string {
 
 func decodeJSON(r *http.Request, target any) error {
 	defer r.Body.Close()
-	decoder := json.NewDecoder(io.LimitReader(r.Body, 4<<20))
+	const maxRequestBodyBytes = 4 << 20
+	data, err := io.ReadAll(io.LimitReader(r.Body, maxRequestBodyBytes+1))
+	if err != nil {
+		return err
+	}
+	if len(data) > maxRequestBodyBytes {
+		return fmt.Errorf("request body exceeds %d bytes", maxRequestBodyBytes)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.UseNumber()
-	return decoder.Decode(target)
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return errors.New("request body must contain a single JSON value")
+		}
+		return err
+	}
+	return nil
 }
 
 func writeJSON(w http.ResponseWriter, status int, value any) {

--- a/backend/internal/server/http_test.go
+++ b/backend/internal/server/http_test.go
@@ -82,6 +82,28 @@ func TestGatewayModelsAndChatCompletion(t *testing.T) {
 	}
 }
 
+func TestGatewayRejectsTrailingJSONValue(t *testing.T) {
+	app := newTestServer()
+	body := `{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"hello"}]}{"extra":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("authorization", "Bearer thk_demo_local")
+	resp := httptest.NewRecorder()
+	app.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for concatenated JSON values, got %d: %s", resp.Code, resp.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode gateway error: %v", err)
+	}
+	errorBody, _ := payload["error"].(map[string]any)
+	if errorBody["code"] != "invalid_request" {
+		t.Fatalf("expected invalid_request, got %#v", payload)
+	}
+}
+
 func TestGatewayModelsExposeJieKouCompatibleFields(t *testing.T) {
 	app := newTestServer()
 
@@ -2873,6 +2895,57 @@ func TestAdminCreatesProviderModelAndRoute(t *testing.T) {
 	}
 	if !strings.Contains(routes.Body, "local-coder") || !strings.Contains(routes.Body, "qwen2.5-coder") {
 		t.Fatalf("expected new route in list: %s", routes.Body)
+	}
+}
+
+func TestAdminProviderConfigurationFailsEarlyAndPatchPreservesFields(t *testing.T) {
+	app := newTestServer()
+
+	invalid := doJSON(t, app, http.MethodPost, "/api/admin/providers", map[string]any{
+		"name":     "Invalid Adapter",
+		"type":     "openai-compatible",
+		"base_url": "https://example.invalid/v1",
+		"healthy":  true,
+	}, "")
+	if invalid.Code != http.StatusBadRequest || !strings.Contains(invalid.Body, `"code":"provider_adapter_missing"`) {
+		t.Fatalf("expected unknown adapter to fail during creation, got %d: %s", invalid.Code, invalid.Body)
+	}
+
+	created := doJSON(t, app, http.MethodPost, "/api/admin/providers", map[string]any{
+		"id":       "prv_patch_preserve",
+		"name":     "Patch Preserve",
+		"type":     ProviderOpenAICompatible,
+		"base_url": "https://example.invalid/v1",
+		"status":   StatusActive,
+		"healthy":  true,
+		"priority": 7,
+		"headers":  map[string]string{"x-provider": "preserved"},
+		"options":  map[string]string{"region": "test"},
+	}, "")
+	if created.Code != http.StatusCreated {
+		t.Fatalf("expected provider creation, got %d: %s", created.Code, created.Body)
+	}
+
+	updated := doJSON(t, app, http.MethodPatch, "/api/admin/providers/prv_patch_preserve", map[string]any{
+		"type": "deepseek",
+	}, "")
+	if updated.Code != http.StatusOK {
+		t.Fatalf("expected partial provider patch, got %d: %s", updated.Code, updated.Body)
+	}
+	var result ProviderCreateResult
+	if err := json.Unmarshal([]byte(updated.Body), &result); err != nil {
+		t.Fatal(err)
+	}
+	provider := result.Provider
+	if provider.Type != "deepseek" ||
+		provider.Name != "Patch Preserve" ||
+		provider.BaseURL != "https://example.invalid/v1" ||
+		provider.Status != StatusActive ||
+		!provider.Healthy ||
+		provider.Priority != 7 ||
+		provider.Headers["x-provider"] != "preserved" ||
+		provider.Options["region"] != "test" {
+		t.Fatalf("partial patch erased provider fields: %+v", provider)
 	}
 }
 

--- a/backend/internal/server/provider_chat_convert.go
+++ b/backend/internal/server/provider_chat_convert.go
@@ -325,17 +325,21 @@ const (
 	geminiSignatureProvider    = "gemini"
 )
 
-// withoutGatewayExtensions strips the TokenHub-only reasoning fields from a
-// request before it is forwarded verbatim to an OpenAI-compatible upstream.
+// withoutGatewayExtensions strips TokenHub-only reasoning fields before a
+// request is forwarded to an OpenAI-shaped upstream.
 //
-// These fields exist to carry Anthropic and Gemini continuation data across the
-// OpenAI-shaped surface. They are not part of the OpenAI schema, and strict
-// implementations reject unknown message fields, so forwarding them would break
-// requests that worked before the fields existed.
-func withoutGatewayExtensions(req ChatCompletionRequest) ChatCompletionRequest {
+// ReasoningContent is preserved only for DeepSeek, where it is an upstream
+// protocol field used by tool-call continuations. Signature fields always stay
+// gateway-local because they carry Anthropic or Gemini opaque state.
+func withoutGatewayExtensions(req ChatCompletionRequest, preserveReasoningContent bool) ChatCompletionRequest {
 	needsCopy := false
 	for _, message := range req.Messages {
-		if message.ReasoningContent != "" || message.ReasoningSignature != "" || message.RedactedReasoningContent != "" {
+		_, hasReasoningContent := message.raw["reasoning_content"]
+		_, hasReasoningSignature := message.raw["reasoning_signature"]
+		_, hasRedactedReasoningContent := message.raw["redacted_reasoning_content"]
+		if (!preserveReasoningContent && (message.ReasoningContent != "" || hasReasoningContent)) ||
+			message.ReasoningSignature != "" || hasReasoningSignature ||
+			message.RedactedReasoningContent != "" || hasRedactedReasoningContent {
 			needsCopy = true
 			break
 		}
@@ -346,9 +350,17 @@ func withoutGatewayExtensions(req ChatCompletionRequest) ChatCompletionRequest {
 	messages := make([]ChatMessage, len(req.Messages))
 	copy(messages, req.Messages)
 	for index := range messages {
-		messages[index].ReasoningContent = ""
+		if messages[index].raw != nil {
+			messages[index].raw = cloneRawJSON(messages[index].raw, 0)
+		}
+		if !preserveReasoningContent {
+			messages[index].ReasoningContent = ""
+			delete(messages[index].raw, "reasoning_content")
+		}
 		messages[index].ReasoningSignature = ""
 		messages[index].RedactedReasoningContent = ""
+		delete(messages[index].raw, "reasoning_signature")
+		delete(messages[index].raw, "redacted_reasoning_content")
 	}
 	req.Messages = messages
 	return req

--- a/backend/internal/server/provider_chat_convert_test.go
+++ b/backend/internal/server/provider_chat_convert_test.go
@@ -21,7 +21,7 @@ func TestWithoutGatewayExtensionsStripsReasoningFields(t *testing.T) {
 		},
 	}}
 
-	sanitized := withoutGatewayExtensions(req)
+	sanitized := withoutGatewayExtensions(req, false)
 
 	for _, message := range sanitized.Messages {
 		if message.ReasoningContent != "" || message.ReasoningSignature != "" || message.RedactedReasoningContent != "" {
@@ -35,6 +35,83 @@ func TestWithoutGatewayExtensionsStripsReasoningFields(t *testing.T) {
 	}
 }
 
+func TestWithoutGatewayExtensionsStripsExplicitEmptyRawFields(t *testing.T) {
+	var req ChatCompletionRequest
+	if err := json.Unmarshal([]byte(`{
+		"messages":[{
+			"role":"assistant",
+			"content":"answer",
+			"reasoning_content":"",
+			"reasoning_signature":"",
+			"redacted_reasoning_content":"",
+			"provider_message":"preserve me"
+		}]
+	}`), &req); err != nil {
+		t.Fatal(err)
+	}
+
+	sanitized := withoutGatewayExtensions(req, false)
+	encoded, err := json.Marshal(sanitized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var forwarded map[string]any
+	if err := json.Unmarshal(encoded, &forwarded); err != nil {
+		t.Fatal(err)
+	}
+	messages, _ := forwarded["messages"].([]any)
+	message, _ := messages[0].(map[string]any)
+	for _, field := range []string{"reasoning_content", "reasoning_signature", "redacted_reasoning_content"} {
+		if _, present := message[field]; present {
+			t.Fatalf("explicit empty %s must not be forwarded: %v", field, message)
+		}
+	}
+	if message["provider_message"] != "preserve me" {
+		t.Fatalf("unrelated provider field was lost: %v", message)
+	}
+
+	if _, present := req.Messages[0].raw["reasoning_signature"]; !present {
+		t.Fatal("the original request was mutated")
+	}
+}
+
+func TestDeepSeekAdapterForwardsReasoningContentOnly(t *testing.T) {
+	var received map[string]any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&received)
+		w.Header().Set("content-type", "application/json")
+		io.WriteString(w, `{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{}}`)
+	}))
+	defer upstream.Close()
+
+	adapter := OpenAICompatibleAdapter{Client: upstream.Client()}
+	provider := Provider{Type: "deepseek", BaseURL: upstream.URL, APIKey: "test-key"}
+	_, _, err := adapter.Chat(context.Background(), provider, "model-x", ChatCompletionRequest{
+		Model: "model-x",
+		Messages: []ChatMessage{{
+			Role:                     "assistant",
+			Content:                  "answer",
+			ReasoningContent:         "deepseek continuation",
+			ReasoningSignature:       "anthropic:sig",
+			RedactedReasoningContent: "opaque",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	messages, _ := received["messages"].([]any)
+	message, _ := messages[0].(map[string]any)
+	if message["reasoning_content"] != "deepseek continuation" {
+		t.Fatalf("DeepSeek reasoning_content was not forwarded: %v", message)
+	}
+	for _, field := range []string{"reasoning_signature", "redacted_reasoning_content"} {
+		if _, present := message[field]; present {
+			t.Fatalf("%s must remain gateway-local: %v", field, message)
+		}
+	}
+}
+
 func TestOpenAICompatibleAdapterDoesNotForwardGatewayExtensions(t *testing.T) {
 	var received map[string]any
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -45,7 +122,7 @@ func TestOpenAICompatibleAdapterDoesNotForwardGatewayExtensions(t *testing.T) {
 	defer upstream.Close()
 
 	adapter := OpenAICompatibleAdapter{Client: upstream.Client()}
-	provider := Provider{BaseURL: upstream.URL, APIKey: "test-key"}
+	provider := Provider{Type: ProviderOpenAICompatible, BaseURL: upstream.URL, APIKey: "test-key"}
 
 	_, _, err := adapter.Chat(context.Background(), provider, "model-x", ChatCompletionRequest{
 		Model: "model-x",

--- a/backend/internal/server/providers.go
+++ b/backend/internal/server/providers.go
@@ -165,7 +165,7 @@ type OpenAICompatibleAdapter struct {
 }
 
 func (a OpenAICompatibleAdapter) Chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
-	req = withoutGatewayExtensions(req)
+	req = withoutGatewayExtensions(req, provider.Type == "deepseek")
 	req.Model = providerModel
 	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
 	var body map[string]any
@@ -176,7 +176,7 @@ func (a OpenAICompatibleAdapter) Chat(ctx context.Context, provider Provider, pr
 }
 
 func (a OpenAICompatibleAdapter) ChatStream(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest, w io.Writer) (Usage, error) {
-	req = withoutGatewayExtensions(req)
+	req = withoutGatewayExtensions(req, provider.Type == "deepseek")
 	req.Model = providerModel
 	req.Stream = true
 	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
@@ -273,7 +273,7 @@ type AzureOpenAIAdapter struct {
 }
 
 func (a AzureOpenAIAdapter) Chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
-	req = withoutGatewayExtensions(req)
+	req = withoutGatewayExtensions(req, false)
 	req.Model = providerModel
 	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
 	var body map[string]any
@@ -284,7 +284,7 @@ func (a AzureOpenAIAdapter) Chat(ctx context.Context, provider Provider, provide
 }
 
 func (a AzureOpenAIAdapter) ChatStream(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest, w io.Writer) (Usage, error) {
-	req = withoutGatewayExtensions(req)
+	req = withoutGatewayExtensions(req, false)
 	req.Model = providerModel
 	req.Stream = true
 	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)

--- a/backend/internal/server/reasoning_effort_test.go
+++ b/backend/internal/server/reasoning_effort_test.go
@@ -38,15 +38,22 @@ func TestGatewayForwardsChatReasoningEffort(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	server, _, secret := newReasoningEffortGateway(t, upstream.URL, ProviderOpenAICompatible)
+	server, _, secret := newReasoningEffortGateway(t, upstream.URL, "deepseek")
 	app := server.Handler()
 	effort := "high"
 	for _, stream := range []bool{false, true} {
 		resp := doJSON(t, app, http.MethodPost, "/v1/chat/completions", map[string]any{
-			"model":            "reasoning-model",
-			"messages":         []map[string]any{{"role": "user", "content": "reason carefully"}},
+			"model": "reasoning-model",
+			"messages": []map[string]any{{
+				"role":              "assistant",
+				"content":           "",
+				"reasoning_content": "provider reasoning state",
+				"provider_message":  "preserve me",
+			}},
 			"reasoning_effort": effort,
 			"stream":           stream,
+			"thinking":         map[string]any{"type": "disabled"},
+			"provider_option":  "preserve me",
 		}, secret)
 		if resp.Code != http.StatusOK {
 			t.Fatalf("stream=%v expected 200, got %d: %s", stream, resp.Code, resp.Body)
@@ -62,6 +69,18 @@ func TestGatewayForwardsChatReasoningEffort(t *testing.T) {
 		}
 		if payload["model"] != "upstream-reasoning-model" {
 			t.Fatalf("expected routed provider model, got %#v", payload["model"])
+		}
+		thinking, _ := payload["thinking"].(map[string]any)
+		if thinking["type"] != "disabled" || payload["provider_option"] != "preserve me" {
+			t.Fatalf("provider-specific request fields were not preserved: %#v", payload)
+		}
+		messages, _ := payload["messages"].([]any)
+		if len(messages) != 1 {
+			t.Fatalf("expected one upstream message, got %#v", payload["messages"])
+		}
+		message, _ := messages[0].(map[string]any)
+		if message["reasoning_content"] != "provider reasoning state" || message["provider_message"] != "preserve me" {
+			t.Fatalf("provider-specific message fields were not preserved: %#v", message)
 		}
 	}
 }

--- a/backend/internal/server/types.go
+++ b/backend/internal/server/types.go
@@ -197,7 +197,7 @@ type ProviderCreateRequest struct {
 	BaseURL        string                 `json:"base_url"`
 	APIKey         string                 `json:"api_key"`
 	Status         string                 `json:"status"`
-	Healthy        bool                   `json:"healthy"`
+	Healthy        *bool                  `json:"healthy"`
 	Priority       int                    `json:"priority"`
 	Headers        map[string]string      `json:"headers"`
 	Options        map[string]string      `json:"options"`
@@ -546,6 +546,7 @@ type ChatMessage struct {
 	ReasoningContent         string `json:"reasoning_content,omitempty"`
 	ReasoningSignature       string `json:"reasoning_signature,omitempty"`
 	RedactedReasoningContent string `json:"redacted_reasoning_content,omitempty"`
+	raw                      map[string]json.RawMessage
 }
 
 type ReasoningOptions = ResponsesReasoning
@@ -576,6 +577,87 @@ type ChatCompletionRequest struct {
 	// string values; other types are forwarded for the upstream to judge.
 	PromptCacheKey any `json:"prompt_cache_key,omitempty"`
 	User           any `json:"user,omitempty"`
+	raw            map[string]json.RawMessage
+}
+
+// UnmarshalJSON keeps provider-specific message fields so compatible upstreams
+// can receive opaque continuation data without TokenHub needing to understand it.
+func (m *ChatMessage) UnmarshalJSON(data []byte) error {
+	type messageAlias ChatMessage
+	var decoded messageAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*m = ChatMessage(decoded)
+	m.raw = raw
+	return nil
+}
+
+func (m ChatMessage) MarshalJSON() ([]byte, error) {
+	type messageAlias ChatMessage
+	if m.raw == nil {
+		return json.Marshal(messageAlias(m))
+	}
+	raw := cloneRawJSON(m.raw, 8)
+	setRawJSONField(raw, "role", m.Role, m.Role != "")
+	setRawJSONField(raw, "content", m.Content, m.Content != nil)
+	setRawJSONField(raw, "name", m.Name, m.Name != "")
+	setRawJSONField(raw, "tool_call_id", m.ToolCallID, m.ToolCallID != "")
+	setRawJSONField(raw, "tool_calls", m.ToolCalls, m.ToolCalls != nil)
+	setOrDeleteRawJSONField(raw, "reasoning_content", m.ReasoningContent, m.ReasoningContent != "")
+	setOrDeleteRawJSONField(raw, "reasoning_signature", m.ReasoningSignature, m.ReasoningSignature != "")
+	setOrDeleteRawJSONField(raw, "redacted_reasoning_content", m.RedactedReasoningContent, m.RedactedReasoningContent != "")
+	return json.Marshal(raw)
+}
+
+// UnmarshalJSON keeps top-level provider extensions such as DeepSeek's thinking
+// switch while typed fields remain available to routing and policy code.
+func (r *ChatCompletionRequest) UnmarshalJSON(data []byte) error {
+	type requestAlias ChatCompletionRequest
+	var decoded requestAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*r = ChatCompletionRequest(decoded)
+	r.raw = raw
+	return nil
+}
+
+func (r ChatCompletionRequest) MarshalJSON() ([]byte, error) {
+	type requestAlias ChatCompletionRequest
+	if r.raw == nil {
+		return json.Marshal(requestAlias(r))
+	}
+	raw := cloneRawJSON(r.raw, 16)
+	setRawJSONField(raw, "model", r.Model, r.Model != "")
+	setRawJSONField(raw, "messages", r.Messages, r.Messages != nil)
+	setRawJSONField(raw, "stream", r.Stream, r.Stream)
+	setRawJSONField(raw, "stream_options", r.StreamOptions, r.StreamOptions != nil)
+	setRawJSONField(raw, "max_tokens", r.MaxTokens, r.MaxTokens != 0)
+	setRawJSONField(raw, "temperature", r.Temperature, r.Temperature != nil)
+	setRawJSONField(raw, "top_p", r.TopP, r.TopP != nil)
+	setRawJSONField(raw, "stop", r.Stop, r.Stop != nil)
+	setRawJSONField(raw, "tools", r.Tools, r.Tools != nil)
+	setRawJSONField(raw, "tool_choice", r.ToolChoice, r.ToolChoice != nil)
+	setRawJSONField(raw, "parallel_tool_calls", r.ParallelToolCalls, r.ParallelToolCalls != nil)
+	setRawJSONField(raw, "response_format", r.ResponseFormat, r.ResponseFormat != nil)
+	if r.ReasoningEffort != nil {
+		setRawJSONField(raw, "reasoning_effort", r.ReasoningEffort, true)
+	} else {
+		delete(raw, "reasoning_effort")
+	}
+	setRawJSONField(raw, "metadata", r.Metadata, r.Metadata != nil)
+	setRawJSONField(raw, "prompt_cache_key", r.PromptCacheKey, r.PromptCacheKey != nil)
+	setRawJSONField(raw, "user", r.User, r.User != nil)
+	return json.Marshal(raw)
 }
 
 type PlaygroundChatResponse struct {
@@ -649,10 +731,7 @@ func (r ResponsesRequest) MarshalJSON() ([]byte, error) {
 	if r.raw == nil {
 		return json.Marshal(requestAlias(r))
 	}
-	raw := make(map[string]json.RawMessage, len(r.raw)+8)
-	for key, value := range r.raw {
-		raw[key] = value
-	}
+	raw := cloneRawJSON(r.raw, 8)
 	setRawJSONField(raw, "model", r.Model, r.Model != "")
 	setRawJSONField(raw, "input", r.Input, r.Input != nil)
 	setRawJSONField(raw, "stream", r.Stream, true)
@@ -702,6 +781,22 @@ func setRawJSONField(raw map[string]json.RawMessage, key string, value any, pres
 	if err == nil {
 		raw[key] = encoded
 	}
+}
+
+func setOrDeleteRawJSONField(raw map[string]json.RawMessage, key string, value any, present bool) {
+	if !present {
+		delete(raw, key)
+		return
+	}
+	setRawJSONField(raw, key, value, true)
+}
+
+func cloneRawJSON(source map[string]json.RawMessage, extra int) map[string]json.RawMessage {
+	cloned := make(map[string]json.RawMessage, len(source)+extra)
+	for key, value := range source {
+		cloned[key] = value
+	}
+	return cloned
 }
 
 type EmbeddingsRequest struct {

--- a/frontend/features/admin/views/provider-editor-fields.tsx
+++ b/frontend/features/admin/views/provider-editor-fields.tsx
@@ -1,0 +1,142 @@
+import { Boxes, KeyRound, Search, Server, Settings, UserRoundCheck } from "lucide-react";
+import { type FieldConfig, type ProviderCredentialMode } from "../core/types";
+import { enumOptionLabel } from "../domain/labels";
+import { clearCustomValidity, handleRequiredFieldInvalid, tx } from "../i18n/runtime";
+
+export function ProviderInlineField({
+  field,
+  value,
+  values,
+  onChange,
+}: {
+  field: FieldConfig;
+  value: string;
+  values: Record<string, string>;
+  onChange: (value: string) => void;
+}) {
+  if (!(field.visible?.(values) ?? true)) return null;
+  const autoComplete = field.autoComplete ?? "off";
+  const inputName = `tokenhub-provider-account-${field.key}`;
+  const options = (field.options ?? []).map((option) => ({ value: option, label: enumOptionLabel(field.key, option) }));
+  if (field.type === "select") {
+    return (
+      <label className="field" data-field-key={field.key}>
+        <span>{tx(field.label)}</span>
+        <select value={value} onChange={(event) => { clearCustomValidity(event); onChange(event.target.value); }} onInvalid={handleRequiredFieldInvalid} required={field.required}>
+          <option value="">{tx("请选择")}</option>
+          {options.map((option) => (
+            <option key={option.value} value={option.value}>{tx(option.label)}</option>
+          ))}
+        </select>
+        {field.help ? <small>{tx(field.help)}</small> : null}
+      </label>
+    );
+  }
+  if (field.type === "textarea") {
+    return (
+      <label className="field" data-field-key={field.key}>
+        <span>{tx(field.label)}</span>
+        <textarea
+          autoComplete={autoComplete}
+          data-1p-ignore={autoComplete === "off" || autoComplete === "new-password" ? "true" : undefined}
+          data-lpignore={autoComplete === "off" || autoComplete === "new-password" ? "true" : undefined}
+          name={inputName}
+          value={value}
+          onChange={(event) => { clearCustomValidity(event); onChange(event.target.value); }}
+          onInvalid={handleRequiredFieldInvalid}
+          placeholder={tx(field.placeholder)}
+          required={field.required}
+        />
+        {field.help ? <small>{tx(field.help)}</small> : null}
+      </label>
+    );
+  }
+  if (field.type === "boolean") {
+    const checked = value === "true";
+    return (
+      <label className="field" data-field-key={field.key}>
+        <span>{tx(field.label)}</span>
+        <div className="boolean-toggle" role="radiogroup" aria-label={tx(field.label)}>
+          <button aria-checked={checked} className={checked ? "active" : ""} onClick={() => onChange("true")} role="radio" type="button">
+            {tx("开启")}
+          </button>
+          <button aria-checked={!checked} className={!checked ? "active" : ""} onClick={() => onChange("false")} role="radio" type="button">
+            {tx("关闭开关")}
+          </button>
+        </div>
+        {field.help ? <small>{tx(field.help)}</small> : null}
+      </label>
+    );
+  }
+  return (
+    <label className="field" data-field-key={field.key}>
+      <span>{tx(field.label)}</span>
+      <input
+        autoComplete={autoComplete}
+        data-1p-ignore={autoComplete === "off" || autoComplete === "new-password" ? "true" : undefined}
+        data-lpignore={autoComplete === "off" || autoComplete === "new-password" ? "true" : undefined}
+        name={inputName}
+        value={value}
+        type={field.type === "number" ? "number" : field.type === "password" ? "password" : "text"}
+        onChange={(event) => { clearCustomValidity(event); onChange(event.target.value); }}
+        onInvalid={handleRequiredFieldInvalid}
+        placeholder={tx(field.placeholder)}
+        required={field.required}
+      />
+      {field.help ? <small>{tx(field.help)}</small> : null}
+    </label>
+  );
+}
+
+export function providerCredentialOptions(): Array<{ key: ProviderCredentialMode; label: string; description: string; icon: typeof KeyRound }> {
+  return [
+    {
+      key: "provider_api_key",
+      label: "直接 API Key",
+      description: "把上游 Key 保存到 Provider，适合单账号或兼容 API。",
+      icon: KeyRound,
+    },
+    {
+      key: "account_integration",
+      label: "账号资源池",
+      description: "适合 OpenAI 账号、Subscription 或多账号轮询，默认通道会自动推荐。",
+      icon: UserRoundCheck,
+    },
+    {
+      key: "later",
+      label: "稍后配置",
+      description: "先创建 Provider 和路由，稍后再添加 Key 或账号资源。",
+      icon: Settings,
+    },
+  ];
+}
+
+export function providerCreateWizardSteps(): Array<{ title: string; icon: typeof Search }> {
+  return [
+    { title: "接入方式", icon: UserRoundCheck },
+    { title: "渠道信息", icon: Server },
+    { title: "账号与凭据", icon: KeyRound },
+    { title: "路由与确认", icon: Boxes },
+  ];
+}
+
+export function providerCreateWizardStepTitle(title: string, credentialMode: ProviderCredentialMode) {
+  if (credentialMode === "account_integration" && title === "渠道信息") return "默认通道";
+  if (title === "账号与凭据") {
+    if (credentialMode === "account_integration") return "账号授权";
+    if (credentialMode === "provider_api_key") return "直接 API Key";
+    return "稍后配置";
+  }
+  return title;
+}
+
+export function providerCredentialModeLabel(mode: ProviderCredentialMode) {
+  return providerCredentialOptions().find((option) => option.key === mode)?.label ?? mode;
+}
+
+export function providerAccountResourceReady(values: Record<string, string>) {
+  if (values.resource_type === "openai_subscription") {
+    return Boolean(values.access_token?.trim() || values.refresh_token?.trim() || values.id_token?.trim());
+  }
+  return Boolean(values.api_key?.trim());
+}

--- a/frontend/features/admin/views/provider-editor.tsx
+++ b/frontend/features/admin/views/provider-editor.tsx
@@ -1,15 +1,16 @@
-import { AlertCircle, Ban, Boxes, Check, Copy, KeyRound, Plus, Search, Send, Server, Settings, Trash2, UserRoundCheck } from "lucide-react";
+import { AlertCircle, Ban, Check, Copy, KeyRound, Plus, Search, Send, Trash2, UserRoundCheck } from "lucide-react";
 import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { clearPendingProviderAccountOAuthSession, consumePendingProviderAccountOAuthResult, hasPendingProviderAccountOAuthResult, parseProviderAccountOAuthResult, providerAccountOAuthCallbackURL, type ProviderAccountOAuthGenerateResponse, type ProviderAccountOAuthResult, readPendingProviderAccountOAuthSession, savePendingProviderAccountOAuthSession } from "../core/session";
-import { type ApiContext, type FieldConfig, type Model, type ModelRoute, type Provider, type ProviderCatalogEntry, type ProviderCredentialMode, type ProviderResource } from "../core/types";
+import { type ApiContext, type Model, type ModelRoute, type Provider, type ProviderCatalogEntry, type ProviderCredentialMode, type ProviderResource } from "../core/types";
 import { buildCustomProviderCatalogEntry, canonicalModelNameForUI, catalogModelCategoryOptions, modelCategory, modelCategoryForCatalog, modelCategoryLabel, providerEntryCategoryCount, providerEntrySupportsCategory } from "../domain/catalog";
 import { compactNumber, formatModelPrice, modelCapabilities } from "../domain/formatting";
-import { enumOptionLabel, providerTypeLabel } from "../domain/labels";
-import { clearCustomValidity, countWithLabel, countWithUnit, handleRequiredFieldInvalid, tx } from "../i18n/runtime";
+import { providerTypeLabel } from "../domain/labels";
+import { countWithLabel, countWithUnit, tx } from "../i18n/runtime";
 import { adminFetch, isAuthExpiredError, providerPayload, providerResourcePayload, providerUpdatePayload, readAdminError } from "../resources/payloads";
 import { assertProviderAccountResourceReady, defaultProviderResourceName, providerAccountTokenSummary, providerCreateAccountManualTokenFields, providerCreateAccountRuntimeFields, providerResourceDraftDefaults } from "../resources/provider-model-config";
 import { ReviewItem } from "../shared/modals";
 import { providerTypeOptions } from "../shared/ui";
+import { ProviderInlineField, providerAccountResourceReady, providerCreateWizardSteps, providerCreateWizardStepTitle, providerCredentialModeLabel, providerCredentialOptions } from "./provider-editor-fields";
 
 const openAIAccountOAuthRedirectURI = "http://localhost:1455/auth/callback";
 
@@ -2009,142 +2010,4 @@ function quotaWindowResetLabel(window?: OpenAIQuotaWindow) {
     return minutes >= 60 ? `${Math.ceil(minutes / 60)} ${tx("小时后")}` : `${minutes} ${tx("分钟后")}`;
   }
   return "-";
-}
-
-export function ProviderInlineField({
-  field,
-  value,
-  values,
-  onChange,
-}: {
-  field: FieldConfig;
-  value: string;
-  values: Record<string, string>;
-  onChange: (value: string) => void;
-}) {
-  if (!(field.visible?.(values) ?? true)) return null;
-  const autoComplete = field.autoComplete ?? "off";
-  const inputName = `tokenhub-provider-account-${field.key}`;
-  const options = (field.options ?? []).map((option) => ({ value: option, label: enumOptionLabel(field.key, option) }));
-  if (field.type === "select") {
-    return (
-      <label className="field" data-field-key={field.key}>
-        <span>{tx(field.label)}</span>
-        <select value={value} onChange={(event) => { clearCustomValidity(event); onChange(event.target.value); }} onInvalid={handleRequiredFieldInvalid} required={field.required}>
-          <option value="">{tx("请选择")}</option>
-          {options.map((option) => (
-            <option key={option.value} value={option.value}>{tx(option.label)}</option>
-          ))}
-        </select>
-        {field.help ? <small>{tx(field.help)}</small> : null}
-      </label>
-    );
-  }
-  if (field.type === "textarea") {
-    return (
-      <label className="field" data-field-key={field.key}>
-        <span>{tx(field.label)}</span>
-        <textarea
-          autoComplete={autoComplete}
-          data-1p-ignore={autoComplete === "off" || autoComplete === "new-password" ? "true" : undefined}
-          data-lpignore={autoComplete === "off" || autoComplete === "new-password" ? "true" : undefined}
-          name={inputName}
-          value={value}
-          onChange={(event) => { clearCustomValidity(event); onChange(event.target.value); }}
-          onInvalid={handleRequiredFieldInvalid}
-          placeholder={tx(field.placeholder)}
-          required={field.required}
-        />
-        {field.help ? <small>{tx(field.help)}</small> : null}
-      </label>
-    );
-  }
-  if (field.type === "boolean") {
-    const checked = value === "true";
-    return (
-      <label className="field" data-field-key={field.key}>
-        <span>{tx(field.label)}</span>
-        <div className="boolean-toggle" role="radiogroup" aria-label={tx(field.label)}>
-          <button aria-checked={checked} className={checked ? "active" : ""} onClick={() => onChange("true")} role="radio" type="button">
-            {tx("开启")}
-          </button>
-          <button aria-checked={!checked} className={!checked ? "active" : ""} onClick={() => onChange("false")} role="radio" type="button">
-            {tx("关闭开关")}
-          </button>
-        </div>
-        {field.help ? <small>{tx(field.help)}</small> : null}
-      </label>
-    );
-  }
-  return (
-    <label className="field" data-field-key={field.key}>
-      <span>{tx(field.label)}</span>
-      <input
-        autoComplete={autoComplete}
-        data-1p-ignore={autoComplete === "off" || autoComplete === "new-password" ? "true" : undefined}
-        data-lpignore={autoComplete === "off" || autoComplete === "new-password" ? "true" : undefined}
-        name={inputName}
-        value={value}
-        type={field.type === "number" ? "number" : field.type === "password" ? "password" : "text"}
-        onChange={(event) => { clearCustomValidity(event); onChange(event.target.value); }}
-        onInvalid={handleRequiredFieldInvalid}
-        placeholder={tx(field.placeholder)}
-        required={field.required}
-      />
-      {field.help ? <small>{tx(field.help)}</small> : null}
-    </label>
-  );
-}
-
-export function providerCredentialOptions(): Array<{ key: ProviderCredentialMode; label: string; description: string; icon: typeof KeyRound }> {
-  return [
-    {
-      key: "provider_api_key",
-      label: "直接 API Key",
-      description: "把上游 Key 保存到 Provider，适合单账号或兼容 API。",
-      icon: KeyRound,
-    },
-    {
-      key: "account_integration",
-      label: "账号资源池",
-      description: "适合 OpenAI 账号、Subscription 或多账号轮询，默认通道会自动推荐。",
-      icon: UserRoundCheck,
-    },
-    {
-      key: "later",
-      label: "稍后配置",
-      description: "先创建 Provider 和路由，稍后再添加 Key 或账号资源。",
-      icon: Settings,
-    },
-  ];
-}
-
-export function providerCreateWizardSteps(): Array<{ title: string; icon: typeof Search }> {
-  return [
-    { title: "接入方式", icon: UserRoundCheck },
-    { title: "渠道信息", icon: Server },
-    { title: "账号与凭据", icon: KeyRound },
-    { title: "路由与确认", icon: Boxes },
-  ];
-}
-
-export function providerCreateWizardStepTitle(title: string, credentialMode: ProviderCredentialMode) {
-  if (credentialMode === "account_integration" && title === "渠道信息") return "默认通道";
-  if (title === "账号与凭据") {
-    if (credentialMode === "account_integration") return "账号授权";
-    if (credentialMode === "provider_api_key") return "直接 API Key";
-    return "稍后配置";
-  }
-  return title;
-}
-
-export function providerCredentialModeLabel(mode: ProviderCredentialMode) {
-  return providerCredentialOptions().find((option) => option.key === mode)?.label ?? mode;
-}
-
-export function providerAccountResourceReady(values: Record<string, string>) {
-  if (values.resource_type === "openai_subscription") {
-    return Boolean(values.access_token?.trim() || values.refresh_token?.trim() || values.id_token?.trim());
-  }
-  return Boolean(values.api_key?.trim());
 }


### PR DESCRIPTION
## Summary

Fix provider compatibility issues found while fuzzing DeepSeek and Volcengine Ark through the gateway. The gateway now preserves opaque provider request fields where appropriate, keeps DeepSeek continuation state intact, rejects malformed multi-value JSON bodies, and applies provider updates without erasing omitted fields.

Responses streaming support is intentionally excluded from this pull request and retains its existing behavior.

## Related Issue

N/A

## Changes

- Preserve unknown top-level Chat Completions fields and unknown message fields while still routing typed fields safely.
- Forward DeepSeek `reasoning_content` for tool-call continuations, while keeping Anthropic and Gemini gateway-only signature fields out of OpenAI-compatible upstream requests.
- Reject request bodies containing more than one JSON value while retaining the 4 MiB request-size limit.
- Reject unregistered provider adapter types during creation and preserve omitted provider properties during partial updates.
- Add regression coverage for extension forwarding, explicit empty extension fields, malformed JSON, provider validation, and partial provider updates.
- Extract provider editor field helpers into a focused module so the frontend source-line check passes without changing behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [x] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [x] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- Focused provider-extension tests pass, including explicit empty gateway-extension fields.
- Live DeepSeek Chat Completions returned the expected `thinking.type=disabled` behavior and completed a two-turn tool-call continuation.
- Live Ark image Chat Completions succeeded.
- Live non-streaming Ark Responses prompt caching produced a second-request cache hit with 3,647 cached input tokens.
- Concatenated JSON values return `400 invalid_request`.
- An unregistered provider adapter type returns `400 provider_adapter_missing`.
- A type-only provider PATCH preserves its base URL, status, health, priority, headers, and options.
- SDK smoke scripts were not run because credentials were removed after the manual live checks.
- Docker Compose rendering was not run because this change does not touch deployment configuration.
- `git diff --check` passes.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: Chat Completions now preserves opaque provider extensions; malformed bodies with trailing JSON values are rejected. Responses streaming behavior is unchanged.
- Security or credential-handling impact: No credential storage or forwarding policy changes. No real credentials are included in the diff.
- Database, environment, or deployment impact: None.
- Rollout and rollback considerations: No migration or configuration change is required; rollback is a normal code revert.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
