### PR TITLE
Codex/vendor provider catalog

### DIFF
--- a/backend/internal/server/http_test.go
+++ b/backend/internal/server/http_test.go
@@ -371,6 +371,7 @@ func TestBootstrapSeedsStandardModelCatalog(t *testing.T) {
 	}
 	for name, category := range map[string]string{
 		"gpt-5.5":                            "openai",
+		"kimi-k3":                            "kimi",
 		"zai-org/glm-5.2":                    "glm",
 		"moonshotai/kimi-k2.7-code":          "kimi",
 		"minimax/minimax-m3":                 "minimax",
@@ -394,6 +395,27 @@ func TestBootstrapSeedsStandardModelCatalog(t *testing.T) {
 	}
 	if !slices.Contains(byName["gpt-5.5"].InputModalities, "image") {
 		t.Fatalf("expected gpt-5.5 image input modality, got %+v", byName["gpt-5.5"].InputModalities)
+	}
+	if k3 := byName["kimi-k3"]; k3.ContextWindow != 1048576 || k3.InputPriceUSDPer1M != 3 || k3.CacheReadPriceUSDPer1M != 0.3 || k3.OutputPriceUSDPer1M != 15 {
+		t.Fatalf("unexpected Kimi K3 limits or pricing: %+v", k3)
+	}
+	if k3 := byName["kimi-k3"]; !slices.Contains(k3.InputModalities, "image") || !slices.Contains(k3.InputModalities, "video") {
+		t.Fatalf("expected Kimi K3 visual input modalities, got %+v", k3.InputModalities)
+	}
+	if k3 := byName["kimi-k3"]; slices.Contains(k3.SupportedParameters, "temperature") || !slices.Contains(k3.SupportedParameters, "reasoning") {
+		t.Fatalf("unexpected Kimi K3 parameters: %+v", k3.SupportedParameters)
+	}
+	for name, expected := range map[string]struct {
+		input, cacheRead, output float64
+	}{
+		"moonshotai/kimi-k2.7-code": {0.95, 0.19, 4},
+		"moonshotai/kimi-k2.6":      {0.95, 0.16, 4},
+		"moonshotai/kimi-k2.5":      {0.6, 0.1, 3},
+	} {
+		model := byName[name]
+		if model.InputPriceUSDPer1M != expected.input || model.CacheReadPriceUSDPer1M != expected.cacheRead || model.OutputPriceUSDPer1M != expected.output {
+			t.Fatalf("unexpected %s pricing: %+v", name, model)
+		}
 	}
 	if byName["gpt-image-2"].Modality != "image" {
 		t.Fatalf("expected gpt-image-2 image modality, got %s", byName["gpt-image-2"].Modality)

--- a/data/model-catalog.yaml
+++ b/data/model-catalog.yaml
@@ -106,31 +106,59 @@ models:
       reasoning_default: "true"
   - name: "moonshotai/kimi-k2.7-code"
     title: "Kimi K2.7 Code"
-    description: "Kimi K2.7 Code is MoonshotAI's strongest coding & agentic model — a 1T-parameter MoE (32B activated) , 256K context and interleaved thinking with multi-step tool calling. It delivers major gains on long-horizon coding tasks while cutting thinking-token usage by ~30% vs K2.6, and accepts text, image and video inputs for vision-driven development workflows."
+    description: "Kimi K2.7 Code is Kimi's dedicated coding model. It improves long-context instruction following and long-horizon coding success rates, supports text, image, and video input, and provides 256K context with always-on thinking and multi-step tool calling."
     category: "kimi"
     family: "kimi"
     modality: "chat"
     context_window: 262144
-    input_price_usd_per_1m: 9.5
-    output_price_usd_per_1m: 40
+    input_price_usd_per_1m: 0.95
+    cache_read_price_usd_per_1m: 0.19
+    output_price_usd_per_1m: 4
     input_modalities: ["text", "image", "video"]
     output_modalities: ["text"]
     capabilities: ["chat", "vision", "video_input", "reasoning", "tools", "serverless", "structured_outputs"]
-    supported_parameters: ["temperature", "tools", "response_format", "reasoning", "image_input", "video_input"]
+    supported_parameters: ["tools", "response_format", "reasoning", "image_input", "video_input"]
     metadata:
       source: "tokenhub-standard-catalog"
-      upstream_source: "public-provider-conf"
-      provider_catalog_id: "jiekou"
-      provider_catalog_updated_at: "2026-07-08T06:38:13.852Z"
-      provider_model_id: "moonshotai/kimi-k2.7-code"
+      upstream_source: "kimi-api-platform"
+      provider_model_id: "kimi-k2.7-code"
       provider_model_name: "Kimi K2.7 Code"
-      endpoints: "chat/completions,anthropic"
+      endpoints: "chat/completions"
       features: "serverless,function-calling,structured-outputs,reasoning"
       max_output_tokens: "262144"
       tool_call: "true"
       vision: "true"
       reasoning_supported: "true"
       reasoning_default: "true"
+      reasoning_mode: "always_on"
+  - name: "kimi-k3"
+    title: "Kimi K3"
+    description: "Kimi K3 is Kimi's flagship model for long-horizon coding, knowledge work, and deep reasoning. It has native visual understanding, supports text, image, and video input, and provides a 1M-token context window with always-on thinking."
+    category: "kimi"
+    family: "kimi"
+    modality: "chat"
+    context_window: 1048576
+    input_price_usd_per_1m: 3
+    cache_read_price_usd_per_1m: 0.3
+    output_price_usd_per_1m: 15
+    input_modalities: ["text", "image", "video"]
+    output_modalities: ["text"]
+    capabilities: ["chat", "vision", "video_input", "reasoning", "tools", "structured_outputs"]
+    supported_parameters: ["tools", "response_format", "reasoning", "image_input", "video_input"]
+    metadata:
+      source: "tokenhub-standard-catalog"
+      upstream_source: "kimi-api-platform"
+      provider_model_id: "kimi-k3"
+      provider_model_name: "Kimi K3"
+      endpoints: "chat/completions"
+      features: "function-calling,structured-outputs,reasoning"
+      max_output_tokens: "1048576"
+      tool_call: "true"
+      vision: "true"
+      reasoning_supported: "true"
+      reasoning_default: "true"
+      reasoning_mode: "always_on"
+      reasoning_effort_options: "low,high,max"
   - name: "minimax/minimax-m3"
     title: "MiniMax M3"
     description: "MiniMax-M3 is a multimodal foundation model from MiniMax. It supports text, image, and video inputs with text output, a 1M-token context window, and is suited for long-horizon agentic work, coding, and tool use. It is built on MiniMax Sparse Attention (MSA), which replaces full attention with KV-block selection to cut per-token compute at long context — roughly 1/20 the cost of the previous generation at 1M tokens, with substantially faster prefill and decode while retaining quality across most tasks.\nTrained as a native multimodal model on interleaved data and tuned for multi-turn, production-like collaboration via an interactive user-simulator framework, the model is oriented toward sustained, multi-step tasks rather than single-turn execution."
@@ -384,25 +412,24 @@ models:
       reasoning_default: "true"
   - name: "moonshotai/kimi-k2.5"
     title: "Kimi K2.5"
-    description: "Kimi K2.5 is the latest flagship iteration of Moonshot AI's large language model series, representing a significant leap in multimodal and agentic capabilities. It features a native multimodal architecture supporting both visual and text inputs, alongside versatile thinking and non-thinking modes. This model maintains the substantial 256k token context window found in the K2 series but achieves new open-source state-of-the-art (SoTA) performance across general intelligence, coding, and visual understanding benchmarks. Kimi K2.5 delivers a breakthrough in frontend development, enabling the generation of fully functional, aesthetically polished interactive interfaces with complex dynamic layouts directly from natural language. Optimized for complex problem-solving, it excels in multi-step tool invocation, logical reasoning, and full-stack code synthesis."
+    description: "Kimi K2.5 is a multimodal Kimi model for agentic, coding, visual understanding, and general intelligence tasks. It supports text, image, and video input, thinking and non-thinking modes, dialogue and Agent tasks, and a 256K-token context window."
     category: "kimi"
     family: "kimi"
     modality: "chat"
     context_window: 262144
-    input_price_usd_per_1m: 6
-    output_price_usd_per_1m: 30
+    input_price_usd_per_1m: 0.6
+    cache_read_price_usd_per_1m: 0.1
+    output_price_usd_per_1m: 3
     input_modalities: ["text", "image", "video"]
     output_modalities: ["text"]
     capabilities: ["chat", "vision", "video_input", "reasoning", "tools", "serverless", "structured_outputs"]
     supported_parameters: ["temperature", "tools", "response_format", "reasoning", "image_input", "video_input"]
     metadata:
       source: "tokenhub-standard-catalog"
-      upstream_source: "public-provider-conf"
-      provider_catalog_id: "jiekou"
-      provider_catalog_updated_at: "2026-07-08T06:38:13.852Z"
-      provider_model_id: "moonshotai/kimi-k2.5"
+      upstream_source: "kimi-api-platform"
+      provider_model_id: "kimi-k2.5"
       provider_model_name: "Kimi K2.5"
-      endpoints: "chat/completions,anthropic"
+      endpoints: "chat/completions"
       features: "serverless,reasoning,structured-outputs,function-calling"
       max_output_tokens: "262144"
       tool_call: "true"
@@ -2615,25 +2642,24 @@ models:
       reasoning_default: "true"
   - name: "moonshotai/kimi-k2.6"
     title: "Kimi K2.6"
-    description: "Kimi K2.5 is the latest flagship iteration of Moonshot AI's large language model series, representing a significant leap in multimodal and agentic capabilities. It features a native multimodal architecture supporting both visual and text inputs, alongside versatile thinking and non-thinking modes. This model maintains the substantial 256k token context window found in the K2 series but achieves new open-source state-of-the-art (SoTA) performance across general intelligence, coding, and visual understanding benchmarks. Kimi K2.5 delivers a breakthrough in frontend development, enabling the generation of fully functional, aesthetically polished interactive interfaces with complex dynamic layouts directly from natural language. Optimized for complex problem-solving, it excels in multi-step tool invocation, logical reasoning, and full-stack code synthesis."
+    description: "Kimi K2.6 is Kimi's general-purpose model for long-horizon coding, dialogue, and Agent tasks. It supports text, image, and video input, thinking and non-thinking modes, multi-step tool calling, and a 256K-token context window."
     category: "kimi"
     family: "kimi"
     modality: "chat"
     context_window: 262144
-    input_price_usd_per_1m: 6
-    output_price_usd_per_1m: 30
+    input_price_usd_per_1m: 0.95
+    cache_read_price_usd_per_1m: 0.16
+    output_price_usd_per_1m: 4
     input_modalities: ["text", "image", "video"]
     output_modalities: ["text"]
     capabilities: ["chat", "vision", "video_input", "reasoning", "tools", "serverless", "structured_outputs"]
     supported_parameters: ["temperature", "tools", "response_format", "reasoning", "image_input", "video_input"]
     metadata:
       source: "tokenhub-standard-catalog"
-      upstream_source: "public-provider-conf"
-      provider_catalog_id: "jiekou"
-      provider_catalog_updated_at: "2026-07-08T06:38:13.852Z"
-      provider_model_id: "moonshotai/kimi-k2.6"
+      upstream_source: "kimi-api-platform"
+      provider_model_id: "kimi-k2.6"
       provider_model_name: "Kimi K2.6"
-      endpoints: "chat/completions,anthropic"
+      endpoints: "chat/completions"
       features: "serverless,reasoning,structured-outputs,function-calling"
       max_output_tokens: "262144"
       tool_call: "true"


### PR DESCRIPTION
> PR title format: `<type>[optional scope][!]: <short summary>` in English, max 72 characters.
> Common types include `feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `style`, and `revert`. Use a lowercase imperative summary without a trailing period.

## Summary

<!-- What problem does this PR solve, and why is the change needed? -->

## Related Issue

<!-- Link the issue or ticket when one exists. Use "N/A" otherwise. -->

## Changes

<!-- Describe the main changes. Group related backend, frontend, SDK, deployment, catalog, and documentation updates. -->

-

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

<!-- List the exact commands or manual checks you ran and their results. Explain why any relevant check was skipped. -->

- [ ] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [ ] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [ ] Other focused or manual verification described below

Verification details:

-

## Compatibility, Security, and Operations

<!-- Call out API contract changes, migrations, rollout/rollback needs, and security-sensitive behavior. Use "None" where applicable. -->

- OpenAI-compatible `/v1` API impact:
- Security or credential-handling impact:
- Database, environment, or deployment impact:
- Rollout and rollback considerations:

## Checklist

- [ ] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [ ] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [ ] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [ ] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [ ] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [ ] `git diff --check` passes.
