### PR TITLE
docs: embed star history chart

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -173,9 +173,13 @@ TokenHub は、実際のエンタープライズ利用からのフィードバ�
 
 ## Star History
 
-[![GitHub Repo stars](https://img.shields.io/github/stars/astaxie/TokenHub?style=social)](https://github.com/astaxie/TokenHub/stargazers)
-
-TokenHub の成長は [Star History のライブチャート](https://star-history.com/#astaxie/TokenHub&Date)で確認できます。
+<a href="https://www.star-history.com/?repos=astaxie%2Ftokenhub&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=astaxie/tokenhub&type=date&theme=dark&legend=top-left&sealed_token=hWH3kDnssTf49CCLxzq3NVqEp0WTL-HFhsdpQJJz1DUuZt0D-nu1jgXLnhCxrUrMYujv6IJJk12B1wCp5qiU2bU_J03ECSYvb3Y9Pv-gqX7RuwS4SehRrQ" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=astaxie/tokenhub&type=date&legend=top-left&sealed_token=hWH3kDnssTf49CCLxzq3NVqEp0WTL-HFhsdpQJJz1DUuZt0D-nu1jgXLnhCxrUrMYujv6IJJk12B1wCp5qiU2bU_J03ECSYvb3Y9Pv-gqX7RuwS4SehRrQ" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=astaxie/tokenhub&type=date&legend=top-left&sealed_token=hWH3kDnssTf49CCLxzq3NVqEp0WTL-HFhsdpQJJz1DUuZt0D-nu1jgXLnhCxrUrMYujv6IJJk12B1wCp5qiU2bU_J03ECSYvb3Y9Pv-gqX7RuwS4SehRrQ" />
+ </picture>
+</a>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -173,9 +173,13 @@ TokenHub grows through product feedback, gateway integrations, documentation, te
 
 ## Star History
 
-[![GitHub Repo stars](https://img.shields.io/github/stars/astaxie/TokenHub?style=social)](https://github.com/astaxie/TokenHub/stargazers)
-
-Track TokenHub's growth on the [live Star History chart](https://star-history.com/#astaxie/TokenHub&Date).
+<a href="https://www.star-history.com/?repos=astaxie%2Ftokenhub&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=astaxie/tokenhub&type=date&theme=dark&legend=top-left&sealed_token=hWH3kDnssTf49CCLxzq3NVqEp0WTL-HFhsdpQJJz1DUuZt0D-nu1jgXLnhCxrUrMYujv6IJJk12B1wCp5qiU2bU_J03ECSYvb3Y9Pv-gqX7RuwS4SehRrQ" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=astaxie/tokenhub&type=date&legend=top-left&sealed_token=hWH3kDnssTf49CCLxzq3NVqEp0WTL-HFhsdpQJJz1DUuZt0D-nu1jgXLnhCxrUrMYujv6IJJk12B1wCp5qiU2bU_J03ECSYvb3Y9Pv-gqX7RuwS4SehRrQ" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=astaxie/tokenhub&type=date&legend=top-left&sealed_token=hWH3kDnssTf49CCLxzq3NVqEp0WTL-HFhsdpQJJz1DUuZt0D-nu1jgXLnhCxrUrMYujv6IJJk12B1wCp5qiU2bU_J03ECSYvb3Y9Pv-gqX7RuwS4SehRrQ" />
+ </picture>
+</a>
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -173,9 +173,13 @@ TokenHub 的演进离不开真实企业场景里的使用反馈、网关集成�
 
 ## Star History
 
-[![GitHub Repo stars](https://img.shields.io/github/stars/astaxie/TokenHub?style=social)](https://github.com/astaxie/TokenHub/stargazers)
-
-在 [Star History 实时图表](https://star-history.com/#astaxie/TokenHub&Date)查看 TokenHub 的增长趋势。
+<a href="https://www.star-history.com/?repos=astaxie%2Ftokenhub&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=astaxie/tokenhub&type=date&theme=dark&legend=top-left&sealed_token=hWH3kDnssTf49CCLxzq3NVqEp0WTL-HFhsdpQJJz1DUuZt0D-nu1jgXLnhCxrUrMYujv6IJJk12B1wCp5qiU2bU_J03ECSYvb3Y9Pv-gqX7RuwS4SehRrQ" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=astaxie/tokenhub&type=date&legend=top-left&sealed_token=hWH3kDnssTf49CCLxzq3NVqEp0WTL-HFhsdpQJJz1DUuZt0D-nu1jgXLnhCxrUrMYujv6IJJk12B1wCp5qiU2bU_J03ECSYvb3Y9Pv-gqX7RuwS4SehRrQ" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=astaxie/tokenhub&type=date&legend=top-left&sealed_token=hWH3kDnssTf49CCLxzq3NVqEp0WTL-HFhsdpQJJz1DUuZt0D-nu1jgXLnhCxrUrMYujv6IJJk12B1wCp5qiU2bU_J03ECSYvb3Y9Pv-gqX7RuwS4SehRrQ" />
+ </picture>
+</a>
 
 ## License
 


### PR DESCRIPTION
## Summary

Replace the static GitHub stars badge and text link with an embedded Star History chart so readers can see the repository's growth directly from each README. The chart supports light and dark color schemes.

## Related Issue

N/A

## Changes

- Embed the Star History chart in the English README.
- Apply the same chart markup to the Simplified Chinese and Japanese READMEs.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [x] Documentation
- [ ] Deployment or configuration

## Verification

- [ ] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [ ] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- `git diff --check main...HEAD` passes.
- Manually reviewed the rendered chart markup for matching light and dark variants across all three READMEs.
- Backend, frontend, SDK, and Docker checks were not run because this change only updates README content.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: None.
- Security or credential-handling impact: None. The `sealed_token` value is a public Star History embed parameter included in README image URLs.
- Database, environment, or deployment impact: None.
- Rollout and rollback considerations: No special rollout is required; revert the documentation commit to roll back.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
