### PR TITLE
feat(providers): test API credentials before creation

### DIFF
--- a/backend/internal/server/admin_provider_catalog_test.go
+++ b/backend/internal/server/admin_provider_catalog_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestAdminCreatesProviderModelAndRoute(t *testing.T) {
@@ -143,6 +144,67 @@ func TestAdminProviderConfigurationFailsEarlyAndPatchPreservesFields(t *testing.
 		provider.Headers["x-provider"] != "preserved" ||
 		provider.Options["region"] != "test" {
 		t.Fatalf("partial patch erased provider fields: %+v", provider)
+	}
+}
+
+func TestAdminTestsUnsavedProviderConnection(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/models" {
+			t.Errorf("unexpected upstream request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		if got := r.Header.Get("authorization"); got != "Bearer test-secret" {
+			t.Errorf("authorization = %q, want Bearer test-secret", got)
+			http.Error(w, "unexpected authorization", http.StatusUnauthorized)
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"data": []map[string]any{{"id": "deepseek-chat"}},
+		})
+	}))
+	defer upstream.Close()
+
+	app := newTestServer()
+	resp := doJSON(t, app, http.MethodPost, "/api/admin/providers/test-connection", map[string]any{
+		"name":     "DeepSeek",
+		"type":     "deepseek",
+		"base_url": upstream.URL + "/v1",
+		"api_key":  "test-secret",
+	}, "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected connection test 200, got %d: %s", resp.Code, resp.Body)
+	}
+	var result struct {
+		Healthy     bool  `json:"healthy"`
+		LatencyMS   int64 `json:"latency_ms"`
+		ModelsCount int   `json:"models_count"`
+	}
+	if err := json.Unmarshal([]byte(resp.Body), &result); err != nil {
+		t.Fatal(err)
+	}
+	if !result.Healthy || result.LatencyMS < 1 || result.ModelsCount != 1 {
+		t.Fatalf("unexpected connection result: %+v", result)
+	}
+}
+
+func TestAdminProviderConnectionTestRequiresCredentials(t *testing.T) {
+	app := newTestServer()
+	for _, testCase := range []struct {
+		name string
+		body map[string]any
+		code string
+	}{
+		{name: "base URL", body: map[string]any{"api_key": "test-secret"}, code: "provider_base_url_required"},
+		{name: "API key", body: map[string]any{"base_url": "https://example.invalid/v1"}, code: "provider_api_key_required"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			resp := doJSON(t, app, http.MethodPost, "/api/admin/providers/test-connection", testCase.body, "")
+			if resp.Code != http.StatusBadRequest || !strings.Contains(resp.Body, `"code":"`+testCase.code+`"`) {
+				t.Fatalf("expected %s, got %d: %s", testCase.code, resp.Code, resp.Body)
+			}
+		})
 	}
 }
 

