### PR TITLE
chore: adopt golangci-lint and clear its existing findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,53 @@
+version: "2"
+
+run:
+  timeout: 10m
+
+linters:
+  # The standard set: errcheck, govet, ineffassign, staticcheck, unused.
+  # Deliberately conservative to start with — a wide rule set on an existing
+  # codebase produces noise that trains people to ignore the linter.
+  default: standard
+  settings:
+    staticcheck:
+      checks:
+        - all
+        # The QF ("quickfix") class is refactoring advice — use a tagged switch,
+        # apply De Morgan's law, drop an embedded field selector. These are
+        # opinions about style rather than defect reports, so the whole class is
+        # opt-in rather than enforced. SA (real bug patterns), S, ST and the rest
+        # stay on.
+        - -QF*
+    errcheck:
+      # Close on a reader, connection or file runs in a defer, after the useful
+      # work, on a path that has already decided its result. Nothing here is a
+      # write or a commit: Flush, Sync and Write stay checked, because a failure
+      # in those means data did not reach its destination.
+      exclude-functions:
+        - (io.Closer).Close
+        - (io.ReadCloser).Close
+        - (net.Conn).Close
+        - (*database/sql.DB).Close
+        - (*database/sql.Conn).Close
+        - (*os.File).Close
+  exclusions:
+    generated: lax
+    # The `std-error-handling` preset is deliberately NOT enabled. It also drops
+    # Flush, Remove, Print* and Setenv, which is much wider than the Close-only
+    # exemption above and would hide failed writes.
+    #
+    # Test files are deliberately NOT exempted either: an ignored error in test
+    # setup, a database call or a fixture server is exactly the kind of failure
+    # that makes a test silently stop testing anything.
+    presets:
+      - comments
+
+issues:
+  # Report everything. The defaults cap a linter at 50 findings and the same
+  # finding at 3, which silently hides work and makes a "clean" run misleading.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+formatters:
+  enable:
+    - gofmt

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -1357,10 +1357,6 @@ func routeStrategy(route ModelRoute) string {
 	return strategy
 }
 
