### PR TITLE
fix(frontend): keep key issuance on key management

### DIFF
--- a/frontend/features/admin/domain/resource-create-target.ts
+++ b/frontend/features/admin/domain/resource-create-target.ts
@@ -1,0 +1,21 @@
+export type ResourceCreateTarget =
+  | "provider-modal"
+  | "project-workspace"
+  | "notification-channel-modal"
+  | "api-key-wizard"
+  | "resource-modal";
+
+export function resourceCreateTarget(view: string): ResourceCreateTarget {
+  switch (view) {
+    case "providers":
+      return "provider-modal";
+    case "projects":
+      return "project-workspace";
+    case "notification-channels":
+      return "notification-channel-modal";
+    case "api-keys":
+      return "api-key-wizard";
+    default:
+      return "resource-modal";
+  }
+}

--- a/frontend/features/admin/shell/admin-console.tsx
+++ b/frontend/features/admin/shell/admin-console.tsx
@@ -10,6 +10,7 @@ import { emptyData, emptySummary, filterByModelCategory, filterRows } from "../d
 import { modelRouteDefaults, rowTitle } from "../domain/entities";
 import { uniqueUIID, viewFromPath } from "../domain/formatting";
 import { reportDatasetLabel } from "../domain/labels";
+import { resourceCreateTarget } from "../domain/resource-create-target";
 import { type AppLanguage, bulkDeleteConfirmMessage, deleteConfirmMessage, importUsersDoneMessage, importUsersSkippedMessage, isIssuedAPIKey, readSavedLanguage, setActiveLanguage, tx } from "../i18n/runtime";
 import { createKeyWithCapture } from "../resources/generic-config";
 import { downloadReport } from "../resources/governance-config";
@@ -666,23 +667,22 @@ export function AdminConsole({ defaultBaseURL }: { defaultBaseURL: string }) {
       setError(tx("数据加载中，请稍后再操作。"));
       return;
     }
-    if (activeConfig.view === "providers") {
-      setProviderCreateOpen(true);
-      return;
+    switch (resourceCreateTarget(activeConfig.view)) {
+      case "provider-modal":
+        setProviderCreateOpen(true);
+        return;
+      case "project-workspace":
+        setProjectWorkspace({ mode: "create" });
+        return;
+      case "notification-channel-modal":
+        setModal({ config: activeConfig, initialValues: notificationChannelDefaults(modelCategoryFilter) });
+        return;
+      case "api-key-wizard":
+        openCreateAPIKey();
+        return;
+      default:
+        setModal({ config: activeConfig });
     }
-    if (activeConfig.view === "projects") {
-      setProjectWorkspace({ mode: "create" });
-      return;
-    }
-    if (activeConfig.view === "notification-channels") {
-      setModal({ config: activeConfig, initialValues: notificationChannelDefaults(modelCategoryFilter) });
-      return;
-    }
-    if (activeConfig.view === "api-keys") {
-      openCreateAPIKey();
-      return;
-    }
-    setModal({ config: activeConfig });
   }
 
   async function saveModelRoutingPolicy(model: Model, policy: ModelRoutePolicy, successMessage = `已应用 ${model.name} 的模型路由策略`) {

--- a/tools/key-issuance-navigation.test.mjs
+++ b/tools/key-issuance-navigation.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { resourceCreateTarget } from "../frontend/features/admin/domain/resource-create-target.ts";
+
+describe("resource create navigation", () => {
+  it("keeps Key issuance in the API Key wizard", () => {
+    assert.equal(resourceCreateTarget("api-keys"), "api-key-wizard");
+  });
+
+  it("keeps resource-specific create targets explicit", () => {
+    assert.equal(resourceCreateTarget("providers"), "provider-modal");
+    assert.equal(resourceCreateTarget("projects"), "project-workspace");
+    assert.equal(resourceCreateTarget("notification-channels"), "notification-channel-modal");
+    assert.equal(resourceCreateTarget("users"), "resource-modal");
+  });
+});


### PR DESCRIPTION
## Summary

Keep the API Key create action on Key Management and open the Key wizard, including for standard users with no issuable projects. The legacy zero-project flow navigated to Projects, after which the access guard redirected standard users to Overview.

## Related Issue

N/A.

## Reproduction

1. Sign in as a standard user that has no project available for Key issuance.
2. Open Key Management at /api-keys.
3. Click either Issue Key action: the toolbar button or the empty-state button shown below.
4. Observe that the browser navigates to /overview instead of opening the Key creation flow.

Expected: remain on /api-keys and open the Create Internal API Key wizard. If no project is available, explain that inside the wizard.

Actual: the standard user is redirected to /overview.

### Screenshot

<img width="2964" height="1296" alt="Standard user Key Management Issue Key buttons redirect to Overview" src="https://github.com/user-attachments/assets/e4b91b52-624f-470c-809f-bd56e9624ae0" />

## Changes

- Extract resource create targets into a small, testable decision module.
- Route api-keys creation explicitly to the API Key wizard instead of another view.
- Add a repository-gate regression test covering Key issuance and the other specialized create targets.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- node --test tools/*.test.mjs (82 passed)
- npm run typecheck
- npm run build
- node tools/check-doc-translations.mjs --base main --head HEAD
- node tools/check-env-contract.mjs
- node tools/check-source-lines.mjs
- git diff --check
- Browser verification on localhost:3012 with the standard-user test account: Create API Key kept the URL at /api-keys, opened Create Internal API Key, and showed the no-project guidance inside the wizard.

## Compatibility, Security, and Operations

No API, persistence, authentication, authorization, environment, deployment, or rollout changes. Rollback is a normal commit revert.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local .env files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, start.sh, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] data/model-catalog.yaml remains tracked and catalog changes were reviewed where applicable.
- [x] git diff --check passes.