--- a/backend/internal/server/admin_providers_http.go
+++ b/backend/internal/server/admin_providers_http.go
@@ -386,6 +386,39 @@ func (s *Server) handleAdminProviderNested(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/admin/providers/"), "/")
+	if len(parts) == 1 && parts[0] == "test-connection" {
+		if r.Method != http.MethodPost {
+			writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+			return
+		}
+		var req ProviderCreateRequest
+		if err := decodeJSON(r, &req); err != nil {
+			writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_request", err.Error()))
+			return
+		}
+		if strings.TrimSpace(req.BaseURL) == "" {
+			writeError(w, r, NewHTTPError(http.StatusBadRequest, "provider_base_url_required", "Base URL is required to test the connection"))
+			return
+		}
+		if strings.TrimSpace(req.APIKey) == "" {
+			writeError(w, r, NewHTTPError(http.StatusBadRequest, "provider_api_key_required", "API key is required to test the connection"))
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+		defer cancel()
+		startedAt := time.Now()
+		catalog, err := CustomProviderCatalogFromUpstream(ctx, http.DefaultClient, req)
+		if err != nil {
+			writeError(w, r, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"healthy":      true,
+			"latency_ms":   time.Since(startedAt).Milliseconds(),
+			"models_count": catalog.ModelsCount,
+		})
+		return
+	}
 	if len(parts) == 1 {
 		switch r.Method {
 		case http.MethodPatch:

--- a/docs/administrator-guide.md
+++ b/docs/administrator-guide.md
@@ -18,7 +18,7 @@ This guide is for platform administrators, security operators, and infrastructur
 ## Production Setup Order
 
 1. Configure at least one identity source and keep a controlled administrator account.
-2. Add an upstream Provider such as `OpenAI Production`, `Azure East US`, or `Internal Model Gateway`, and import the upstream models that it can serve.
+2. Add an upstream Provider such as `OpenAI Production`, `Azure East US`, or `Internal Model Gateway`. Before saving, use **Test Connection** to validate its Base URL and API Key and review the measured response latency, then import the upstream models that it can serve.
 3. Record each imported Provider model's actual input, cache-read, and output costs for audit.
 4. Create the external models to expose to applications and set their unified client-facing prices.
 5. Add routes from each external model to one or more imported Provider models.

--- a/docs/ja/administrator-guide.md
+++ b/docs/ja/administrator-guide.md
@@ -18,7 +18,7 @@ Language: [English](../administrator-guide.md) | [简体中文](../zh-CN/adminis
 ## 本番設定順序
 
 1. 少なくとも 1 つの ID プロバイダーを設定し、管理者アカウントを保持します。
-2. `OpenAI Production`、`Azure East US`、`Internal Model Gateway` などの上流 Provider を追加し、提供可能な上流モデルを取り込みます。
+2. `OpenAI Production`、`Azure East US`、`Internal Model Gateway` などの上流 Provider を追加します。保存前に **接続テスト** で Base URL と API Key を検証し、実測された応答時間を確認してから、提供可能な上流モデルを取り込みます。
 3. 取り込んだ各 Provider モデルに、監査用の実際の入力、キャッシュ読み取り、出力コストを記録します。
 4. アプリケーションへ公開する外部モデルを作成し、統一された顧客向け価格を設定します。
 5. 各外部モデルから、1 つ以上の取り込み済み Provider モデルへのルートを追加します。

--- a/docs/zh-CN/administrator-guide.md
+++ b/docs/zh-CN/administrator-guide.md
@@ -18,7 +18,7 @@ Language: [English](../administrator-guide.md) | 简体中文 | [日本語](../j
 ## 生产上线顺序
 
 1. 至少配置一个身份源，并保留可控的管理员账号。
-2. 添加上游 Provider，例如 `OpenAI Production`、`Azure East US` 或 `Internal Model Gateway`，并引入它可提供的上游模型。
+2. 添加上游 Provider，例如 `OpenAI Production`、`Azure East US` 或 `Internal Model Gateway`。保存前先用「测试连接」校验 Base URL 和 API Key，并查看实测响应耗时，再引入它可提供的上游模型。
 3. 为每个已引入的 Provider 模型记录真实的输入、缓存读取和输出成本，用于审计。
 4. 创建需要向业务开放的对外模型，并设置统一对客价格。
 5. 将每个对外模型路由到一个或多个已引入的 Provider 模型。

--- a/frontend/app/styles/legacy/provider-quick-connect.css
+++ b/frontend/app/styles/legacy/provider-quick-connect.css
@@ -241,6 +241,61 @@
   text-decoration: none;
 }
 
+.provider-quick-test-row {
+  min-height: 32px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.provider-quick-test-button {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.provider-quick-test-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.provider-quick-test-button.testing svg {
+  animation: provider-quick-test-spin 0.8s linear infinite;
+}
+
+.provider-quick-test-status {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted-strong);
+  font-size: 11px;
+}
+
+.provider-quick-test-status span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.provider-quick-test-status strong {
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.provider-quick-test-status.success {
+  color: var(--pos);
+}
+
+.provider-quick-test-status.error {
+  color: var(--red);
+}
+
+@keyframes provider-quick-test-spin {
+  to { transform: rotate(360deg); }
+}
+
 .provider-quick-custom-note {
   color: var(--muted);
   font-size: 10px;

--- a/frontend/features/admin/i18n/provider-connection.tsx
+++ b/frontend/features/admin/i18n/provider-connection.tsx
@@ -1,0 +1,17 @@
+const en: Record<string, string> = {
+  "正在测试": "Testing",
+  "测试 Provider 连接": "Test Provider connection",
+  "请填写 Base URL 和 API Key 后测试。": "Enter the Base URL and API key before testing.",
+  "API Key 配置有效": "API key is valid",
+  "Provider 连接测试失败": "Provider connection test failed",
+};
+
+const ja: Record<string, string> = {
+  "正在测试": "テスト中",
+  "测试 Provider 连接": "Provider 接続をテスト",
+  "请填写 Base URL 和 API Key 后测试。": "テストする前に Base URL と API Key を入力してください。",
+  "API Key 配置有效": "API Key は有効です",
+  "Provider 连接测试失败": "Provider 接続テストに失敗しました",
+};
+
+export const providerConnectionTranslations = { en, ja };

--- a/frontend/features/admin/i18n/translations.tsx
+++ b/frontend/features/admin/i18n/translations.tsx
@@ -1,9 +1,10 @@
 import { enTranslations } from "./en";
 import { jaTranslations } from "./ja";
 import { modelGovernanceTranslations } from "./model-governance";
+import { providerConnectionTranslations } from "./provider-connection";
 import { routingTranslations } from "./routing";
 
 export const translations: Record<"en" | "ja", Record<string, string>> = {
-  en: { ...enTranslations, ...routingTranslations.en, ...modelGovernanceTranslations.en },
-  ja: { ...jaTranslations, ...routingTranslations.ja, ...modelGovernanceTranslations.ja },
+  en: { ...enTranslations, ...routingTranslations.en, ...modelGovernanceTranslations.en, ...providerConnectionTranslations.en },
+  ja: { ...jaTranslations, ...routingTranslations.ja, ...modelGovernanceTranslations.ja, ...providerConnectionTranslations.ja },
 };

--- a/frontend/features/admin/views/provider-api-quick-connect.tsx
+++ b/frontend/features/admin/views/provider-api-quick-connect.tsx
@@ -1,10 +1,17 @@
-import { Check, Eye, EyeOff, KeyRound, Plus, RefreshCw, Search } from "lucide-react";
-import { useState } from "react";
-import { type ProviderCatalogEntry, type ProviderCatalogModel } from "../core/types";
+import { Check, CircleAlert, CircleCheck, Eye, EyeOff, KeyRound, LoaderCircle, Plus, RefreshCw, Search } from "lucide-react";
+import { useRef, useState } from "react";
+import { type ApiContext, type ProviderCatalogEntry, type ProviderCatalogModel } from "../core/types";
 import { providerTypeLabel } from "../domain/labels";
 import { formatModelPrice } from "../domain/formatting";
 import { clearCustomValidity, countWithUnit, handleRequiredFieldInvalid, tx } from "../i18n/runtime";
+import { adminFetch, isAuthExpiredError, readAdminError } from "../resources/payloads";
 import { providerTypeOptions } from "../shared/ui";
+
+type ProviderConnectionTestState = {
+  status: "idle" | "testing" | "success" | "error";
+  latencyMS?: number;
+  message?: string;
+};
 
 export function ProviderAPIQuickCatalog({
   entries,
@@ -61,6 +68,7 @@ export function ProviderAPIQuickCatalog({
 }
 
 export function ProviderAPIQuickConnect({
+  api,
   catalogID,
   entry,
   modelCount,
@@ -78,6 +86,7 @@ export function ProviderAPIQuickConnect({
   onTabChange,
   onUpdate,
 }: {
+  api: ApiContext;
   catalogID: string;
   entry?: ProviderCatalogEntry;
   modelCount: number;
@@ -96,8 +105,57 @@ export function ProviderAPIQuickConnect({
   onUpdate: (key: string, value: string) => void;
 }) {
   const [showKey, setShowKey] = useState(false);
+  const [connectionTest, setConnectionTest] = useState<ProviderConnectionTestState>({ status: "idle" });
+  const connectionTestRun = useRef(0);
   const custom = catalogID === "custom";
   const name = values.name || entry?.display_name || entry?.name || tx("请选择渠道商");
+  const connectionReady = Boolean(values.base_url?.trim() && values.api_key?.trim());
+
+  function updateConnectionValue(key: string, value: string) {
+    if (key === "base_url" || key === "api_key") {
+      connectionTestRun.current += 1;
+      setConnectionTest({ status: "idle" });
+    }
+    onUpdate(key, value);
+  }
+
+  async function testConnection() {
+    if (!connectionReady) {
+      setConnectionTest({ status: "error", message: tx("请填写 Base URL 和 API Key 后测试。") });
+      return;
+    }
+    const run = connectionTestRun.current + 1;
+    connectionTestRun.current = run;
+    const startedAt = performance.now();
+    setConnectionTest({ status: "testing" });
+    try {
+      const resp = await adminFetch(api, "/api/admin/providers/test-connection", {
+        method: "POST",
+        body: JSON.stringify({
+          catalog_id: catalogID,
+          name: values.name,
+          type: values.type,
+          base_url: values.base_url,
+          api_key: values.api_key,
+        }),
+      });
+      if (!resp.ok) throw new Error(await readAdminError(resp, tx("测试 Provider 连接")));
+      const result = (await resp.json()) as { healthy: boolean; latency_ms: number };
+      if (connectionTestRun.current !== run) return;
+      setConnectionTest({
+        status: "success",
+        latencyMS: Math.max(0, result.latency_ms),
+        message: tx("API Key 配置有效"),
+      });
+    } catch (err) {
+      if (connectionTestRun.current !== run || isAuthExpiredError(err)) return;
+      setConnectionTest({
+        status: "error",
+        latencyMS: Math.max(0, Math.round(performance.now() - startedAt)),
+        message: err instanceof Error ? err.message : tx("Provider 连接测试失败"),
+      });
+    }
+  }
 
   return (
     <section className="provider-api-quick-connect">
@@ -134,13 +192,13 @@ export function ProviderAPIQuickConnect({
               </label>
               <label className="field">
                 <span>Base URL</span>
-                <input value={values.base_url ?? ""} onChange={(event) => onUpdate("base_url", event.target.value)} required />
+                <input value={values.base_url ?? ""} onChange={(event) => updateConnectionValue("base_url", event.target.value)} required />
               </label>
             </div>
           ) : (
             <label className="field">
               <span>Base URL</span>
-              <input value={values.base_url ?? ""} onChange={(event) => onUpdate("base_url", event.target.value)} />
+              <input value={values.base_url ?? ""} onChange={(event) => updateConnectionValue("base_url", event.target.value)} />
             </label>
           )}
 
@@ -154,7 +212,7 @@ export function ProviderAPIQuickConnect({
                 type={showKey ? "text" : "password"}
                 onChange={(event) => {
                   clearCustomValidity(event);
-                  onUpdate("api_key", event.target.value);
+                  updateConnectionValue("api_key", event.target.value);
                 }}
                 onInvalid={handleRequiredFieldInvalid}
                 required
@@ -165,6 +223,24 @@ export function ProviderAPIQuickConnect({
             </div>
             {entry?.doc_url ? <a href={entry.doc_url} rel="noreferrer" target="_blank">{tx("获取 API Key")}</a> : null}
           </label>
+          <div className="provider-quick-test-row">
+            <button
+              className={connectionTest.status === "testing" ? "secondary-button provider-quick-test-button testing" : "secondary-button provider-quick-test-button"}
+              disabled={!connectionReady || connectionTest.status === "testing"}
+              onClick={() => void testConnection()}
+              type="button"
+            >
+              {connectionTest.status === "testing" ? <LoaderCircle size={14} /> : <RefreshCw size={14} />}
+              {tx(connectionTest.status === "testing" ? "正在测试" : "测试连接")}
+            </button>
+            {connectionTest.status !== "idle" && connectionTest.status !== "testing" ? (
+              <div className={`provider-quick-test-status ${connectionTest.status}`} aria-live="polite" role="status">
+                {connectionTest.status === "success" ? <CircleCheck size={15} /> : <CircleAlert size={15} />}
+                <span>{connectionTest.message}</span>
+                {connectionTest.latencyMS !== undefined ? <strong>{connectionTest.latencyMS} ms</strong> : null}
+              </div>
+            ) : null}
+          </div>
         </div>
       ) : null}
 

--- a/frontend/features/admin/views/provider-editor.tsx
+++ b/frontend/features/admin/views/provider-editor.tsx
@@ -1325,7 +1325,7 @@ export function ProviderUpsertModal({
             ) : null}
             {mode === "create" && createStep === 1 ? (
               quickAPIConnect ? (
-                <ProviderAPIQuickConnect
+                <ProviderAPIQuickConnect api={api}
                   key={catalogID}
                   catalogID={catalogID}
                   entry={selectedEntry}


### PR DESCRIPTION
## Summary

Add a pre-save connection test to the Provider creation flow so administrators can validate an upstream Base URL and API key and see measured response latency before storing the credentials.

## Related Issue

N/A.

## Changes

- Add an authenticated `POST /api/admin/providers/test-connection` probe that requests the upstream `/models` endpoint with a 15-second timeout and does not persist credentials.
- Add connection-test loading, success, failure, and latency feedback beside the Provider API key field.
- Add backend coverage plus English, Simplified Chinese, and Japanese UI/documentation updates.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor or maintenance
- [x] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...`
- `go vet ./...`
- `npm run typecheck`
- `npm run build`
- `node --test tools/*.test.mjs`
- `node tools/check-doc-translations.mjs --base origin/main --head HEAD`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- `git diff --check origin/main...HEAD`

## Compatibility, Security, and Operations

The admin API addition is backward compatible and requires existing Provider administration permission. The probe sends the submitted key only to the configured upstream endpoint, does not persist or return it, and does not include it in an audit payload. No database, environment, deployment, or rollout changes are required. Reverting the commit removes the endpoint and UI entry.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