-func shouldFailoverProviderError(err error) bool {
-	return shouldFailoverRoutedError(err, false)
-}
-
 func shouldFailoverRoutedError(err error, routeIsBound bool) bool {
 	if err == nil {
 		return false
@@ -2425,14 +2421,13 @@ func (s *Server) handleAdminOverview(w http.ResponseWriter, r *http.Request) {
 	}
 	providers := []Provider{}
 	providerResources := []ProviderResource{}
-	models := []Model{}
 	alerts := []AlertEvent{}
 	if s.canViewGlobalOperations(user) {
 		providers = s.store.ListProviders()
 		providerResources = s.store.ListProviderResources()
 		alerts = s.store.ListAlerts()
 	}
-	models = s.accessibleModelsForAdminUser(user)
+	models := s.accessibleModelsForAdminUser(user)
 	routes := []ModelRoute{}
 	if s.canViewGlobalOperations(user) {
 		routes = s.store.ListRoutes()
@@ -5717,7 +5712,10 @@ func sendEmail(ctx context.Context, fields map[string]any, recipients []string, 
 		_ = conn.Close()
 		return err
 	}
-	defer client.Close()
+	// Close force-drops the connection as a safety net. Delivery is decided by Quit
+	// below, whose error is returned; a Close failure after that adds no information.
+	// The static type is *smtp.Client, so the io.Closer exemption does not apply.
+	defer client.Close() //nolint:errcheck // delivery result comes from Quit
 
 	if ok, _ := client.Extension("STARTTLS"); ok {
 		if err := client.StartTLS(&tls.Config{ServerName: host, MinVersion: tls.VersionTLS12}); err != nil {
@@ -6175,11 +6173,6 @@ func quotaLimitsFromPayload(value any) QuotaLimits {
 	default:
 		return QuotaLimits{}
 	}
-}
-
-func (s *Server) authorizeAdmin(w http.ResponseWriter, r *http.Request) bool {
-	_, ok := s.requireAdmin(w, r, "overview", r.Method)
-	return ok
 }
 
 func (s *Server) authorizeAdminUser(w http.ResponseWriter, r *http.Request) (AdminUser, bool) {

--- a/backend/internal/server/identity_provider_oauth.go
+++ b/backend/internal/server/identity_provider_oauth.go
@@ -111,7 +111,7 @@ func exchangeConfiguredIdentityProviderOAuthCode(ctx context.Context, provider A
 	}
 	clientID := strings.TrimSpace(stringField(provider.Fields, "client_id"))
 	clientSecret := strings.TrimSpace(stringField(provider.Fields, "client_secret"))
-	payload := map[string]any{}
+	var payload map[string]any
 	if templateKey == identityProviderDingTalk {
 		payload = map[string]any{
 			"clientId":     clientID,

--- a/backend/internal/server/provider_account_codex.go
+++ b/backend/internal/server/provider_account_codex.go
@@ -54,7 +54,6 @@ type ProviderProbeResult struct {
 }
 
 type codexSubscriptionTestRequest = ProviderProbeRequest
-type codexSubscriptionTestResponse = ProviderProbeResult
 
 func (a CodexSubscriptionAdapter) Responses(ctx context.Context, provider Provider, providerModel string, request ResponsesRequest) (any, Usage, error) {
 	return a.ResponsesWithHeaders(ctx, provider, providerModel, request, nil)

--- a/backend/internal/server/provider_account_models.go
+++ b/backend/internal/server/provider_account_models.go
@@ -468,16 +468,6 @@ func (s *Server) filterCodexRoutesByModel(_ context.Context, modelName string, r
 	)
 }
 
-func providerCatalogModelIDs(models []ProviderCatalogModel) []string {
-	modelIDs := make([]string, 0, len(models))
-	for _, model := range models {
-		if modelID := strings.TrimSpace(model.ID); modelID != "" {
-			modelIDs = append(modelIDs, modelID)
-		}
-	}
-	return modelIDs
-}
-
 func (s *Server) removeCodexResourceModel(resourceID string, modelName string) {
 	resource, ok := s.providerResourceByID(resourceID)
 	if !ok {
@@ -583,15 +573,6 @@ func (s *Server) codexProviderCatalogFromStandardModels(selected []string) Provi
 		Source:         "openai-codex-live",
 		Models:         models,
 	}
-}
-
-func codexCatalogModelByID(models []ProviderCatalogModel, id string) (ProviderCatalogModel, bool) {
-	for _, model := range models {
-		if model.ID == id {
-			return model, true
-		}
-	}
-	return ProviderCatalogModel{}, false
 }
 
 func cloneStringMap(values map[string]string) map[string]string {

--- a/backend/internal/server/provider_account_oauth.go
+++ b/backend/internal/server/provider_account_oauth.go
@@ -516,21 +516,6 @@ func providerAccountCredentialSummary(creds ProviderResourceCredentials) map[str
 	return options
 }
 
-func providerAccountOAuthCallbackURL(r *http.Request) string {
-	scheme := "http"
-	if r.TLS != nil {
-		scheme = "https"
-	}
-	if forwarded := firstForwardedValue(r.Header.Get("x-forwarded-proto")); forwarded != "" {
-		scheme = forwarded
-	}
-	host := r.Host
-	if forwarded := firstForwardedValue(r.Header.Get("x-forwarded-host")); forwarded != "" {
-		host = forwarded
-	}
-	return fmt.Sprintf("%s://%s/api/admin/provider-account-oauth/openai/oauth/callback", scheme, host)
-}
-
 func providerAccountOAuthRedirectWithError(returnURL string, code string) string {
 	target, err := url.Parse(returnURL)
 	if err != nil {

--- a/backend/internal/server/provider_account_quota.go
+++ b/backend/internal/server/provider_account_quota.go
@@ -173,10 +173,6 @@ func (s *Server) providerResourceByID(resourceID string) (ProviderResource, bool
 	return ProviderResource{}, false
 }
 
-func fetchOpenAIAccountQuota(ctx context.Context, creds ProviderResourceCredentials) (OpenAIAccountQuota, int, error) {
-	return fetchOpenAIAccountQuotaWithClient(ctx, nil, openAIAccountQuotaURL, creds)
-}
-
 func fetchOpenAIAccountQuotaWithClient(ctx context.Context, client *http.Client, endpoint string, creds ProviderResourceCredentials) (OpenAIAccountQuota, int, error) {
 	accessToken := strings.TrimSpace(creds.AccessToken)
 	accountID := strings.TrimSpace(creds.AccountID)

--- a/backend/internal/server/provider_anthropic_convert.go
+++ b/backend/internal/server/provider_anthropic_convert.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -428,15 +427,4 @@ func anthropicFinishReason(stopReason string, hasToolCalls bool) (string, error)
 	default:
 		return "", invalidProviderResponseError(fmt.Sprintf("provider returned an unrecognized stop_reason %q", stopReason))
 	}
-}
-
-// anthropicRequestJSON renders the request payload, used by both adapter paths.
-func anthropicRequestJSON(payload map[string]any, stream bool) (map[string]any, error) {
-	if stream {
-		payload["stream"] = true
-	}
-	if _, err := json.Marshal(payload); err != nil {
-		return nil, err
-	}
-	return payload, nil
 }

--- a/backend/internal/server/provider_chat_convert_test.go
+++ b/backend/internal/server/provider_chat_convert_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -78,9 +77,9 @@ func TestWithoutGatewayExtensionsStripsExplicitEmptyRawFields(t *testing.T) {
 func TestDeepSeekAdapterForwardsReasoningContentOnly(t *testing.T) {
 	var received map[string]any
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewDecoder(r.Body).Decode(&received)
+		decodeFixtureRequest(t, r.Body, &received)
 		w.Header().Set("content-type", "application/json")
-		io.WriteString(w, `{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{}}`)
+		writeFixture(t, w, `{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{}}`)
 	}))
 	defer upstream.Close()
 
@@ -115,9 +114,9 @@ func TestDeepSeekAdapterForwardsReasoningContentOnly(t *testing.T) {
 func TestOpenAICompatibleAdapterDoesNotForwardGatewayExtensions(t *testing.T) {
 	var received map[string]any
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewDecoder(r.Body).Decode(&received)
+		decodeFixtureRequest(t, r.Body, &received)
 		w.Header().Set("content-type", "application/json")
-		io.WriteString(w, `{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{}}`)
+		writeFixture(t, w, `{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{}}`)
 	}))
 	defer upstream.Close()
 

--- a/backend/internal/server/provider_stream_adapter_test.go
+++ b/backend/internal/server/provider_stream_adapter_test.go
@@ -48,17 +48,17 @@ func TestAnthropicAdapterStreamsIncrementally(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		flusher, _ := w.(http.Flusher)
 
-		io.WriteString(w, "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":4}}}\n\n")
-		io.WriteString(w, "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"first\"}}\n\n")
+		writeFixture(t, w, "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":4}}}\n\n")
+		writeFixture(t, w, "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"first\"}}\n\n")
 		flusher.Flush()
 
 		// Hold the rest of the response back; the client must already have the
 		// first chunk. A buffered implementation would deadlock this test.
 		<-release
 
-		io.WriteString(w, "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"second\"}}\n\n")
-		io.WriteString(w, "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":6}}\n\n")
-		io.WriteString(w, "data: {\"type\":\"message_stop\"}\n\n")
+		writeFixture(t, w, "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"second\"}}\n\n")
+		writeFixture(t, w, "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":6}}\n\n")
+		writeFixture(t, w, "data: {\"type\":\"message_stop\"}\n\n")
 		flusher.Flush()
 	}))
 	defer upstream.Close()
