### PR TITLE
fix(api-keys): allow clearing all quota limits

### DIFF
--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -3575,14 +3575,14 @@ func (s *Server) handleAdminAPIKeyItem(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPatch:
 		var req struct {
-			Name          string      `json:"name"`
-			Group         string      `json:"group"`
-			OwnerUserID   *string     `json:"owner_user_id"`
-			AllowedModels []string    `json:"allowed_models"`
-			IPAllowlist   []string    `json:"ip_allowlist"`
-			Limits        QuotaLimits `json:"limits"`
-			Status        string      `json:"status"`
-			ExpiresAt     *time.Time  `json:"expires_at"`
+			Name          string       `json:"name"`
+			Group         string       `json:"group"`
+			OwnerUserID   *string      `json:"owner_user_id"`
+			AllowedModels []string     `json:"allowed_models"`
+			IPAllowlist   []string     `json:"ip_allowlist"`
+			Limits        *QuotaLimits `json:"limits"`
+			Status        string       `json:"status"`
+			ExpiresAt     *time.Time   `json:"expires_at"`
 		}
 		if err := decodeJSON(r, &req); err != nil {
 			writeError(w, r, NewHTTPError(400, "invalid_request", err.Error()))
@@ -3593,9 +3593,12 @@ func (s *Server) handleAdminAPIKeyItem(w http.ResponseWriter, r *http.Request) {
 			Group:       req.Group,
 			Allowed:     req.AllowedModels,
 			IPAllowlist: req.IPAllowlist,
-			Limits:      req.Limits,
+			LimitsSet:   req.Limits != nil,
 			Status:      req.Status,
 			ExpiresAt:   req.ExpiresAt,
+		}
+		if req.Limits != nil {
+			patch.Limits = *req.Limits
 		}
 		if req.OwnerUserID != nil {
 			ownerUserID, err := s.resolveAPIKeyOwner(user, *req.OwnerUserID)
@@ -6021,7 +6024,8 @@ func (s *Server) matchApprovalFlow(trigger string, payload any) (AdminResource, 
 
 func (s *Server) apiKeyUpdateApproval(user AdminUser, key APIKey, patch APIKey) (ApprovalRequest, bool) {
 	trigger := ""
-	if patch.Limits != (QuotaLimits{}) {
+	limitsSet := patch.LimitsSet || patch.Limits != (QuotaLimits{})
+	if limitsSet {
 		trigger = "quota_increase"
 	}
 	if trigger == "" && len(patch.Allowed) > 0 {
@@ -6036,8 +6040,10 @@ func (s *Server) apiKeyUpdateApproval(user AdminUser, key APIKey, patch APIKey) 
 		"requested_action": trigger,
 		"owner_user_id":    patch.OwnerUserID,
 		"allowed_models":   patch.Allowed,
-		"limits":           patch.Limits,
 		"status":           patch.Status,
+	}
+	if limitsSet {
+		payload["limits"] = patch.Limits
 	}
 	return s.approvalRequired(user, trigger, "api_key", key.ID, payload)
 }
@@ -6697,11 +6703,13 @@ func (s *Server) applyApprovalRequest(request ApprovalRequest, actor AdminUser) 
 			"plain_text_visible_once": true,
 		}, nil
 	case request.ResourceType == "api_key":
+		limits, limitsSet := payload["limits"]
 		key, err := s.store.UpdateAPIKey(request.ResourceID, APIKey{
 			OwnerUserID: stringFromPayload(payload, "owner_user_id"),
 			Allowed:     stringSliceFromPayload(payload["allowed_models"]),
 			IPAllowlist: stringSliceFromPayload(payload["ip_allowlist"]),
-			Limits:      quotaLimitsFromPayload(payload["limits"]),
+			Limits:      quotaLimitsFromPayload(limits),
+			LimitsSet:   limitsSet,
 			Status:      stringFromPayload(payload, "status"),
 		})
 		return key, err

--- a/backend/internal/server/http_test.go
+++ b/backend/internal/server/http_test.go
@@ -760,6 +760,103 @@ func TestAdminCreatesAPIKeyUnderDefaultProject(t *testing.T) {
 	}
 }
 
+func TestAdminCanClearAllAPIKeyLimits(t *testing.T) {
+	store := NewMemoryStore()
+	if err := BootstrapBaseData(store); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := store.CreateAPIKey(defaultProjectID, APIKey{
+		ID:   "key_clear_limits",
+		Name: "Clear Limits",
+		Limits: QuotaLimits{
+			DailyRequests:   1000,
+			MonthlyRequests: 30000,
+			DailyTokens:     1000000,
+			MonthlyTokens:   20000000,
+			DailyCostUSD:    100,
+			MonthlyCostUSD:  2000,
+			MaxConcurrency:  20,
+		},
+		Status: StatusActive,
+	}, "thk_clear_limits")
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := New(store).Handler()
+
+	resp := doJSON(t, app, http.MethodPatch, "/api/admin/api-keys/key_clear_limits", map[string]any{
+		"name": "Renamed Key",
+	}, "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body)
+	}
+	var updated APIKey
+	if err := json.Unmarshal([]byte(resp.Body), &updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Limits.DailyRequests != 1000 {
+		t.Fatalf("expected omitted limits to be preserved, got %+v", updated.Limits)
+	}
+
+	resp = doJSON(t, app, http.MethodPatch, "/api/admin/api-keys/key_clear_limits", map[string]any{
+		"limits": QuotaLimits{},
+	}, "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body)
+	}
+	if err := json.Unmarshal([]byte(resp.Body), &updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Limits != (QuotaLimits{}) {
+		t.Fatalf("expected all limits to be cleared, got %+v", updated.Limits)
+	}
+}
+
+func TestAdminCanClearAllAPIKeyLimitsAfterApproval(t *testing.T) {
+	store := NewMemoryStore()
+	if err := BootstrapBaseData(store); err != nil {
+		t.Fatal(err)
+	}
+	key, _, err := store.CreateAPIKey(defaultProjectID, APIKey{
+		Name:   "Clear Limits After Approval",
+		Limits: QuotaLimits{DailyRequests: 1000},
+		Status: StatusActive,
+	}, "thk_clear_limits_after_approval")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.CreateResource("approval-flows", AdminResource{
+		Name:   "Quota Increase",
+		Status: StatusActive,
+		Fields: map[string]any{"trigger": "quota_increase", "approver_role": "admin"},
+	})
+	app := New(store).Handler()
+
+	resp := doJSON(t, app, http.MethodPatch, "/api/admin/api-keys/"+key.ID, map[string]any{
+		"limits": QuotaLimits{},
+	}, "")
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("expected approval response, got %d: %s", resp.Code, resp.Body)
+	}
+	approvals := store.ListApprovalRequests()
+	if len(approvals) != 1 || approvals[0].Trigger != "quota_increase" {
+		t.Fatalf("expected quota increase approval, got %+v", approvals)
+	}
+	keys := store.ListProjectKeys(defaultProjectID)
+	if len(keys) != 1 || keys[0].Limits.DailyRequests != 1000 {
+		t.Fatalf("expected limits to remain unchanged before approval, got %+v", keys)
+	}
+
+	resp = doJSON(t, app, http.MethodPost, "/api/admin/approvals/"+approvals[0].ID+"/approve", map[string]any{}, "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected approval to apply, got %d: %s", resp.Code, resp.Body)
+	}
+	keys = store.ListProjectKeys(defaultProjectID)
+	if len(keys) != 1 || keys[0].Limits != (QuotaLimits{}) {
+		t.Fatalf("expected approved limits to be cleared, got %+v", keys)
+	}
+}
+
 func TestUserCreatesPersonalAPIKeyWithoutProjectMembership(t *testing.T) {
 	store := NewMemoryStore()
 	if err := BootstrapBaseData(store); err != nil {

--- a/backend/internal/server/store.go
+++ b/backend/internal/server/store.go
@@ -1453,7 +1453,7 @@ func (s *GormStore) UpdateAPIKey(id string, patch APIKey) (APIKey, error) {
 	if patch.IPAllowlist != nil {
 		key.IPAllowlist = patch.IPAllowlist
 	}
-	if patch.Limits != (QuotaLimits{}) {
+	if patch.LimitsSet || patch.Limits != (QuotaLimits{}) {
 		key.Limits = patch.Limits
 	}
 	if patch.ExpiresAt != nil {

--- a/backend/internal/server/types.go
+++ b/backend/internal/server/types.go
@@ -122,6 +122,7 @@ type APIKey struct {
 	Allowed       []string          `json:"allowed_models" gorm:"serializer:json"`
 	IPAllowlist   []string          `json:"ip_allowlist,omitempty" gorm:"serializer:json"`
 	Limits        QuotaLimits       `json:"limits" gorm:"embedded;embeddedPrefix:limit_"`
+	LimitsSet     bool              `json:"-" gorm:"-"`
 	Status        string            `json:"status"`
 	ExpiresAt     *time.Time        `json:"expires_at,omitempty"`
 	RotatedFromID string            `json:"rotated_from_id,omitempty" gorm:"index"`


### PR DESCRIPTION
## Summary

API key updates currently treat a zero-valued `QuotaLimits` struct as if the `limits` field was omitted. As a result, administrators cannot clear every quota after a key has non-zero limits.

This change distinguishes an omitted `limits` field from an explicitly supplied all-zero value. Existing limits are preserved when the field is absent, while an explicit all-zero value clears them. Because zero means unlimited, configured quota-increase approval flows still intercept the update and apply it only after approval.

## Related Issue

N/A

## Changes

- Decode API key update limits as an optional field and record whether the field was supplied.
- Persist explicitly supplied all-zero quota limits while preserving the existing non-zero update behavior.
- Preserve explicit limit presence through quota-increase approval requests and approval replay.
- Add regression tests for omitted limits, direct all-zero updates, and approved all-zero updates.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [ ] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [ ] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- Passed: `gofmt -w internal/server/types.go internal/server/http.go internal/server/store.go internal/server/http_test.go`
- Passed: `go test ./internal/server -run 'TestAdminCanClearAllAPIKeyLimits|TestAPIKeyStatusUpdatePreservesExpiration|TestAPIKeyUpdateApprovalUsesProjectPrimaryTeam' -count=1`
- Passed: `go vet ./...`
- Passed: `git diff --check`
- `go test ./...` was run on Windows. It reached unrelated existing failures involving `sqlite://C:\\...` URL parsing, a temporary SQLite file lock during cleanup, Unix executable-bit expectations, and GitHub release API HTTP 503 responses. The focused tests for the changed behavior pass.
- Frontend, SDK, and Docker checks were not run locally because this is a backend-only API key update fix with no frontend, SDK, or deployment changes.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: None. This only changes admin API key PATCH handling for an explicitly supplied all-zero `limits` object.
- Security or credential-handling impact: Configured quota-increase approval flows continue to intercept all-zero updates before unlimited quotas are applied. No credential-handling behavior changes.
- Database, environment, or deployment impact: None. The presence flag is neither serialized nor persisted, and no migration or configuration change is required.
- Rollout and rollback considerations: Standard backend rollout. Revert this commit to restore the previous behavior.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.