### PR TITLE
fix(gateway): accept Claude Code mid-conversation system messages

### DIFF
--- a/backend/internal/server/anthropic_messages.go
+++ b/backend/internal/server/anthropic_messages.go
@@ -20,6 +20,8 @@ type anthropicMessagesRequest struct {
 	Stream    bool
 }
 
+const anthropicMidConversationSystemBeta = "mid-conversation-system-2026-04-07"
+
 func (s *Server) handleAnthropicMessages(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		writeAnthropicError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
@@ -100,13 +102,14 @@ func decodeAnthropicMessagesRequest(r *http.Request, requireMaxTokens bool) (ant
 	if !ok || len(messages) == 0 {
 		return anthropicMessagesRequest{}, NewHTTPError(http.StatusBadRequest, "missing_messages", "messages are required")
 	}
+	allowSystemMessages := anthropicBetaEnabled(r.Header.Get("anthropic-beta"), anthropicMidConversationSystemBeta)
 	for _, item := range messages {
 		message, ok := item.(map[string]any)
 		if !ok {
 			return anthropicMessagesRequest{}, NewHTTPError(http.StatusBadRequest, "invalid_message", "each message must be an object")
 		}
 		role, _ := message["role"].(string)
-		if role != "user" && role != "assistant" {
+		if role != "user" && role != "assistant" && !(allowSystemMessages && role == "system") {
 			return anthropicMessagesRequest{}, NewHTTPError(http.StatusBadRequest, "invalid_message", "message role must be user or assistant")
 		}
 		if _, exists := message["content"]; !exists {
@@ -125,6 +128,15 @@ func decodeAnthropicMessagesRequest(r *http.Request, requireMaxTokens bool) (ant
 		Messages:  messages,
 		Stream:    stream,
 	}, nil
+}
+
+func anthropicBetaEnabled(header string, target string) bool {
+	for _, beta := range strings.Split(header, ",") {
+		if strings.TrimSpace(beta) == target {
+			return true
+		}
+	}
+	return false
 }
 
 func keyCanAccessModel(store Store, key APIKey, model string) bool {
@@ -416,6 +428,13 @@ func anthropicSystemText(value any) (string, error) {
 
 func anthropicMessageToOpenAI(message map[string]any) ([]ChatMessage, error) {
 	role, _ := message["role"].(string)
+	if role == "system" {
+		content, err := anthropicSystemText(message["content"])
+		if err != nil {
+			return nil, err
+		}
+		return []ChatMessage{{Role: "system", Content: content}}, nil
+	}
 	blocks, err := anthropicContentBlocks(message["content"])
 	if err != nil {
 		return nil, err

--- a/backend/internal/server/anthropic_messages_test.go
+++ b/backend/internal/server/anthropic_messages_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -328,6 +327,121 @@ func TestAnthropicMessagesPreservesNativeProtocolAndHeaders(t *testing.T) {
 	if !strings.Contains(resp.Body.String(), `"model":"claude-tokenhub-test"`) ||
 		!strings.Contains(resp.Body.String(), `"type":"tool_use"`) {
 		t.Fatalf("native response was not preserved and remapped: %s", resp.Body)
+	}
+}
+
+func TestAnthropicMessagesConvertsMidConversationSystemForOpenAI(t *testing.T) {
+	var upstreamPayload map[string]any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&upstreamPayload); err != nil {
+			t.Errorf("decode upstream request: %v", err)
+		}
+		w.Header().Set("content-type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl_mid_system",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":10,"completion_tokens":1,"total_tokens":11}
+		}`)
+	}))
+	defer upstream.Close()
+
+	handler, _, secret := newAnthropicGateway(t, upstream.URL, ProviderOpenAICompatible)
+	resp := doAnthropicRequestWithBeta(t, handler, "/v1/messages", map[string]any{
+		"model":      "claude-tokenhub-test",
+		"max_tokens": 1024,
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Inspect the repository."},
+			map[string]any{
+				"role": "system",
+				"content": []any{
+					map[string]any{
+						"type":          "text",
+						"text":          "Keep the next response concise.",
+						"cache_control": map[string]any{"type": "ephemeral"},
+					},
+				},
+			},
+			map[string]any{"role": "user", "content": "Summarize it."},
+		},
+	}, "Bearer "+secret, "", "interleaved-thinking-2025-05-14, "+anthropicMidConversationSystemBeta)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	messages, _ := upstreamPayload["messages"].([]any)
+	if len(messages) != 3 {
+		t.Fatalf("expected three ordered upstream messages, got %#v", messages)
+	}
+	systemMessage, _ := messages[1].(map[string]any)
+	if systemMessage["role"] != "system" || systemMessage["content"] != "Keep the next response concise." {
+		t.Fatalf("expected translated mid-conversation system message, got %#v", systemMessage)
+	}
+}
+
+func TestAnthropicMessagesPreservesMidConversationSystemForNativeRoute(t *testing.T) {
+	var upstreamPayload map[string]any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("anthropic-beta") != anthropicMidConversationSystemBeta {
+			t.Errorf("unexpected beta %q", r.Header.Get("anthropic-beta"))
+		}
+		if err := json.NewDecoder(r.Body).Decode(&upstreamPayload); err != nil {
+			t.Errorf("decode upstream request: %v", err)
+		}
+		w.Header().Set("content-type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"msg_mid_system",
+			"type":"message",
+			"role":"assistant",
+			"model":"upstream-model",
+			"content":[{"type":"text","text":"ok"}],
+			"stop_reason":"end_turn",
+			"stop_sequence":null,
+			"usage":{"input_tokens":10,"output_tokens":1}
+		}`)
+	}))
+	defer upstream.Close()
+
+	handler, _, secret := newAnthropicGateway(t, upstream.URL, ProviderAnthropic)
+	resp := doAnthropicRequestWithBeta(t, handler, "/v1/messages", map[string]any{
+		"model":      "claude-tokenhub-test",
+		"max_tokens": 1024,
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Inspect the repository."},
+			map[string]any{"role": "system", "content": "Keep the next response concise."},
+			map[string]any{"role": "user", "content": "Summarize it."},
+		},
+	}, "Bearer "+secret, "", anthropicMidConversationSystemBeta)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	messages, _ := upstreamPayload["messages"].([]any)
+	if len(messages) != 3 {
+		t.Fatalf("expected native messages to be preserved, got %#v", messages)
+	}
+	systemMessage, _ := messages[1].(map[string]any)
+	if systemMessage["role"] != "system" || systemMessage["content"] != "Keep the next response concise." {
+		t.Fatalf("expected native mid-conversation system message, got %#v", systemMessage)
+	}
+}
+
+func TestAnthropicMessagesRejectsSystemRoleWithoutBeta(t *testing.T) {
+	body := bytes.NewBufferString(`{
+		"model":"claude-tokenhub-test",
+		"max_tokens":1024,
+		"messages":[
+			{"role":"user","content":"Inspect the repository."},
+			{"role":"system","content":"Keep the next response concise."}
+		]
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", body)
+	req.Header.Set("content-type", "application/json")
+
+	_, err := decodeAnthropicMessagesRequest(req, true)
+	if err == nil {
+		t.Fatal("expected system role without beta to be rejected")
+	}
+	httpErr := AsHTTPError(err)
+	if httpErr.Status != http.StatusBadRequest || httpErr.Code != "invalid_message" {
+		t.Fatalf("expected invalid_message, got %#v", httpErr)
 	}
 }
 
@@ -717,6 +831,19 @@ func doAnthropicRequest(
 	apiKey string,
 ) *httptest.ResponseRecorder {
 	t.Helper()
+	return doAnthropicRequestWithBeta(t, handler, path, payload, authorization, apiKey, findTestBeta(payload))
+}
+
+func doAnthropicRequestWithBeta(
+	t *testing.T,
+	handler http.Handler,
+	path string,
+	payload any,
+	authorization string,
+	apiKey string,
+	beta string,
+) *httptest.ResponseRecorder {
+	t.Helper()
 	body, err := json.Marshal(payload)
 	if err != nil {
 		t.Fatal(err)
@@ -730,10 +857,7 @@ func doAnthropicRequest(
 	if apiKey != "" {
 		req.Header.Set("x-api-key", apiKey)
 	}
-	if strings.Contains(fmt.Sprint(payload), "interleaved-thinking") {
-		req.Header.Set("anthropic-beta", "interleaved-thinking-2025-05-14")
-	}
-	if beta := findTestBeta(payload); beta != "" {
+	if beta != "" {
 		req.Header.Set("anthropic-beta", beta)
 	}
 	resp := httptest.NewRecorder()

--- a/docs/ja/user-guide.md
+++ b/docs/ja/user-guide.md
@@ -165,6 +165,8 @@ curl --request POST \
 
 Anthropic ネイティブルートでは Anthropic content block と beta header を保持します。OpenAI 互換ルートではテキスト、画像、クライアントツール、ツール結果、並列ツール呼び出し、ストリーミング event を変換します。OpenAI 互換 Provider で表現できない Anthropic サーバーツールには `400 unsupported_tool` を返します。
 
+`mid-conversation-system-2026-04-07` を有効にした Claude Code リクエストでは、`messages` 内に `system` エントリを含めることができます。TokenHub は Anthropic ネイティブルートではそのエントリを保持し、OpenAI 互換ルートでは順序を維持した system message に変換します。この beta がない場合、`messages` で使用できる role は引き続き `user` と `assistant` のみです。
+
 ローカル Claude Code には `/v1` suffix を付けず、TokenHub Host URL を設定します。
 
 ```bash

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -165,6 +165,8 @@ curl --request POST \
 
 Native Anthropic routes preserve Anthropic content blocks and beta headers. OpenAI-compatible routes translate text, images, client tools, tool results, parallel tool calls, and streaming events. Anthropic server tools that cannot be represented by an OpenAI-compatible provider return `400 unsupported_tool`.
 
+Claude Code requests that enable `mid-conversation-system-2026-04-07` may include `system` entries inside `messages`. TokenHub preserves those entries on native Anthropic routes and translates them into ordered system messages on OpenAI-compatible routes. Without that beta, `messages` continues to accept only `user` and `assistant` roles.
+
 Configure local Claude Code with the TokenHub host URL, without the `/v1` suffix:
 
 ```bash

--- a/docs/zh-CN/user-guide.md
+++ b/docs/zh-CN/user-guide.md
@@ -165,6 +165,8 @@ curl --request POST \
 
 原生 Anthropic 路由保留 Anthropic 内容块与 beta Header。OpenAI 兼容路由转换文本、图片、客户端工具、工具结果、并行工具调用和流式事件。Anthropic 服务端工具无法转换到 OpenAI 兼容 Provider 时，接口返回 `400 unsupported_tool`。
 
+启用 `mid-conversation-system-2026-04-07` 的 Claude Code 请求可以在 `messages` 中包含 `system` 条目。TokenHub 会在原生 Anthropic 路由中保留这些条目，并在 OpenAI 兼容路由中将其转换为保持原顺序的系统消息。未启用该 beta 时，`messages` 仍只接受 `user` 和 `assistant` role。
+
 本地 Claude Code 使用 TokenHub Host URL，不添加 `/v1` 后缀：
 
 ```bash


### PR DESCRIPTION
## Summary

Fix Claude Code requests that fail with `400 message role must be user or assistant` when the `mid-conversation-system-2026-04-07` beta places a `system` entry inside `messages`.

TokenHub previously forwarded Anthropic beta headers but rejected the beta message shape before route selection. This change recognizes the beta explicitly, preserves the message on native Anthropic routes, and translates it in order for OpenAI-compatible routes. Requests without the beta retain the existing strict role validation.

## Related Issue

- https://github.com/anthropics/claude-code/issues/63469

## Changes

- Accept `messages[].role: system` only when `anthropic-beta` includes `mid-conversation-system-2026-04-07`.
- Preserve mid-conversation system entries and beta headers on native Anthropic routes.
- Translate text-only mid-conversation system entries into ordered system messages on OpenAI-compatible routes.
- Add regression coverage for native passthrough, OpenAI conversion, comma-separated beta headers, and rejection without the beta.
- Document the behavior in English, Simplified Chinese, and Japanese.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [x] Documentation
- [ ] Deployment or configuration

## Verification

- [x] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [ ] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- `GOCACHE=/private/tmp/tokenhub-go-cache go test ./internal/server -run 'TestAnthropicMessages(ConvertsMidConversationSystemForOpenAI|PreservesMidConversationSystemForNativeRoute|RejectsSystemRoleWithoutBeta)$'`
- `GOCACHE=/private/tmp/tokenhub-go-cache go test ./...`
- `GOCACHE=/private/tmp/tokenhub-go-cache go vet ./...`
- `git diff --check`
- Frontend, SDK smoke, and Docker checks were not run because this change only affects backend request translation and documentation; the in-process backend tests cover both provider route types without external dependencies.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: No change to the public Chat Completions contract. Anthropic `/v1/messages` requests using the named beta can now carry ordered system entries, which are translated for OpenAI-compatible upstreams.
- Security or credential-handling impact: None. The broader message role remains gated by an exact beta token.
- Database, environment, or deployment impact: None.
- Rollout and rollback considerations: No migration or configuration change is required. Roll back by reverting this commit; affected current Claude Code requests would resume returning the previous 400 response.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