@@ -116,7 +116,7 @@ func TestGeminiAdapterStreamRequestTargetsSSEEndpoint(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		captured = r.Clone(r.Context())
 		w.Header().Set("content-type", "text/event-stream")
-		io.WriteString(w, "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hi\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":2,\"candidatesTokenCount\":3}}\n\n")
+		writeFixture(t, w, "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hi\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":2,\"candidatesTokenCount\":3}}\n\n")
 	}))
 	defer upstream.Close()
 
@@ -153,12 +153,12 @@ func TestGeminiAdapterStreamRequestTargetsSSEEndpoint(t *testing.T) {
 func TestAnthropicAdapterChatConvertsToolCalls(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var payload map[string]any
-		json.NewDecoder(r.Body).Decode(&payload)
+		decodeFixtureRequest(t, r.Body, &payload)
 		if _, present := payload["tools"]; !present {
 			t.Errorf("tools must reach the provider, got %v", payload)
 		}
 		w.Header().Set("content-type", "application/json")
-		io.WriteString(w, `{"content":[{"type":"tool_use","id":"toolu_1","name":"ping","input":{"a":1}}],`+
+		writeFixture(t, w, `{"content":[{"type":"tool_use","id":"toolu_1","name":"ping","input":{"a":1}}],`+
 			`"stop_reason":"tool_use","usage":{"input_tokens":3,"output_tokens":5}}`)
 	}))
 	defer upstream.Close()
@@ -188,7 +188,7 @@ func TestAnthropicAdapterChatConvertsToolCalls(t *testing.T) {
 func TestAnthropicAdapterPropagatesUpstreamHTTPError(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusTooManyRequests)
-		io.WriteString(w, `{"error":{"type":"rate_limit_error","message":"slow down"}}`)
+		writeFixture(t, w, `{"error":{"type":"rate_limit_error","message":"slow down"}}`)
 	}))
 	defer upstream.Close()
 
@@ -207,5 +207,24 @@ func TestAnthropicAdapterPropagatesUpstreamHTTPError(t *testing.T) {
 	}
 	if status := AsHTTPError(err).Status; status != http.StatusTooManyRequests {
 		t.Fatalf("expected the upstream status to be preserved, got %d", status)
+	}
+}
+
+// writeFixture writes a canned upstream response body. The write itself cannot
+// realistically fail against an httptest recorder, but an unchecked error here is
+// how a fixture server silently stops serving what the test believes it serves.
+func writeFixture(t *testing.T, w io.Writer, body string) {
+	t.Helper()
+	if _, err := io.WriteString(w, body); err != nil {
+		t.Errorf("write fixture response: %v", err)
+	}
+}
+
+// decodeFixtureRequest decodes what the adapter sent upstream. Ignoring this error
+// would turn a malformed request into a confusing assertion failure further down.
+func decodeFixtureRequest(t *testing.T, body io.Reader, target any) {
+	t.Helper()
+	if err := json.NewDecoder(body).Decode(target); err != nil {
+		t.Errorf("decode upstream request: %v", err)
 	}
 }

