### PR TITLE
fix(observability): measure request latency with the local clock

### DIFF
--- a/backend/internal/server/gateway_http.go
+++ b/backend/internal/server/gateway_http.go
@@ -509,6 +509,7 @@ func (s *Server) handleAdminPlaygroundChat(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	requestID := NewID("pg")
+	startedAt := time.Now()
 	routed := RoutedCall{
 		Call: CallContext{
 			RequestID: requestID,
@@ -517,8 +518,9 @@ func (s *Server) handleAdminPlaygroundChat(w http.ResponseWriter, r *http.Reques
 			// The catalog model, not a bare name: pricing lives on it, and per-attempt
 			// cost is computed from whatever this carries. A name-only model silently
 			// reports every playground generation as free.
-			Model:     playgroundModel(s.store, req.Model),
-			StartedAt: time.Now().UTC(),
+			Model:      playgroundModel(s.store, req.Model),
+			StartedAt:  startedAt.UTC(),
+			measuredAt: startedAt,
 		},
 	}
 	routed.Routes = s.planRouteOrder(routed.Call, routes)

--- a/backend/internal/server/request_latency_test.go
+++ b/backend/internal/server/request_latency_test.go
@@ -1,0 +1,225 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// skewedCall reproduces what StartCall produces on a PostgreSQL deployment whose
+// database host runs ahead of the application host: StartedAt is the database
+// clock reading, measuredAt is the local reading taken at the same moment.
+func skewedCall(requestID string, skew time.Duration) CallContext {
+	return CallContext{
+		RequestID:  requestID,
+		Project:    Project{ID: "project_clock_skew"},
+		Key:        APIKey{ID: "key_clock_skew"},
+		Model:      Model{Name: "skewed-chat", Modality: "chat", Status: StatusActive},
+		StartedAt:  time.Now().UTC().Add(skew),
+		measuredAt: time.Now(),
+	}
+}
+
+func TestFinishCallLatencyIsNotNegativeWhenDatabaseClockRunsAhead(t *testing.T) {
+	store := NewMemoryStore()
+	route := RouteSelection{Provider: Provider{ID: "provider_clock_skew", Type: ProviderOpenAI}}
+
+	store.FinishCall(skewedCall("req_clock_skew", 4*time.Minute), route, Usage{
+		PromptTokens:     10,
+		CompletionTokens: 5,
+		TotalTokens:      15,
+	}, 200, "", "127.0.0.1", "latency-test")
+
+	logs := store.ListRequestLogs()
+	if len(logs) != 1 {
+		t.Fatalf("request logs = %d, want 1", len(logs))
+	}
+	if logs[0].LatencyMS < 0 {
+		t.Fatalf("request log latency_ms = %d, want a non-negative value", logs[0].LatencyMS)
+	}
+	if logs[0].LatencyMS > time.Minute.Milliseconds() {
+		t.Fatalf("request log latency_ms = %d, want the locally measured duration", logs[0].LatencyMS)
+	}
+
+	observations := store.ListProviderObservations(time.Time{})
+	if len(observations) != 1 {
+		t.Fatalf("provider observations = %d, want 1", len(observations))
+	}
+	if observations[0].LatencyMS < 0 {
+		t.Fatalf("provider observation latency_ms = %d, want a non-negative value", observations[0].LatencyMS)
+	}
+}
+
+func TestRecordPlaygroundRequestLatencyIsNotNegativeWhenDatabaseClockRunsAhead(t *testing.T) {
+	store := NewMemoryStore()
+	route := RouteSelection{Provider: Provider{ID: "provider_playground_skew", Type: ProviderOpenAI}}
+
+	store.RecordPlaygroundRequest(skewedCall("req_playground_skew", 4*time.Minute), route, 200, "", "127.0.0.1", "latency-test")
+
+	logs := store.ListRequestLogs()
+	if len(logs) != 1 {
+		t.Fatalf("request logs = %d, want 1", len(logs))
+	}
+	if logs[0].LatencyMS < 0 || logs[0].LatencyMS > time.Minute.Milliseconds() {
+		t.Fatalf("playground latency_ms = %d, want the locally measured duration", logs[0].LatencyMS)
+	}
+}
+
+func TestCompleteImageJobLatencyIsNotNegativeWhenDatabaseClockRunsAhead(t *testing.T) {
+	store := NewMemoryStore()
+	project := store.CreateProject(Project{Name: "Image Clock Skew"})
+	call := skewedCall("req_image_skew", 4*time.Minute)
+	call.Project = project
+	call.Model = Model{Name: openAIImageModelName, Modality: "image", Status: StatusActive}
+	provider := store.AddProvider(Provider{
+		ID: "prv_image_skew", Name: "Image Skew Provider", Type: ProviderOpenAI, Status: StatusActive, Healthy: true,
+	})
+
+	job, err := store.CreateImageJob(ImageJob{
+		ProjectID: project.ID, RequestID: call.RequestID,
+		Status: imageJobStatusQueued, Model: call.Model.Name, Action: "generate",
+	}, "skewed image prompt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	job, claimed, err := store.ClaimImageJob(job.ID)
+	if err != nil || !claimed {
+		t.Fatalf("claim image job: claimed=%v err=%v", claimed, err)
+	}
+	job.Status = imageJobStatusCompleted
+
+	asset := ImageAsset{
+		JobID: job.ID, ProjectID: project.ID, Role: "output",
+		RelativePath: "skew/output.png", ContentType: "image/png",
+	}
+	selection := RouteSelection{Provider: provider, ProviderModel: openAIImageModelName}
+	if err := store.CompleteImageJob(call, job, "", asset, selection, Usage{TotalTokens: 1}, "127.0.0.1", "latency-test"); err != nil {
+		t.Fatal(err)
+	}
+
+	logs := store.ListRequestLogs()
+	if len(logs) != 1 {
+		t.Fatalf("request logs = %d, want 1", len(logs))
+	}
+	if logs[0].LatencyMS < 0 || logs[0].LatencyMS > time.Minute.Milliseconds() {
+		t.Fatalf("image completion latency_ms = %d, want the locally measured duration", logs[0].LatencyMS)
+	}
+}
+
+func TestFailUnfinishedImageJobsLatencyIsNotNegativeForFutureCreatedAt(t *testing.T) {
+	store := NewMemoryStore()
+	project := store.CreateProject(Project{Name: "Image Recovery Skew"})
+
+	// A replica whose clock ran ahead queued this job, so its created_at is in the
+	// future for the replica that recovers it after a restart.
+	if _, err := store.CreateImageJob(ImageJob{
+		ProjectID: project.ID, RequestID: "req_image_recovery_skew",
+		Status: imageJobStatusQueued, Model: openAIImageModelName, Action: "generate",
+		CreatedAt: time.Now().UTC().Add(4 * time.Minute),
+	}, "recovered image prompt"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.FailUnfinishedImageJobs("server_restarted", "server restarted"); err != nil {
+		t.Fatal(err)
+	}
+
+	logs := store.ListRequestLogs()
+	if len(logs) != 1 {
+		t.Fatalf("request logs = %d, want 1", len(logs))
+	}
+	if logs[0].LatencyMS != 0 {
+		t.Fatalf("recovered image job latency_ms = %d, want 0", logs[0].LatencyMS)
+	}
+}
+
+func TestStartCallRecordsLocalLatencyReference(t *testing.T) {
+	store := NewMemoryStore()
+	project := store.CreateProject(Project{Name: "Latency Reference"})
+	key, _, err := store.CreateAPIKey(project.ID, APIKey{
+		Name: "latency-reference", Allowed: []string{"reference-chat"}, Status: StatusActive,
+	}, "thk_latency_reference")
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := store.AddModel(Model{Name: "reference-chat", Modality: "chat", Status: StatusActive})
+
+	call, err := store.StartCall(context.Background(), project, key, model.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if call.measuredAt.IsZero() {
+		t.Fatal("StartCall must record a local reference so latency does not depend on the database clock")
+	}
+	if elapsed := call.elapsed(); elapsed < 0 || elapsed > time.Minute {
+		t.Fatalf("elapsed = %v, want a small non-negative duration", elapsed)
+	}
+}
+
+func TestTracingSpanStartsOnTheLocalClockWhenDatabaseClockRunsAhead(t *testing.T) {
+	endpoint := newFakeOTLPEndpoint(t)
+	app := newTracingTestServer(t, tracingTestConfig(endpoint.tracesURL()))
+
+	call := skewedCall("req_trace_skew", 4*time.Minute)
+	finishedAt := time.Now().UTC()
+	app.traceEmitter.EmitGatewayCall(GatewayCallCompletion{
+		Kind:       CompletionKindRouted,
+		Call:       call,
+		StatusCode: http.StatusOK,
+		FinishedAt: finishedAt,
+	})
+	flushTracing(t, app)
+
+	spans := endpoint.collected()
+	if len(spans) != 1 {
+		t.Fatalf("exported spans = %d, want 1", len(spans))
+	}
+	startedAt := time.Unix(0, int64(spans[0].GetStartTimeUnixNano())).UTC()
+	endedAt := time.Unix(0, int64(spans[0].GetEndTimeUnixNano())).UTC()
+	if startedAt.After(finishedAt) {
+		t.Fatalf("span starts at %s, after the call finished at %s", startedAt, finishedAt)
+	}
+	if endedAt.Sub(startedAt) > time.Minute {
+		t.Fatalf("span covers %s, want the locally measured duration", endedAt.Sub(startedAt))
+	}
+}
+
+func TestCallElapsedNeverReportsNegativeDuration(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		call CallContext
+		want time.Duration
+	}{
+		{
+			name: "no timestamps at all",
+			call: CallContext{},
+			want: 0,
+		},
+		{
+			name: "only a future database timestamp",
+			call: CallContext{StartedAt: time.Now().UTC().Add(4 * time.Minute)},
+			want: 0,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := testCase.call.elapsed(); got != testCase.want {
+				t.Fatalf("elapsed = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+
+	past := CallContext{StartedAt: time.Now().UTC().Add(-2 * time.Second)}
+	if elapsed := past.elapsed(); elapsed < time.Second {
+		t.Fatalf("elapsed = %v, want at least the two seconds since StartedAt", elapsed)
+	}
+}
+
+func TestLatencyMillisClampsNegativeIntervals(t *testing.T) {
+	if got := latencyMillis(-4 * time.Minute); got != 0 {
+		t.Fatalf("latencyMillis(-4m) = %d, want 0", got)
+	}
+	if got := latencyMillis(1500 * time.Millisecond); got != 1500 {
+		t.Fatalf("latencyMillis(1.5s) = %d, want 1500", got)
+	}
+}

--- a/backend/internal/server/store_routing_calls.go
+++ b/backend/internal/server/store_routing_calls.go
@@ -507,6 +507,9 @@ func (s *GormStore) StartCall(ctx context.Context, project Project, key APIKey, 
 		if err != nil {
 			return err
 		}
+		// Taken next to the database reading so the two describe the same instant,
+		// and the local reference does not also absorb the admission work below.
+		measuredAt := time.Now()
 		dayCounter, err := s.quotaBucketForUpdate(tx, privateKey.ID, "day", dayBucket(now))
 		if err != nil {
 			return err
@@ -545,6 +548,7 @@ func (s *GormStore) StartCall(ctx context.Context, project Project, key APIKey, 
 			Key:            publicKey(privateKey),
 			Model:          model,
 			StartedAt:      now,
+			measuredAt:     measuredAt,
 			requestContext: ctx,
 		}
 		return nil
@@ -561,11 +565,10 @@ func (s *GormStore) StartCall(ctx context.Context, project Project, key APIKey, 
 func (s *GormStore) FinishCall(call CallContext, route RouteSelection, usage Usage, statusCode int, errorCode string, clientIP string, userAgent string) {
 	// Measured here rather than inside the deferred observation, so latency reflects
 	// what the client waited for and excludes the persistence and lock time that
-	// follows. FinishCall is invoked after the last streamed byte is written.
-	elapsed := time.Duration(0)
-	if !call.StartedAt.IsZero() {
-		elapsed = time.Since(call.StartedAt)
-	}
+	// follows. FinishCall is invoked after the last streamed byte is written. The
+	// same value is threaded into the transaction below so the persisted latency
+	// and the reported metric describe the same interval.
+	elapsed := call.elapsed()
 	_ = s.stopInFlightLeaseHeartbeat(call.RequestID)
 	// priceUsage is pure, so it runs outside the lock and its result is final here.
 	usage = priceUsage(call.Model, usage)
@@ -580,7 +583,7 @@ func (s *GormStore) FinishCall(call CallContext, route RouteSelection, usage Usa
 	defer s.mu.Unlock()
 	now := time.Now().UTC()
 	err := s.db.Transaction(func(tx *gorm.DB) error {
-		return s.finishCallTransaction(tx, call, route, usage, statusCode, errorCode, clientIP, userAgent, now)
+		return s.finishCallTransaction(tx, call, route, usage, statusCode, errorCode, clientIP, userAgent, now, elapsed)
 	})
 	if err != nil {
 		log.Printf("[tokenhub] failed to finish call request=%s: %v", call.RequestID, err)
@@ -590,7 +593,7 @@ func (s *GormStore) FinishCall(call CallContext, route RouteSelection, usage Usa
 	}
 }
 
-func (s *GormStore) finishCallTransaction(tx *gorm.DB, call CallContext, route RouteSelection, usage Usage, statusCode int, errorCode string, clientIP string, userAgent string, now time.Time) error {
+func (s *GormStore) finishCallTransaction(tx *gorm.DB, call CallContext, route RouteSelection, usage Usage, statusCode int, errorCode string, clientIP string, userAgent string, now time.Time, elapsed time.Duration) error {
 	if call.Key.ID != "" {
 		if err := s.lockScopeForUpdate(tx, "api_key", call.Key.ID); err != nil {
 			return err
@@ -638,7 +641,7 @@ func (s *GormStore) finishCallTransaction(tx *gorm.DB, call CallContext, route R
 		Transport:          usage.Transport,
 		StatusCode:         statusCode,
 		ErrorCode:          errorCode,
-		LatencyMS:          time.Since(call.StartedAt).Milliseconds(),
+		LatencyMS:          elapsed.Milliseconds(),
 		ClientIP:           clientIP,
 		UserAgent:          userAgent,
 		CreatedAt:          now,
@@ -654,7 +657,7 @@ func (s *GormStore) finishCallTransaction(tx *gorm.DB, call CallContext, route R
 			Source:      "gateway_request",
 			Operation:   "inference",
 			Success:     providerObservationSuccess(statusCode, errorCode),
-			LatencyMS:   time.Since(call.StartedAt).Milliseconds(),
+			LatencyMS:   elapsed.Milliseconds(),
 			ErrorCode:   errorCode,
 			ObservedAt:  now,
 		}).Error; err != nil {
@@ -691,6 +694,9 @@ func (s *GormStore) finishCallTransaction(tx *gorm.DB, call CallContext, route R
 }
 
 func (s *GormStore) RecordPlaygroundRequest(call CallContext, route RouteSelection, statusCode int, errorCode string, clientIP string, userAgent string) {
+	// Measured before the lock, matching FinishCall: the recorded latency is what
+	// the caller waited for and excludes contention on the store-wide mutex.
+	elapsed := call.elapsed()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -705,7 +711,7 @@ func (s *GormStore) RecordPlaygroundRequest(call CallContext, route RouteSelecti
 		ProviderModel:      route.ProviderModel,
 		StatusCode:         statusCode,
 		ErrorCode:          errorCode,
-		LatencyMS:          time.Since(call.StartedAt).Milliseconds(),
+		LatencyMS:          elapsed.Milliseconds(),
 		ClientIP:           clientIP,
 		UserAgent:          userAgent,
 		CreatedAt:          time.Now().UTC(),
@@ -909,7 +915,7 @@ func (s *GormStore) FailUnfinishedImageJobs(code string, message string) ([]Imag
 					ModelName:  job.Model,
 					StatusCode: http.StatusServiceUnavailable,
 					ErrorCode:  code,
-					LatencyMS:  now.Sub(job.CreatedAt).Milliseconds(),
+					LatencyMS:  latencyMillis(now.Sub(job.CreatedAt)),
 					CreatedAt:  now,
 				}).Error; err != nil {
 					return err
@@ -941,10 +947,7 @@ func (s *GormStore) UpdateImageJob(job ImageJob, revisedPrompt string) error {
 }
 
 func (s *GormStore) CompleteImageJob(call CallContext, job ImageJob, revisedPrompt string, asset ImageAsset, route RouteSelection, usage Usage, clientIP string, userAgent string) error {
-	elapsed := time.Duration(0)
-	if !call.StartedAt.IsZero() {
-		elapsed = time.Since(call.StartedAt)
-	}
+	elapsed := call.elapsed()
 	_ = s.stopInFlightLeaseHeartbeat(call.RequestID)
 	usage = priceUsage(call.Model, usage)
 	usage.ProviderCostUSD = s.providerCostUSD(route, usage)
@@ -968,7 +971,7 @@ func (s *GormStore) CompleteImageJob(call CallContext, job ImageJob, revisedProm
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		return s.db.Transaction(func(tx *gorm.DB) error {
-			if err := s.finishCallTransaction(tx, call, route, usage, http.StatusOK, "", clientIP, userAgent, now); err != nil {
+			if err := s.finishCallTransaction(tx, call, route, usage, http.StatusOK, "", clientIP, userAgent, now, elapsed); err != nil {
 				return err
 			}
 			if err := tx.Create(&asset).Error; err != nil {

--- a/backend/internal/server/tracing_langfuse.go
+++ b/backend/internal/server/tracing_langfuse.go
@@ -111,7 +111,10 @@ func randomSpanID() trace.SpanID {
 // record converts one completion into a trace: a root span for the request, and a
 // generation child for every candidate that entered the invocation path.
 func (e *otlpTraceEmitter) record(completion GatewayCallCompletion) {
-	startedAt := completion.Call.StartedAt
+	// The local reading, not the database one in StartedAt: it is compared with
+	// FinishedAt, which this process stamps, so a database host running ahead
+	// would otherwise place the whole trace in the future.
+	startedAt := completion.Call.measuredStart()
 	if startedAt.IsZero() {
 		startedAt = completion.FinishedAt
 	}
@@ -176,7 +179,7 @@ func (e *otlpTraceEmitter) record(completion GatewayCallCompletion) {
 func (e *otlpTraceEmitter) recordAttempt(ctx context.Context, completion GatewayCallCompletion, shared []attribute.KeyValue, index int, attempt RouteAttempt, traceID trace.TraceID) {
 	startedAt := attempt.StartedAt
 	if startedAt.IsZero() {
-		startedAt = completion.Call.StartedAt
+		startedAt = completion.Call.measuredStart()
 	}
 	endedAt := attempt.EndedAt
 	if endedAt.Before(startedAt) {

--- a/backend/internal/server/types.go
+++ b/backend/internal/server/types.go
@@ -1069,12 +1069,63 @@ type CallContext struct {
 	Project   Project
 	Key       APIKey
 	Model     Model
+	// StartedAt is the database clock reading taken when the call was admitted:
+	// StartCall derives the quota buckets and the lease expiry from that reading
+	// so every replica agrees on them, and reports it here for callers that want
+	// the admission timestamp. It is *not* a valid reference for measuring how
+	// long the call ran — no production path reads it for that any more.
 	StartedAt time.Time
+	// measuredAt is the local reference used to measure how long the call ran.
+	// It is deliberately separate from StartedAt: on PostgreSQL deployments the
+	// database and the application usually run on different hosts, and any clock
+	// skew between them would otherwise land directly in request_logs.latency_ms
+	// (a database host running four minutes ahead produced latencies near
+	// -240000ms). time.Now keeps its monotonic reading here, so the measurement
+	// also survives wall-clock adjustments on this host.
+	measuredAt time.Time
 	// Stream records whether the client asked for a streamed response. It only
 	// labels observability output and never influences routing.
 	Stream         bool
 	Affinity       *RequestAffinity
 	requestContext context.Context
+}
+
+// measuredStart reports when the call began, on the clock its duration is
+// measured against. Anything paired with a timestamp this process stamps — an
+// elapsed time, a trace span end — has to start here rather than at StartedAt,
+// which the database clock produced.
+func (c CallContext) measuredStart() time.Time {
+	if !c.measuredAt.IsZero() {
+		return c.measuredAt
+	}
+	// Contexts assembled by hand rather than by StartCall carry only StartedAt.
+	// Falling back to it keeps their reporting working; callers clamp the result.
+	return c.StartedAt
+}
+
+// elapsed reports how long the call has been running. It never returns a
+// negative duration: callers persist the result as latency_ms, and a negative
+// latency is always a clock artefact rather than a real measurement.
+func (c CallContext) elapsed() time.Duration {
+	reference := c.measuredStart()
+	if reference.IsZero() {
+		return 0
+	}
+	if elapsed := time.Since(reference); elapsed > 0 {
+		return elapsed
+	}
+	return 0
+}
+
+// latencyMillis converts an interval into the non-negative value stored in a
+// latency_ms column. Intervals derived from a persisted timestamp can come out
+// negative when the replica that wrote it ran ahead of the replica reading it,
+// and a negative latency is never a real measurement.
+func latencyMillis(interval time.Duration) int64 {
+	if interval <= 0 {
+		return 0
+	}
+	return interval.Milliseconds()
 }
 
 func NewID(prefix string) string {


### PR DESCRIPTION
## Summary

`request_logs.latency_ms` could be written as a large negative value on PostgreSQL deployments (issue #91 reports values near `-240000`).

`CallContext.StartedAt` is a **database** clock reading — on PostgreSQL `SELECT EXTRACT(EPOCH FROM clock_timestamp())` — because `StartCall` derives the quota day/month buckets and the in-flight lease expiry from it, and every replica has to agree on those. Latency, however, was computed as `time.Since(call.StartedAt)`, i.e. against the **application process** clock:

```text
latency_ms = application host now − PostgreSQL host start reading
```

Any skew between the two hosts therefore landed directly in the stored latency. The reporter's database host ran about four minutes ahead, so a request that really took a few seconds was recorded as roughly `-240000ms`. SQLite deployments never showed it because the database and the application share one clock.

## Related Issue

Closes #91

## Changes

- `CallContext` gains an unexported `measuredAt` reference, taken next to the `databaseNow` reading in `StartCall` (and once in the admin playground handler) so both describe the same instant. It keeps its monotonic clock value, so the measurement also survives wall-clock adjustments on the application host.
- New `CallContext.elapsed()` measures against `measuredAt`, falls back to `StartedAt` for contexts assembled by hand, and never returns a negative duration.
- `FinishCall` threads the measured interval into `finishCallTransaction`, so `request_logs.latency_ms`, `provider_observations.latency_ms`, and the `tokenhub_gateway_request_duration_seconds` metric all describe the same interval. Previously each of the three re-read the clock at a different point, and the two persisted ones did so *inside* the store lock and transaction.
- `RecordPlaygroundRequest` measures before taking the store lock, matching `FinishCall`.
- New `latencyMillis` clamps latency derived from a persisted timestamp (the image-job restart-recovery path), where the replica that wrote the row may have been running ahead of the replica reading it back.
- `backend/internal/server/request_latency_test.go` covers the gateway, playground, image-completion, and image-recovery paths plus the `elapsed`/`latencyMillis` boundaries.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [x] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [ ] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- `gofmt -l backend/internal` — clean.
- `go vet ./...` — clean.
- `go test ./...` — pass (`ok tokenhub/backend/internal/server`).
- Repository gates from the root: `node --test tools/*.test.mjs` (80 pass), `node tools/check-doc-translations.mjs`, `node tools/check-env-contract.mjs`, `node tools/check-source-lines.mjs`, `git diff --check` — all pass. The translation gate ran its existence half only; there are no diff endpoints outside CI.
- Red check: with the fix reverted but the tests kept, `TestFinishCallLatencyIsNotNegativeWhenDatabaseClockRunsAhead` fails with `latency_ms = -239999`, reproducing the value reported in the issue.
- Frontend and SDK checks were skipped because no frontend, SDK, or deployment file is touched. No Docker or Compose file changed, so the Compose render check does not apply.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: None. No request or response shape changes.
- Security or credential-handling impact: None. No credential, key, or audit payload handling is touched.
- Database, environment, or deployment impact: No schema change, no migration, no new environment variable. One observable change in recorded values: `request_logs.latency_ms` and `provider_observations.latency_ms` are now measured before the store lock rather than inside the finish transaction, so on a contended gateway they no longer include lock and transaction time. That aligns them with the existing gateway duration metric, but latency percentiles on dashboards may step down slightly after the upgrade.
- Rollout and rollback considerations: Rollback is a plain revert; no state is written that an older build cannot read. Rows already written with a negative `latency_ms` are deliberately left untouched — this PR stops new ones from being produced but does not migrate history. Operators who want the old rows cleaned can run `UPDATE request_logs SET latency_ms = 0 WHERE latency_ms < 0;` themselves.

### Known related issue, not fixed here

Review of this change surfaced the same database-clock/application-clock split in `provider_resources.cooldown_until`: it is written with the application clock in `FinishProviderResourceAttempt` (`store_providers.go`) but written and read with the database clock on the half-open recovery path, and read with the application clock in `CheckProviderResourceCapacity`. Under the same four-minute skew a circuit-breaker backoff window can be skipped entirely. That is provider routing and circuit-breaking behavior rather than logging, so it is left for a separate change.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable. (No environment variable changed.)
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable. (No user-facing documentation describes `request_logs.latency_ms`, so no translation update applies.)
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable. (Untouched.)
- [x] `git diff --check` passes.
