### PR TITLE
fix(models): avoid sending string metadata on edit

### DIFF
--- a/frontend/features/admin/resources/payloads.tsx
+++ b/frontend/features/admin/resources/payloads.tsx
@@ -136,7 +136,20 @@ export function providerResourceToForm(item: ProviderResource) {
 }
 
 export function modelPayload(values: Record<string, string>) {
-  const payload = numberPayload(values, ["context_window", "input_price_usd_per_1m", "cache_read_price_usd_per_1m", "output_price_usd_per_1m", "embedding_price_usd_per_1m"]);
+  const payload = numberPayload(
+    {
+      name: values.name,
+      family: values.family,
+      modality: values.modality,
+      context_window: values.context_window,
+      input_price_usd_per_1m: values.input_price_usd_per_1m,
+      cache_read_price_usd_per_1m: values.cache_read_price_usd_per_1m,
+      output_price_usd_per_1m: values.output_price_usd_per_1m,
+      embedding_price_usd_per_1m: values.embedding_price_usd_per_1m,
+      status: values.status,
+    },
+    ["context_window", "input_price_usd_per_1m", "cache_read_price_usd_per_1m", "output_price_usd_per_1m", "embedding_price_usd_per_1m"],
+  );
   if (values.modality === "embedding") {
     payload.cache_read_price_usd_per_1m = 0;
   }


### PR DESCRIPTION
## Summary

Fix model edits that failed when changing a model capability, such as from text/chat to video. The generic edit form serialized hidden model metadata as a JSON string, while the Go API expects `metadata` to be an object.

## Related Issue

N/A

## Changes

- Build model create and update payloads from an explicit allowlist of editable fields.
- Prevent hidden fields such as stringified `metadata` and `created_at` from leaking into model API requests.
- Preserve editable modality and pricing fields when constructing the request.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [x] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [x] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- `go test ./...` passed; no Go files changed, so `gofmt` was not applicable.
- `go vet ./...` passed.
- `npm run typecheck` passed.
- `npm run build` passed.
- `git diff --check` passed.
- A focused before/after payload harness reproduced the string-valued `metadata` leak on the base revision and confirmed that the fixed payload excludes `metadata` and `created_at` while retaining `modality: "video"` and numeric model fields.
- SDK smoke tests were skipped because this frontend-only serialization fix does not change the OpenAI-compatible or security-policy APIs.
- Docker Compose validation was skipped because there are no deployment or configuration changes.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: None.
- Security or credential-handling impact: None.
- Database, environment, or deployment impact: None.
- Rollout and rollback considerations: Standard frontend rollout; rollback by reverting this commit.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.

No checked-in test was added because the frontend currently has no unit test runner. The focused payload harness and the full frontend typecheck/build cover this targeted serialization change.
