### PR TITLE
fix(frontend): increase default API key token quotas

### DIFF
--- a/frontend/features/admin/resources/payloads.tsx
+++ b/frontend/features/admin/resources/payloads.tsx
@@ -397,8 +397,8 @@ export function defaultFormValues<T>(config: ResourceConfig<T>, data: AppData, c
     if (field.key === "allowed_models") values[field.key] = "";
     if (field.key === "daily_requests") values[field.key] = "1000";
     if (field.key === "monthly_requests") values[field.key] = "30000";
-    if (field.key === "daily_tokens") values[field.key] = "1000000";
-    if (field.key === "monthly_tokens") values[field.key] = "20000000";
+    if (field.key === "daily_tokens") values[field.key] = config.view === "api-keys" ? "100000000" : "1000000";
+    if (field.key === "monthly_tokens") values[field.key] = config.view === "api-keys" ? "2000000000" : "20000000";
     if (field.key === "daily_cost_usd") values[field.key] = "100";
     if (field.key === "monthly_cost_usd") values[field.key] = "2000";
     if (field.key === "max_concurrency") values[field.key] = "20";


### PR DESCRIPTION
## Summary

New API keys currently default to 1,000,000 daily tokens and 20,000,000 monthly tokens. These limits are too low for the expected usage and require administrators to adjust every key during issuance.

Increase the API key defaults while preserving the existing defaults used by other resource forms.

## Related Issue

N/A

## Changes

- Increase the default daily API key token quota to 100,000,000.
- Increase the default monthly API key token quota to 2,000,000,000.
- Scope the higher defaults to the `api-keys` view so quota-policy defaults are unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [ ] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [x] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- `npm run typecheck` passed.
- `npm run build` passed with Next.js 16.2.9.
- `git diff --check` passed.
- The local `/api-keys` route returned HTTP 200 and the backend health check passed.
- Backend, SDK, and Docker checks were not run because this is a frontend-only form-default change with no API, persistence, or deployment changes.
- No focused unit test was added because the frontend does not currently provide a unit-test harness for `defaultFormValues`; type checking, production compilation, and local route verification cover this scoped change.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: None.
- Security or credential-handling impact: None. Only initial form values for newly issued API keys change.
- Database, environment, or deployment impact: None. Existing API keys and persisted quota values are unchanged.
- Rollout and rollback considerations: No migration is required. Reverting this commit restores the previous defaults.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