--- a/backend/internal/server/store.go
+++ b/backend/internal/server/store.go
@@ -3845,7 +3845,10 @@ func (s *GormStore) copySQLiteDatabase(path string, restore bool) error {
 			if err != nil {
 				return err
 			}
-			defer backup.Finish()
+			// Finish only releases the backup handle; the copy's success is decided
+			// by Step above, and this runs in a defer where nothing could act on a
+			// failure anyway.
+			defer backup.Finish() //nolint:errcheck // release-only, result not actionable
 			for {
 				done, err := backup.Step(64)
 				if err != nil {


### PR DESCRIPTION
## Summary

The repository had no linter configuration. This adds one and fixes everything it reports, so the check can be enabled in CI without landing red — a linter that starts out failing is one people learn to ignore.

This is the prerequisite for a `Lint` workflow, which is intentionally not in this PR: adding the workflow first would fail every pull request until these findings were cleared.

## Related Issue

N/A

## Changes

- **`.golangci.yml`** using the standard set (errcheck, govet, ineffassign, staticcheck, unused). Deliberately not a wide selection: on an existing codebase a broad rule set produces noise unrelated to whatever is under review.
- **Two exclusions kept narrower than the obvious defaults.**
  - The `std-error-handling` preset is *not* enabled. Besides `Close` it also drops `Flush`, `Remove`, `Print*` and `Setenv` — a `Flush` error means data did not reach its destination and must stay visible. Only `Close` on a reader, connection or file is exempt.
  - Test files are *not* exempted from errcheck. An ignored error in test setup or in a fixture server is exactly what makes a test quietly stop testing anything.
  - The two remaining unchecked calls carry a `//nolint` with the reason they are safe (`backup.Finish` releases a handle after `Step` already decided the result; `smtp.Client.Close` is a safety net after `Quit`, whose error *is* returned).
- **Issue caps lifted.** golangci-lint reports at most three instances of the same finding by default. That default reported 6 unchecked errors here when there were in fact **14** — a "clean" run under it would have been misleading.
- **Findings fixed:**
  - *Eight unused symbols removed*, each confirmed to have no remaining references. Two were thin wrappers whose callers had moved on (`shouldFailoverProviderError`, `authorizeAdmin`). One was a package-level `fetchOpenAIAccountQuota` sitting alongside an identically named method that is still in use — removing it also removes that ambiguity. One (`anthropicRequestJSON`) carried a comment claiming it was "used by both adapter paths", which was no longer true.
  - *Fourteen unchecked errors.* The thirteen in tests now run through checked helpers (`writeFixture`, `decodeFixtureRequest`) instead of being ignored.
  - *Two ineffectual assignments* where a variable was given an empty literal and then unconditionally reassigned.
- **QF class disabled.** staticcheck's "quickfix" checks are refactoring advice about style (use a tagged switch, apply De Morgan's law); adopting them should be a deliberate choice rather than a side effect of turning the linter on.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [x] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [ ] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- `golangci-lint run ./...` from `backend/`: **0 issues** (v2.12.2; the config is discovered from the repository root).
- `gofmt -l internal/ cmd/` clean; `go vet ./...` clean; `go test ./...` passes (`ok tokenhub/backend/internal/server 15.4s`).
- `git diff --check` passes.
- Before deleting each unused symbol its name was grepped across `internal/` and `cmd/` to confirm the only occurrence was the definition itself; the full test suite passing after removal confirms nothing referenced them indirectly.
- Frontend, SDK and Compose checks were not run: this change touches only Go source and a lint configuration.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: none. No behaviour changes — the deletions are unreferenced code, and the two assignment fixes replace values that were unconditionally overwritten before use.
- Security or credential-handling impact: none. Errors that were previously discarded in tests are now reported, which can only surface problems rather than hide them.
- Database, environment, or deployment impact: none. No new dependencies at runtime; golangci-lint is a development and CI tool only.
- Rollout and rollback considerations: no runtime effect. Merge order matters only in one direction — this PR should land before a `Lint` workflow is added, otherwise that workflow fails on the findings cleared here.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented. (No behaviour changed; existing tests cover the touched paths and the test helpers are exercised by every test that uses the fixture servers.)
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable. (No environment variables changed.)
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable. (No user-facing behaviour changed.)
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable. (Not touched.)
- [x] `git diff --check` passes.
