### PR TITLE
fix(frontend): use full API key issuance wizard

### DIFF
--- a/frontend/features/admin/shell/admin-console.tsx
+++ b/frontend/features/admin/shell/admin-console.tsx
@@ -31,7 +31,6 @@ import { modelRoutePolicyPayload } from "../views/model-routing-policy";
 import { OverviewView } from "../views/overview";
 import { PlaygroundPage } from "../views/playground";
 import { ProviderUpsertModal } from "../views/provider-editor";
-import { QuickAPIKeyModal } from "../views/quick-access";
 import { EditModal, SettingsView, usePagination } from "../views/settings-table";
 import { BillingView, UsageView } from "../views/usage-billing";
 
@@ -62,7 +61,6 @@ export function AdminConsole({ defaultBaseURL }: { defaultBaseURL: string }) {
   const [modal, setModal] = useState<ModalState<any> | null>(null);
   const [providerCreateOpen, setProviderCreateOpen] = useState(false);
   const [providerEditItem, setProviderEditItem] = useState<Provider | null>(null);
-  const [quickAPIKeyOpen, setQuickAPIKeyOpen] = useState(false);
   const [apiKeyWizardOpen, setApiKeyWizardOpen] = useState(false);
   const [apiKeyWizardInitialValues, setApiKeyWizardInitialValues] = useState<Record<string, string>>({});
   const [userImportOpen, setUserImportOpen] = useState(false);
@@ -606,7 +604,8 @@ export function AdminConsole({ defaultBaseURL }: { defaultBaseURL: string }) {
       return;
     }
     setIssuedKey("");
-    setQuickAPIKeyOpen(true);
+    setApiKeyWizardInitialValues({});
+    setApiKeyWizardOpen(true);
   }
 
   function quickCreateAPIKey(values: Record<string, string>, onCreated: () => void) {
@@ -905,18 +904,6 @@ export function AdminConsole({ defaultBaseURL }: { defaultBaseURL: string }) {
           setLoading={setLoading}
           setError={setError}
           setNotice={setNotice}
-        />
-      ) : null}
-
-      {quickAPIKeyOpen ? (
-        <QuickAPIKeyModal
-          data={data}
-          user={currentUser}
-          loading={loading}
-          onClose={() => {
-            if (!loading) setQuickAPIKeyOpen(false);
-          }}
-          onCreate={(values) => quickCreateAPIKey(values, () => setQuickAPIKeyOpen(false))}
         />
       ) : null}
 


### PR DESCRIPTION
## Summary

The Key Management page currently opens a simplified quick-create modal that only collects a key name and project. This prevents administrators from assigning an owner, configuring the model allowlist, and reviewing quota or security settings during issuance.

Reuse the existing full API key issuance wizard already used by Project Space so both entry points provide the same configuration flow.

## Related Issue

N/A

## Changes

- Route the Key Management "Issue Key" action to the existing full API key wizard.
- Reset wizard initial values when opening it from Key Management.
- Remove the now-unused quick-modal import, state, and render branch from the admin console.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [ ] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [x] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- `npm run typecheck` passed.
- `npm run build` passed with Next.js 16.2.9.
- `git diff --check` passed.
- The local frontend `/api-keys` route returned HTTP 200 with the backend health check passing.
- Backend, SDK, and Docker checks were not run because this is a frontend-only entry-point change with no API, deployment, or persistence changes.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: None.
- Security or credential-handling impact: No credential storage or API contract changes; the UI now exposes the existing owner, model allowlist, quota, and security configuration fields during key issuance.
- Database, environment, or deployment impact: None.
- Rollout and rollback considerations: No migration is required. Reverting this commit restores the previous quick-create modal.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
