### PR TITLE
fix(playground): support codex oauth responses

### DIFF
--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -690,6 +690,37 @@ func (s *Server) executeRoutedChat(r *http.Request, routed RoutedCall, req ChatC
 	})
 }
 
+func (s *Server) executeRoutedPlaygroundChat(r *http.Request, routed RoutedCall, req ChatCompletionRequest) (any, RouteSelection, Usage, []RouteAttempt, error) {
+	allowEffortFallback := normalizedReasoningEffort(req.ReasoningEffort) != nil
+	responsesReq := playgroundChatResponsesRequest(req)
+	return executeRoutedWithStore(r.Context(), s.store, routed, allowEffortFallback, func(ctx context.Context, route RouteSelection, omitReasoningEffort bool, _ int) (any, Usage, error) {
+		route, err := s.prepareRouteForUpstream(ctx, route)
+		if err != nil {
+			return nil, Usage{}, err
+		}
+		if route.Provider.Type == ProviderOpenAICodex {
+			upstreamReq := responsesReq
+			if omitReasoningEffort {
+				upstreamReq = withoutResponsesReasoningEffort(upstreamReq)
+			}
+			resp, usage, err := s.invokeResponsesAdapter(ctx, route, upstreamReq, r.Header)
+			if isCodexModelUnsupportedError(err) {
+				s.removeCodexResourceModel(routeResourceID(route), route.ProviderModel)
+			}
+			return resp, usage, err
+		}
+		adapter, err := s.adapterForRoute(route)
+		if err != nil {
+			return nil, Usage{}, err
+		}
+		upstreamReq := req
+		if omitReasoningEffort {
+			upstreamReq.ReasoningEffort = nil
+		}
+		return adapter.Chat(ctx, route.Provider, route.ProviderModel, upstreamReq)
+	})
+}
+
 func (s *Server) executeRoutedResponses(r *http.Request, routed RoutedCall, req ResponsesRequest) (any, RouteSelection, Usage, []RouteAttempt, error) {
 	allowEffortFallback := normalizedReasoningEffort(responsesReasoningEffort(req)) != nil
 	return executeRoutedWithStore(r.Context(), s.store, routed, allowEffortFallback, func(ctx context.Context, route RouteSelection, omitReasoningEffort bool, _ int) (any, Usage, error) {
@@ -697,28 +728,64 @@ func (s *Server) executeRoutedResponses(r *http.Request, routed RoutedCall, req 
 		if err != nil {
 			return nil, Usage{}, err
 		}
-		adapter, err := s.responsesAdapterForRoute(route)
-		if err != nil {
-			return nil, Usage{}, err
-		}
 		upstreamReq := req
 		if omitReasoningEffort {
 			upstreamReq = withoutResponsesReasoningEffort(upstreamReq)
 		}
-		var resp any
-		var usage Usage
-		if envelopeAdapter, ok := adapter.(ResponsesEnvelopeAdapter); ok {
-			resp, usage, err = envelopeAdapter.ResponsesWithHeaders(ctx, route.Provider, route.ProviderModel, upstreamReq, r.Header)
-		} else if responsesAdapter, ok := adapter.(ResponsesInvoker); ok {
-			resp, usage, err = responsesAdapter.Responses(ctx, route.Provider, route.ProviderModel, upstreamReq)
-		} else {
-			err = NewHTTPError(http.StatusBadRequest, "adapter_capability_unsupported", "Provider adapter does not support Responses")
-		}
+		resp, usage, err := s.invokeResponsesAdapter(ctx, route, upstreamReq, r.Header)
 		if isCodexModelUnsupportedError(err) {
 			s.removeCodexResourceModel(routeResourceID(route), route.ProviderModel)
 		}
 		return resp, usage, err
 	})
+}
+
+func (s *Server) invokeResponsesAdapter(ctx context.Context, route RouteSelection, req ResponsesRequest, incoming http.Header) (any, Usage, error) {
+	adapter, err := s.responsesAdapterForRoute(route)
+	if err != nil {
+		return nil, Usage{}, err
+	}
+	if envelopeAdapter, ok := adapter.(ResponsesEnvelopeAdapter); ok {
+		return envelopeAdapter.ResponsesWithHeaders(ctx, route.Provider, route.ProviderModel, req, incoming)
+	}
+	if responsesAdapter, ok := adapter.(ResponsesInvoker); ok {
+		return responsesAdapter.Responses(ctx, route.Provider, route.ProviderModel, req)
+	}
+	return nil, Usage{}, NewHTTPError(http.StatusBadRequest, "adapter_capability_unsupported", "Provider adapter does not support Responses")
+}
+
+func playgroundChatResponsesRequest(req ChatCompletionRequest) ResponsesRequest {
+	instructions := make([]string, 0, len(req.Messages))
+	input := make([]map[string]any, 0, len(req.Messages))
+	for _, message := range req.Messages {
+		role := strings.ToLower(strings.TrimSpace(message.Role))
+		text := contentToText(message.Content)
+		switch role {
+		case "system", "developer":
+			if strings.TrimSpace(text) != "" {
+				instructions = append(instructions, text)
+			}
+		case "assistant":
+			input = append(input, map[string]any{
+				"role":    "assistant",
+				"content": []map[string]any{{"type": "output_text", "text": text}},
+			})
+		default:
+			input = append(input, map[string]any{
+				"role":    role,
+				"content": []map[string]any{{"type": "input_text", "text": text}},
+			})
+		}
+	}
+	responsesReq := ResponsesRequest{
+		Model:        req.Model,
+		Input:        input,
+		Instructions: strings.Join(instructions, "\n\n"),
+	}
+	if effort := normalizedReasoningEffort(req.ReasoningEffort); effort != nil {
+		responsesReq.Reasoning = &ResponsesReasoning{Effort: effort}
+	}
+	return responsesReq
 }
 
 func (s *Server) executeRoutedCompact(r *http.Request, routed RoutedCall, request map[string]json.RawMessage) (any, RouteSelection, Usage, []RouteAttempt, error) {
@@ -809,7 +876,7 @@ func (s *Server) handleAdminPlaygroundChat(w http.ResponseWriter, r *http.Reques
 		},
 	}
 	routed.Routes = s.planRouteOrder(routed.Call, routes)
-	resp, route, usage, attempts, err := s.executeRoutedChat(r, routed, req)
+	resp, route, usage, attempts, err := s.executeRoutedPlaygroundChat(r, routed, req)
 	if err != nil {
 		httpErr := AsHTTPError(err)
 		route = lastAttemptRoute(attempts)

--- a/backend/internal/server/http_test.go
+++ b/backend/internal/server/http_test.go
@@ -331,6 +331,119 @@ func TestAdminPlaygroundChatUsesRoutesWithoutProjectBilling(t *testing.T) {
 	}
 }
 
+func TestAdminPlaygroundChatUsesResponsesForCodexSubscription(t *testing.T) {
+	store := NewMemoryStore()
+	provider := store.AddProvider(Provider{
+		ID:      "prv_playground_codex",
+		Name:    "Playground Codex",
+		Type:    ProviderOpenAICodex,
+		Status:  StatusActive,
+		Healthy: true,
+	})
+	resource, err := store.AddProviderResource(ProviderResource{
+		ID:           "rsrc_playground_codex",
+		ProviderID:   provider.ID,
+		Name:         "Playground Codex Account",
+		ResourceType: ProviderResourceOpenAISubscription,
+		Status:       StatusActive,
+		Healthy:      true,
+		Options:      codexCapabilityOptionsForTest("gpt-playground-codex"),
+		Credentials: &ProviderResourceCredentials{
+			AccessToken: "access_playground_codex",
+			AccountID:   "account_playground_codex",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.AddModel(Model{Name: "gpt-playground-codex", Status: StatusActive})
+	store.AddRoute(ModelRoute{
+		ID:                 "route_playground_codex",
+		ModelName:          "gpt-playground-codex",
+		ProviderID:         provider.ID,
+		ProviderResourceID: resource.ID,
+		ProviderModel:      "gpt-playground-codex",
+		Status:             StatusActive,
+	})
+
+	server := New(store)
+	server.codexSubscription.Client = &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path != "/backend-api/codex/responses" {
+			t.Fatalf("expected Codex Responses endpoint, got %s", req.URL)
+		}
+		if req.Header.Get("Authorization") != "Bearer access_playground_codex" || req.Header.Get("ChatGPT-Account-ID") != "account_playground_codex" {
+			t.Fatalf("expected OAuth account credentials, got %#v", req.Header)
+		}
+		var payload map[string]any
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		if payload["model"] != "gpt-playground-codex" || payload["instructions"] != "Be concise." || payload["stream"] != true {
+			t.Fatalf("unexpected Codex playground payload: %#v", payload)
+		}
+		if _, ok := payload["max_output_tokens"]; ok {
+			t.Fatalf("Codex playground request must not send max_output_tokens: %#v", payload)
+		}
+		if _, ok := payload["temperature"]; ok {
+			t.Fatalf("Codex playground request must not send temperature: %#v", payload)
+		}
+		reasoning, _ := payload["reasoning"].(map[string]any)
+		if reasoning["effort"] != "high" {
+			t.Fatalf("expected playground reasoning effort, got %#v", payload["reasoning"])
+		}
+		input, _ := payload["input"].([]any)
+		if len(input) != 3 {
+			t.Fatalf("expected user, assistant, and user history in Responses input, got %#v", payload["input"])
+		}
+		first, _ := input[0].(map[string]any)
+		second, _ := input[1].(map[string]any)
+		third, _ := input[2].(map[string]any)
+		if first["role"] != "user" || second["role"] != "assistant" || third["role"] != "user" {
+			t.Fatalf("unexpected Responses roles: %#v", input)
+		}
+		firstContent, _ := first["content"].([]any)
+		secondContent, _ := second["content"].([]any)
+		firstPart, _ := firstContent[0].(map[string]any)
+		secondPart, _ := secondContent[0].(map[string]any)
+		if firstPart["type"] != "input_text" || firstPart["text"] != "First question" || secondPart["type"] != "output_text" || secondPart["text"] != "First answer" {
+			t.Fatalf("unexpected Responses content: %#v", input)
+		}
+		stream := strings.Join([]string{
+			"event: response.output_text.delta",
+			`data: {"type":"response.output_text.delta","delta":"Codex playground works."}`,
+			"",
+			"event: response.completed",
+			`data: {"type":"response.completed","response":{"id":"resp_playground","status":"completed","model":"gpt-playground-codex","output":[],"usage":{"input_tokens":5,"output_tokens":4,"total_tokens":9}}}`,
+			"",
+		}, "\n")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(stream)),
+			Request:    req,
+		}, nil
+	})}
+
+	resp := doJSON(t, server.Handler(), http.MethodPost, "/api/admin/playground/chat", map[string]any{
+		"model": "gpt-playground-codex",
+		"messages": []map[string]any{
+			{"role": "system", "content": "Be concise."},
+			{"role": "user", "content": "First question"},
+			{"role": "assistant", "content": "First answer"},
+			{"role": "user", "content": "Second question"},
+		},
+		"max_tokens":       321,
+		"temperature":      0.2,
+		"reasoning_effort": "high",
+	}, "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected Codex playground request to succeed, got %d: %s", resp.Code, resp.Body)
+	}
+	if !strings.Contains(resp.Body, "Codex playground works.") || !strings.Contains(resp.Body, `"prompt_tokens":5`) || !strings.Contains(resp.Body, `"completion_tokens":4`) {
+		t.Fatalf("unexpected Codex playground response: %s", resp.Body)
+	}
+}
+
 func TestGatewayEmbeddings(t *testing.T) {
 	app := newTestServer()
 	resp := doJSON(t, app, http.MethodPost, "/v1/embeddings", map[string]any{


### PR DESCRIPTION
## Summary

Fix the admin Playground for OpenAI Codex subscription providers. The Playground accepts Chat Completions-shaped UI requests, while Codex OAuth supports the Responses upstream protocol. The handler now converts requests per selected Codex route and omits `max_output_tokens` and `temperature`, which the Codex upstream rejects.

## Related Issue

N/A

## Changes

- Route admin Playground requests through Responses for `openai_codex` provider routes while keeping other providers on Chat Completions.
- Translate system and developer instructions plus conversation history into the Responses payload.
- Preserve reasoning effort and omit unsupported Codex output and sampling parameters.
- Add a regression test covering OAuth headers, Responses payload, SSE response, and parameter omission.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [x] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [ ] Frontend: `npm run typecheck` and `npm run build` (not run; backend-only change)
- [ ] SDK smoke tests against a compatible backend (not run; no compatible external backend needed)
- [ ] Docker Compose configuration rendered successfully (not run; no deployment change)
- [x] Other focused or manual verification described below

Verification details:

- `go test ./internal/server -run "^TestAdminPlaygroundChatUsesResponsesForCodexSubscription$" -count=1` passed.
- `git diff --check` passed.
- Local TokenHub restarted successfully; `GET /healthz` returned 200 and `GET /playground` returned 200.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: None. The change is limited to the admin Playground endpoint.
- Security or credential-handling impact: Existing OAuth access token and account ID forwarding are preserved; no credentials are logged or added.
- Database, environment, or deployment impact: None.
- Rollout and rollback considerations: Deploy normally. Revert this commit to restore previous Playground routing behavior.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.