### PR TITLE
fix(frontend): prevent version update dialog clipping

### DIFF
--- a/frontend/app/styles/redesign/shell.css
+++ b/frontend/app/styles/redesign/shell.css
@@ -15,6 +15,7 @@
 
 .sidebar {
   height: 100dvh;
+  overflow: visible;
   padding: 0;
   border-right: 1px solid var(--border);
   background: var(--surface);

--- a/frontend/app/styles/redesign/shell.css
+++ b/frontend/app/styles/redesign/shell.css
@@ -103,11 +103,11 @@
 
 .version-popover {
   position: absolute;
-  top: 36px;
+  top: 32px;
   left: 0;
-  width: min(410px, calc(100vw - 32px));
+  width: min(340px, calc(100vw - 24px));
   border: 1px solid var(--border);
-  border-radius: 18px;
+  border-radius: 16px;
   background: var(--surface);
   color: var(--ink);
   box-shadow: var(--shadow-lg);
@@ -115,8 +115,8 @@
 }
 
 .version-popover-header {
-  min-height: 74px;
-  padding: 0 26px;
+  min-height: 58px;
+  padding: 0 20px;
   border-bottom: 1px solid var(--border);
   display: flex;
   align-items: center;
@@ -124,61 +124,61 @@
 }
 
 .version-popover-header strong {
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 760;
 }
 
 .version-popover-body {
-  padding: 32px 32px 28px;
+  padding: 22px 22px 20px;
   display: grid;
   justify-items: center;
-  gap: 14px;
+  gap: 10px;
 }
 
 .version-current {
   color: var(--ink);
-  font-size: 36px;
+  font-size: 30px;
   font-weight: 820;
   line-height: 1;
 }
 
 .version-latest {
   color: var(--ink-2);
-  font-size: 15px;
+  font-size: 13px;
   font-weight: 560;
 }
 
 .version-update-card {
   width: 100%;
-  min-height: 86px;
-  margin-top: 10px;
-  padding: 16px 22px;
+  min-height: 68px;
+  margin-top: 4px;
+  padding: 12px 14px;
   border: 1px solid color-mix(in srgb, #ffd43b 78%, var(--border));
   border-radius: 14px;
   display: flex;
   align-items: center;
-  gap: 18px;
+  gap: 12px;
   background: color-mix(in srgb, #fff7d6 72%, var(--surface));
   color: #b94a00;
 }
 
 .version-update-card strong {
   display: block;
-  font-size: 19px;
+  font-size: 15px;
   font-weight: 760;
 }
 
 .version-update-card span {
   display: block;
-  margin-top: 5px;
+  margin-top: 3px;
   color: #ee8a35;
-  font-size: 16px;
+  font-size: 13px;
 }
 
 .version-update-icon {
-  width: 50px;
-  height: 50px;
-  flex: 0 0 50px;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 40px;
   border-radius: 999px;
   display: inline-flex;
   align-items: center;
@@ -188,12 +188,13 @@
 }
 
 .version-status-text {
-  min-height: 56px;
-  margin: 10px 0 0;
+  min-height: 40px;
+  margin: 4px 0 0;
   display: flex;
   align-items: center;
   color: var(--ink-2);
-  font-size: 14px;
+  font-size: 13px;
+  line-height: 1.45;
   text-align: center;
 }
 
@@ -203,16 +204,16 @@
 
 .version-primary-action {
   width: 100%;
-  min-height: 56px;
+  min-height: 44px;
   margin-top: 2px;
   border-radius: 12px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
+  gap: 9px;
   background: #19b8a7;
   color: white;
-  font-size: 18px;
+  font-size: 15px;
   font-weight: 760;
   text-decoration: none;
   transition: background 150ms ease, transform 150ms ease;
@@ -228,7 +229,7 @@
   align-items: center;
   gap: 6px;
   color: var(--ink-2);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 560;
   text-decoration: none;
 }


### PR DESCRIPTION
## Summary

Prevent the version update dialog from being clipped at the sidebar boundary. The redesigned sidebar still inherited `overflow: hidden` from the legacy shell styles, so most of the dialog was hidden behind the workspace. The dialog proportions are also tightened for a smaller, more polished presentation.

## Related Issue

N/A

## Changes

- Allow overflow from the redesigned sidebar so the version update dialog can render over the workspace.
- Reduce the popover width, spacing, typography, status area, and action height while preserving readability and update states.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [ ] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [x] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- `npm ci` completed successfully; npm reported three existing high-severity audit findings, and this PR does not change dependencies.
- `npm run typecheck` passed.
- `npm run build` passed.
- `git diff --check` passed.
- Manually reproduced the clipping in an authenticated Chrome session at `http://localhost:3000/security-policies`, then verified the full dialog, primary action, and changelog link render above the workspace after the fix.
- Verified the refined popover renders at 340 x 299 px in a 1490 x 1024 viewport, with a 58 px header and 44 px primary action, no clipping, no framework overlay, and no console warnings or errors.
- Backend, SDK, and Docker checks were skipped because this is a frontend CSS-only change with no backend, SDK, or deployment impact.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: None.
- Security or credential-handling impact: None.
- Database, environment, or deployment impact: None.
- Rollout and rollback considerations: No special rollout is required; rollback by reverting the single CSS declaration.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.

No automated test was added because the regression is a CSS overflow/paint behavior; it is covered by the rendered interaction verification above. Environment variables, documentation, and the model catalog are unchanged.
