### PR TITLE
refactor(server): share the openai-compatible core between adapters

### DIFF
--- a/backend/internal/server/anthropic_messages.go
+++ b/backend/internal/server/anthropic_messages.go
@@ -925,10 +925,8 @@ func (s *Server) doNativeAnthropicRequest(
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode >= 400 {
-		defer resp.Body.Close()
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, newProviderHTTPError(resp.StatusCode, resp.Header, data)
+	if err := checkProviderResponse(resp); err != nil {
+		return nil, err
 	}
 	return resp, nil
 }

--- a/backend/internal/server/image_openai_http.go
+++ b/backend/internal/server/image_openai_http.go
@@ -206,10 +206,8 @@ func (a OpenAICompatibleAdapter) doMultipartRaw(
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode >= http.StatusBadRequest {
-		defer resp.Body.Close()
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, newProviderHTTPError(resp.StatusCode, resp.Header, data)
+	if err := checkProviderResponse(resp); err != nil {
+		return nil, err
 	}
 	return resp, nil
 }

--- a/backend/internal/server/provider_error_classification.go
+++ b/backend/internal/server/provider_error_classification.go
@@ -1,9 +1,15 @@
 package server
 
 import (
+	"io"
 	"net/http"
 	"strings"
 )
+
+// providerErrorBodyPrefix is how much of a failed upstream response is read for
+// the error message. Provider error bodies are small; the bound is what keeps a
+// misbehaving upstream from making the gateway buffer an arbitrary amount.
+const providerErrorBodyPrefix = 4096
 
 // An upstream failure has to answer three separate questions, and collapsing them
 // into one status code answers none of them well:
@@ -96,6 +102,23 @@ func newProviderMisconfigured(message string) error {
 		Err:         NewHTTPError(http.StatusServiceUnavailable, "provider_not_configured", message),
 		Disposition: ProviderErrorResourceBroken,
 	}
+}
+
+// checkProviderResponse reports whether an upstream response carries a failure,
+// and if so consumes it: a bounded prefix of the body becomes the error message
+// and the body is closed. It deliberately only inspects a response someone else
+// sent, because how a request is sent is not shared — a streaming call runs on a
+// client with no total deadline and an idle budget, and folding sending into
+// this check would put every caller on one policy.
+//
+// A nil error leaves the body open and owned by the caller.
+func checkProviderResponse(resp *http.Response) error {
+	if resp.StatusCode < http.StatusBadRequest {
+		return nil
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, providerErrorBodyPrefix))
+	return newProviderHTTPError(resp.StatusCode, resp.Header, data)
 }
 
 // newProviderHTTPError turns one upstream failure into the error the rest of the

--- a/backend/internal/server/provider_openai_core_test.go
+++ b/backend/internal/server/provider_openai_core_test.go
@@ -1,0 +1,487 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// capturedRequest is what an upstream saw, recorded before the handler answers.
+type capturedRequest struct {
+	method      string
+	escapedPath string
+	rawQuery    string
+	header      http.Header
+	body        map[string]any
+}
+
+// chatUpstream answers one non-streaming chat or embeddings call and records the
+// request the adapter built.
+func chatUpstream(t *testing.T, captured *capturedRequest) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.method = r.Method
+		captured.escapedPath = r.URL.EscapedPath()
+		captured.rawQuery = r.URL.RawQuery
+		captured.header = r.Header.Clone()
+		decodeFixtureRequest(t, r.Body, &captured.body)
+		w.Header().Set("content-type", "application/json")
+		writeFixture(t, w, `{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{}}`)
+	}))
+}
+
+func azureProvider(baseURL string, apiVersion string) Provider {
+	provider := Provider{Type: ProviderAzureOpenAI, BaseURL: baseURL, APIKey: "azure-key"}
+	if apiVersion != "" {
+		provider.Options = map[string]string{"api_version": apiVersion}
+	}
+	return provider
+}
+
+func simpleChatRequest() ChatCompletionRequest {
+	return ChatCompletionRequest{Model: "gateway-model", Messages: []ChatMessage{{Role: "user", Content: "hi"}}}
+}
+
+// Azure addresses a deployment by name in the path, so a deployment containing a
+// slash, a space or a percent sign must not be able to reshape the URL.
+func TestAzureOpenAIAdapterChatEscapesDeploymentAndAPIVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		deployment string
+		apiVersion string
+		wantPath   string
+		wantQuery  string
+	}{
+		{
+			name:       "default api version",
+			deployment: "gpt-4o",
+			wantPath:   "/openai/deployments/gpt-4o/chat/completions",
+			wantQuery:  "api-version=" + azureOpenAIDefaultAPIVersion,
+		},
+		{
+			name:       "slash in deployment",
+			deployment: "team/gpt-4o",
+			apiVersion: "2025-01-01-preview",
+			wantPath:   "/openai/deployments/team%2Fgpt-4o/chat/completions",
+			wantQuery:  "api-version=2025-01-01-preview",
+		},
+		{
+			name:       "space in deployment",
+			deployment: "gpt 4o",
+			apiVersion: "2025-01-01-preview",
+			wantPath:   "/openai/deployments/gpt%204o/chat/completions",
+			wantQuery:  "api-version=2025-01-01-preview",
+		},
+		{
+			name:       "percent in deployment",
+			deployment: "gpt%4o",
+			apiVersion: "2025-01-01-preview",
+			wantPath:   "/openai/deployments/gpt%254o/chat/completions",
+			wantQuery:  "api-version=2025-01-01-preview",
+		},
+		{
+			name:       "api version cannot add query parameters",
+			deployment: "gpt-4o",
+			apiVersion: "2025-01-01-preview&api-key=leak",
+			wantPath:   "/openai/deployments/gpt-4o/chat/completions",
+			wantQuery:  "api-version=2025-01-01-preview%26api-key%3Dleak",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured capturedRequest
+			upstream := chatUpstream(t, &captured)
+			defer upstream.Close()
+
+			adapter := AzureOpenAIAdapter{Client: upstream.Client()}
+			_, _, err := adapter.Chat(context.Background(), azureProvider(upstream.URL, tt.apiVersion), tt.deployment, simpleChatRequest())
+			if err != nil {
+				t.Fatalf("Chat: %v", err)
+			}
+
+			if captured.method != http.MethodPost {
+				t.Fatalf("method = %s, want POST", captured.method)
+			}
+			if captured.escapedPath != tt.wantPath {
+				t.Fatalf("path = %q, want %q", captured.escapedPath, tt.wantPath)
+			}
+			if captured.rawQuery != tt.wantQuery {
+				t.Fatalf("query = %q, want %q", captured.rawQuery, tt.wantQuery)
+			}
+			// The deployment names the URL; the body still carries the provider model.
+			if captured.body["model"] != tt.deployment {
+				t.Fatalf("body model = %v, want %q", captured.body["model"], tt.deployment)
+			}
+		})
+	}
+}
+
+// Azure authenticates with api-key and has never forwarded Provider.Headers or
+// the OpenAI account headers. Sharing request machinery with the OpenAI adapter
+// must not start sending either.
+func TestAzureOpenAIAdapterSendsOnlyAzureHeaders(t *testing.T) {
+	var captured capturedRequest
+	upstream := chatUpstream(t, &captured)
+	defer upstream.Close()
+
+	provider := azureProvider(upstream.URL, "")
+	provider.Headers = map[string]string{"x-custom": "forwarded-by-openai-only"}
+	provider.Options = map[string]string{
+		"organization_id":   "org-1",
+		"openai_project_id": "proj-1",
+		"account_id":        "acct-1",
+	}
+
+	adapter := AzureOpenAIAdapter{Client: upstream.Client()}
+	if _, _, err := adapter.Chat(context.Background(), provider, "gpt-4o", simpleChatRequest()); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if got := captured.header.Get("api-key"); got != "azure-key" {
+		t.Fatalf("api-key = %q, want azure-key", got)
+	}
+	if got := captured.header.Get("content-type"); got != "application/json" {
+		t.Fatalf("content-type = %q, want application/json", got)
+	}
+	for _, name := range []string{"authorization", "x-custom", "OpenAI-Organization", "OpenAI-Project", "X-TokenHub-Upstream-Account"} {
+		if got := captured.header.Get(name); got != "" {
+			t.Fatalf("Azure request carried %s = %q", name, got)
+		}
+	}
+}
+
+// An empty API key still sets the header, which is what makes a misconfigured
+// deployment fail at Azure with its own error rather than silently anonymously.
+func TestAzureOpenAIAdapterSetsAPIKeyHeaderEvenWhenEmpty(t *testing.T) {
+	var captured capturedRequest
+	upstream := chatUpstream(t, &captured)
+	defer upstream.Close()
+
+	provider := azureProvider(upstream.URL, "")
+	provider.APIKey = ""
+
+	adapter := AzureOpenAIAdapter{Client: upstream.Client()}
+	if _, _, err := adapter.Chat(context.Background(), provider, "gpt-4o", simpleChatRequest()); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if _, present := captured.header["Api-Key"]; !present {
+		t.Fatalf("api-key header was omitted: %v", captured.header)
+	}
+}
+
+func TestAzureOpenAIAdapterEmbeddingsUsesDeploymentURL(t *testing.T) {
+	var captured capturedRequest
+	upstream := chatUpstream(t, &captured)
+	defer upstream.Close()
+
+	adapter := AzureOpenAIAdapter{Client: upstream.Client()}
+	_, _, err := adapter.Embeddings(context.Background(), azureProvider(upstream.URL, ""), "text-embed", EmbeddingsRequest{Model: "gateway-embed", Input: "hi"})
+	if err != nil {
+		t.Fatalf("Embeddings: %v", err)
+	}
+
+	if captured.escapedPath != "/openai/deployments/text-embed/embeddings" {
+		t.Fatalf("path = %q", captured.escapedPath)
+	}
+	if captured.body["model"] != "text-embed" {
+		t.Fatalf("body model = %v, want text-embed", captured.body["model"])
+	}
+}
+
+// reasoning_content is a TokenHub extension that only DeepSeek understands, so
+// Azure must keep stripping it along with the other gateway-local fields.
+func TestAzureOpenAIAdapterDoesNotForwardGatewayExtensions(t *testing.T) {
+	var captured capturedRequest
+	upstream := chatUpstream(t, &captured)
+	defer upstream.Close()
+
+	adapter := AzureOpenAIAdapter{Client: upstream.Client()}
+	_, _, err := adapter.Chat(context.Background(), azureProvider(upstream.URL, ""), "gpt-4o", ChatCompletionRequest{
+		Model: "gateway-model",
+		Messages: []ChatMessage{{
+			Role:                     "assistant",
+			Content:                  "answer",
+			ReasoningContent:         "thinking",
+			ReasoningSignature:       "anthropic:sig",
+			RedactedReasoningContent: "opaque",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	messages, _ := captured.body["messages"].([]any)
+	if len(messages) == 0 {
+		t.Fatalf("no messages were forwarded: %v", captured.body)
+	}
+	message, _ := messages[0].(map[string]any)
+	for _, field := range []string{"reasoning_content", "reasoning_signature", "redacted_reasoning_content"} {
+		if _, present := message[field]; present {
+			t.Fatalf("%s must remain gateway-local: %v", field, message)
+		}
+	}
+}
+
+// Stripping is the Azure adapter's own rule, not something inferred from the
+// provider type: nothing enforces which types an adapter is registered under,
+// so a provider row typed "deepseek" must not talk the Azure adapter into
+// forwarding the extension.
+func TestAzureOpenAIAdapterStripsReasoningContentForAnyProviderType(t *testing.T) {
+	var captured capturedRequest
+	upstream := chatUpstream(t, &captured)
+	defer upstream.Close()
+
+	provider := azureProvider(upstream.URL, "")
+	provider.Type = "deepseek"
+
+	adapter := AzureOpenAIAdapter{Client: upstream.Client()}
+	_, _, err := adapter.Chat(context.Background(), provider, "gpt-4o", ChatCompletionRequest{
+		Model:    "gateway-model",
+		Messages: []ChatMessage{{Role: "assistant", Content: "answer", ReasoningContent: "thinking"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	messages, _ := captured.body["messages"].([]any)
+	message, _ := messages[0].(map[string]any)
+	if _, present := message["reasoning_content"]; present {
+		t.Fatalf("Azure forwarded reasoning_content: %v", message)
+	}
+}
+
+func TestAzureOpenAIAdapterRequiresBaseURL(t *testing.T) {
+	adapter := AzureOpenAIAdapter{}
+	_, _, err := adapter.Chat(context.Background(), Provider{Type: ProviderAzureOpenAI, APIKey: "azure-key"}, "gpt-4o", simpleChatRequest())
+
+	httpErr := AsHTTPError(err)
+	if httpErr == nil || httpErr.Message != "Azure OpenAI base_url is required" {
+		t.Fatalf("error = %v, want the Azure-specific misconfiguration message", err)
+	}
+	if httpErr.Code != "provider_not_configured" {
+		t.Fatalf("code = %q, want provider_not_configured", httpErr.Code)
+	}
+}
+
+// /v1/responses dispatches on the adapter's Responses method without consulting
+// the capability registry, so Azure's explicit 501 is the only thing standing
+// between a caller and a request to an endpoint Azure deployments do not serve.
+func TestAzureOpenAIAdapterResponsesIsNotImplemented(t *testing.T) {
+	adapter := AzureOpenAIAdapter{}
+	_, _, err := adapter.Responses(context.Background(), azureProvider("https://example.invalid", ""), "gpt-4o", ResponsesRequest{Model: "gateway-model"})
+
+	httpErr := AsHTTPError(err)
+	if httpErr == nil || httpErr.Status != 501 {
+		t.Fatalf("error = %v, want a 501", err)
+	}
+	if httpErr.Code != "provider_capability_not_supported" {
+		t.Fatalf("code = %q, want provider_capability_not_supported", httpErr.Code)
+	}
+	if httpErr.Message != "Azure responses adapter is not implemented in MVP" {
+		t.Fatalf("message = %q", httpErr.Message)
+	}
+}
+
+// The streaming half of the same rule: the responses streaming path picks its
+// adapter by interface, so Azure must not satisfy ResponsesStreamOpener.
+func TestAzureOpenAIAdapterIsNotAResponsesStreamOpener(t *testing.T) {
+	var adapter any = AzureOpenAIAdapter{}
+	if _, ok := adapter.(ResponsesStreamOpener); ok {
+		t.Fatal("AzureOpenAIAdapter must not implement ResponsesStreamOpener: /v1/responses would stream from an endpoint Azure does not serve")
+	}
+	if _, ok := adapter.(ProviderAdapter); !ok {
+		t.Fatal("AzureOpenAIAdapter must still be a ProviderAdapter")
+	}
+}
+
+// Streaming runs on StreamClient precisely so the non-streaming total deadline
+// cannot truncate a live stream. Azure shares that machinery and must keep the
+// same policy.
+func TestAzureChatStreamOutlivesTheNonStreamingTimeout(t *testing.T) {
+	upstream := sseUpstream(t, 0, []time.Duration{80 * time.Millisecond, 80 * time.Millisecond, 80 * time.Millisecond})
+	defer upstream.Close()
+
+	client := upstream.Client()
+	client.Timeout = 100 * time.Millisecond
+	adapter := AzureOpenAIAdapter{
+		Client:            client,
+		StreamClient:      &http.Client{Transport: client.Transport},
+		StreamIdleTimeout: time.Second,
+	}
+
+	var out bytes.Buffer
+	_, err := adapter.ChatStream(context.Background(), azureProvider(upstream.URL, ""), "gpt-4o", simpleChatRequest(), &out)
+	if err != nil {
+		t.Fatalf("an active Azure stream was cut short: %v", err)
+	}
+	if !strings.Contains(out.String(), "[DONE]") {
+		t.Fatalf("stream was truncated before [DONE]: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "chunk-2") {
+		t.Fatalf("stream lost its last chunk: %q", out.String())
+	}
+}
+
+func TestAzureOpenAIAdapterChatStreamUsesDeploymentURL(t *testing.T) {
+	var captured capturedRequest
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.escapedPath = r.URL.EscapedPath()
+		captured.rawQuery = r.URL.RawQuery
+		captured.header = r.Header.Clone()
+		decodeFixtureRequest(t, r.Body, &captured.body)
+		w.Header().Set("content-type", "text/event-stream")
+		writeFixture(t, w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	adapter := AzureOpenAIAdapter{Client: upstream.Client()}
+	var out bytes.Buffer
+	if _, err := adapter.ChatStream(context.Background(), azureProvider(upstream.URL, ""), "gpt-4o", simpleChatRequest(), &out); err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+
+	if captured.escapedPath != "/openai/deployments/gpt-4o/chat/completions" {
+		t.Fatalf("path = %q", captured.escapedPath)
+	}
+	if captured.rawQuery != "api-version="+azureOpenAIDefaultAPIVersion {
+		t.Fatalf("query = %q", captured.rawQuery)
+	}
+	if captured.body["stream"] != true {
+		t.Fatalf("stream flag = %v, want true", captured.body["stream"])
+	}
+	streamOptions, _ := captured.body["stream_options"].(map[string]any)
+	if streamOptions["include_usage"] != true {
+		t.Fatalf("include_usage = %v, want true", streamOptions["include_usage"])
+	}
+	if got := captured.header.Get("api-key"); got != "azure-key" {
+		t.Fatalf("api-key = %q", got)
+	}
+}
+
+// Adapters are initialised as struct literals across the repository, so the zero
+// value has to reach an upstream on its own: no client and no configured
+// request builder.
+func TestZeroValueOpenAICompatibleAdapterCallsUpstream(t *testing.T) {
+	var captured capturedRequest
+	upstream := chatUpstream(t, &captured)
+	defer upstream.Close()
+
+	adapter := OpenAICompatibleAdapter{}
+	provider := Provider{Type: ProviderOpenAICompatible, BaseURL: upstream.URL, APIKey: "openai-key"}
+	if _, _, err := adapter.Chat(context.Background(), provider, "model-x", simpleChatRequest()); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if captured.escapedPath != "/chat/completions" {
+		t.Fatalf("path = %q, want /chat/completions", captured.escapedPath)
+	}
+	if got := captured.header.Get("authorization"); got != "Bearer openai-key" {
+		t.Fatalf("authorization = %q", got)
+	}
+}
+
+func TestOpenAICompatibleAdapterSendsAccountAndProviderHeaders(t *testing.T) {
+	var captured capturedRequest
+	upstream := chatUpstream(t, &captured)
+	defer upstream.Close()
+
+	provider := Provider{
+		Type:    ProviderOpenAICompatible,
+		BaseURL: upstream.URL,
+		APIKey:  "openai-key",
+		Headers: map[string]string{"x-custom": "kept"},
+		Options: map[string]string{
+			"organization_id":   "org-1",
+			"openai_project_id": "proj-1",
+			"account_id":        "acct-1",
+		},
+	}
+
+	adapter := OpenAICompatibleAdapter{Client: upstream.Client()}
+	if _, _, err := adapter.Chat(context.Background(), provider, "model-x", simpleChatRequest()); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	for name, want := range map[string]string{
+		"authorization":               "Bearer openai-key",
+		"OpenAI-Organization":         "org-1",
+		"OpenAI-Project":              "proj-1",
+		"X-TokenHub-Upstream-Account": "acct-1",
+		"x-custom":                    "kept",
+	} {
+		if got := captured.header.Get(name); got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestOpenAICompatibleAdapterRequiresBaseURL(t *testing.T) {
+	adapter := OpenAICompatibleAdapter{}
+	_, _, err := adapter.Chat(context.Background(), Provider{Type: ProviderOpenAICompatible, APIKey: "openai-key"}, "model-x", simpleChatRequest())
+
+	httpErr := AsHTTPError(err)
+	if httpErr == nil || httpErr.Message != "Provider base_url is required" {
+		t.Fatalf("error = %v, want the provider misconfiguration message", err)
+	}
+}
+
+// closeTrackingBody reports whether the response body was closed.
+type closeTrackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestCheckProviderResponseClassifiesAndBoundsTheBody(t *testing.T) {
+	body := &closeTrackingBody{Reader: strings.NewReader(strings.Repeat("x", providerErrorBodyPrefix*3))}
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Retry-After": []string{"7"}},
+		Body:       body,
+	}
+
+	err := checkProviderResponse(resp)
+	if err == nil {
+		t.Fatal("a 429 must be reported as a provider error")
+	}
+	httpErr := AsHTTPError(err)
+	if httpErr.Code != "provider_rate_limited" || httpErr.UpstreamStatus != http.StatusTooManyRequests {
+		t.Fatalf("error = %+v, want a rate-limit classification", httpErr)
+	}
+	if len(httpErr.Message) != providerErrorBodyPrefix {
+		t.Fatalf("message length = %d, want the body read to stop at %d", len(httpErr.Message), providerErrorBodyPrefix)
+	}
+	var invocation *ProviderInvocationError
+	if !errors.As(err, &invocation) || invocation.RetryAfter != 7*time.Second {
+		t.Fatalf("retry-after was lost: %v", err)
+	}
+	if !body.closed {
+		t.Fatal("a failed response body must be closed")
+	}
+}
+
+// The success path hands the body back still open, because the caller streams or
+// decodes it.
+func TestCheckProviderResponseLeavesSuccessfulResponsesAlone(t *testing.T) {
+	body := &closeTrackingBody{Reader: strings.NewReader("{}")}
+	resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: body}
+
+	if err := checkProviderResponse(resp); err != nil {
+		t.Fatalf("checkProviderResponse: %v", err)
+	}
+	if body.closed {
+		t.Fatal("a successful response body must stay open for the caller")
+	}
+}

--- a/backend/internal/server/providers.go
+++ b/backend/internal/server/providers.go
@@ -159,6 +159,133 @@ func (a MockAdapter) Embeddings(ctx context.Context, provider Provider, provider
 	}, usage, nil
 }
 
+// preservesReasoningContent reports whether an OpenAI-compatible upstream
+// understands the reasoning_content it produced being handed back on the next
+// turn. DeepSeek does and needs it for multi-turn reasoning; for everyone else
+// the field is a TokenHub-local extension and is stripped.
+func preservesReasoningContent(provider Provider) bool {
+	return provider.Type == "deepseek"
+}
+
+// dropsReasoningContent is the Azure policy: reasoning_content never reaches a
+// deployment. It is stated as the adapter's own rule rather than inferred from
+// the provider type, because nothing enforces which types an adapter is
+// registered under and Azure's answer does not depend on that.
+func dropsReasoningContent(Provider) bool {
+	return false
+}
+
+// providerRequestBuilder builds the upstream request for one OpenAI-shaped call.
+// The URL and the auth headers are the whole wire-format difference between the
+// OpenAI-compatible and Azure OpenAI adapters; everything around it — sending,
+// failure checking, decoding, streaming — is shared by openAICompatibleCore.
+type providerRequestBuilder func(ctx context.Context, provider Provider, method string, model string, endpoint string, body []byte) (*http.Request, error)
+
+// openAICompatibleCore is the request machinery the OpenAI-compatible and Azure
+// OpenAI adapters share. The adapters hold it through a core() method rather
+// than embedding it, and it stays unexported, because embedding would also hand
+// AzureOpenAIAdapter the OpenAI adapter's Responses and OpenResponses methods:
+// /v1/responses dispatches on those interfaces without consulting the
+// capability registry, so Azure would stop answering 501 and start calling an
+// endpoint Azure deployments do not serve.
+type openAICompatibleCore struct {
+	client *http.Client
+	// streamClient carries no total deadline; see provider_stream_timeout.go.
+	// Streaming calls fall back to client when it is unset.
+	streamClient      *http.Client
+	streamIdleTimeout time.Duration
+	// baseURLRequired is the misconfiguration reported when the provider has no
+	// base URL. Both adapters require one; only the wording differs.
+	baseURLRequired string
+	// preserveReasoningContent is the adapter's rule for whether TokenHub's
+	// reasoning_content extension may be forwarded to this provider.
+	preserveReasoningContent func(provider Provider) bool
+	build                    providerRequestBuilder
+}
+
+func (c openAICompatibleCore) chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
+	req = withoutGatewayExtensions(req, c.preserveReasoningContent(provider))
+	req.Model = providerModel
+	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
+	var body map[string]any
+	if err := c.doJSON(ctx, provider, http.MethodPost, providerModel, "/chat/completions", req, &body); err != nil {
+		return nil, Usage{}, err
+	}
+	return body, usageFromMap(body), nil
+}
+
+func (c openAICompatibleCore) chatStream(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest, w io.Writer) (Usage, error) {
+	req = withoutGatewayExtensions(req, c.preserveReasoningContent(provider))
+	req.Model = providerModel
+	req.Stream = true
+	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
+	req = includeOpenAIStreamUsage(req)
+	resp, err := c.doRaw(ctx, provider, http.MethodPost, providerModel, "/chat/completions", req, true)
+	if err != nil {
+		return Usage{}, err
+	}
+	defer resp.Body.Close()
+	return copyOpenAIStreamAndUsage(w, resp.Body)
+}
+
+func (c openAICompatibleCore) embeddings(ctx context.Context, provider Provider, providerModel string, req EmbeddingsRequest) (any, Usage, error) {
+	req.Model = providerModel
+	var body map[string]any
+	if err := c.doJSON(ctx, provider, http.MethodPost, providerModel, "/embeddings", req, &body); err != nil {
+		return nil, Usage{}, err
+	}
+	return body, usageFromMap(body), nil
+}
+
+func (c openAICompatibleCore) doJSON(ctx context.Context, provider Provider, method string, model string, endpoint string, payload any, target any) error {
+	resp, err := c.doRaw(ctx, provider, method, model, endpoint, payload, false)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+func (c openAICompatibleCore) doRaw(ctx context.Context, provider Provider, method string, model string, endpoint string, payload any, stream bool) (*http.Response, error) {
+	if provider.BaseURL == "" {
+		return nil, newProviderMisconfigured(c.baseURLRequired)
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	req, err := c.build(ctx, provider, method, model, endpoint, body)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := sendUpstream(c.client, c.streamClient, c.streamIdleTimeout, req, stream)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkProviderResponse(resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// openAICompatibleRequest addresses an OpenAI-compatible base URL directly: the
+// model travels in the body, so the model argument is unused here.
+func openAICompatibleRequest(ctx context.Context, provider Provider, method string, _ string, endpoint string, body []byte) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, joinURL(provider.BaseURL, endpoint), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("content-type", "application/json")
+	if provider.APIKey != "" {
+		req.Header.Set("authorization", "Bearer "+provider.APIKey)
+	}
+	applyOpenAICompatibleAccountHeaders(req, provider)
+	for key, value := range provider.Headers {
+		req.Header.Set(key, value)
+	}
+	return req, nil
+}
+
 type OpenAICompatibleAdapter struct {
 	Client *http.Client
 	// StreamClient carries no total deadline; see provider_stream_timeout.go.
@@ -167,29 +294,23 @@ type OpenAICompatibleAdapter struct {
 	StreamIdleTimeout time.Duration
 }
 
-func (a OpenAICompatibleAdapter) Chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
-	req = withoutGatewayExtensions(req, provider.Type == "deepseek")
-	req.Model = providerModel
-	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
-	var body map[string]any
-	if err := a.doJSON(ctx, provider, http.MethodPost, "/chat/completions", req, &body); err != nil {
-		return nil, Usage{}, err
+func (a OpenAICompatibleAdapter) core() openAICompatibleCore {
+	return openAICompatibleCore{
+		client:                   a.Client,
+		streamClient:             a.StreamClient,
+		streamIdleTimeout:        a.StreamIdleTimeout,
+		baseURLRequired:          "Provider base_url is required",
+		preserveReasoningContent: preservesReasoningContent,
+		build:                    openAICompatibleRequest,
 	}
-	return body, usageFromMap(body), nil
+}
+
+func (a OpenAICompatibleAdapter) Chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
+	return a.core().chat(ctx, provider, providerModel, req)
 }
 
 func (a OpenAICompatibleAdapter) ChatStream(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest, w io.Writer) (Usage, error) {
-	req = withoutGatewayExtensions(req, provider.Type == "deepseek")
-	req.Model = providerModel
-	req.Stream = true
-	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
-	req = includeOpenAIStreamUsage(req)
-	resp, err := a.doRaw(ctx, provider, http.MethodPost, "/chat/completions", req, true)
-	if err != nil {
-		return Usage{}, err
-	}
-	defer resp.Body.Close()
-	return copyOpenAIStreamAndUsage(w, resp.Body)
+	return a.core().chatStream(ctx, provider, providerModel, req, w)
 }
 
 func (a OpenAICompatibleAdapter) Responses(ctx context.Context, provider Provider, providerModel string, req ResponsesRequest) (any, Usage, error) {
@@ -210,53 +331,15 @@ func (a OpenAICompatibleAdapter) OpenResponses(ctx context.Context, provider Pro
 }
 
 func (a OpenAICompatibleAdapter) Embeddings(ctx context.Context, provider Provider, providerModel string, req EmbeddingsRequest) (any, Usage, error) {
-	req.Model = providerModel
-	var body map[string]any
-	if err := a.doJSON(ctx, provider, http.MethodPost, "/embeddings", req, &body); err != nil {
-		return nil, Usage{}, err
-	}
-	return body, usageFromMap(body), nil
+	return a.core().embeddings(ctx, provider, providerModel, req)
 }
 
 func (a OpenAICompatibleAdapter) doJSON(ctx context.Context, provider Provider, method, endpoint string, payload any, target any) error {
-	resp, err := a.doRaw(ctx, provider, method, endpoint, payload, false)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	return json.NewDecoder(resp.Body).Decode(target)
+	return a.core().doJSON(ctx, provider, method, "", endpoint, payload, target)
 }
 
 func (a OpenAICompatibleAdapter) doRaw(ctx context.Context, provider Provider, method, endpoint string, payload any, stream bool) (*http.Response, error) {
-	if provider.BaseURL == "" {
-		return nil, newProviderMisconfigured("Provider base_url is required")
-	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequestWithContext(ctx, method, joinURL(provider.BaseURL, endpoint), bytes.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("content-type", "application/json")
-	if provider.APIKey != "" {
-		req.Header.Set("authorization", "Bearer "+provider.APIKey)
-	}
-	applyOpenAICompatibleAccountHeaders(req, provider)
-	for key, value := range provider.Headers {
-		req.Header.Set(key, value)
-	}
-	resp, err := sendUpstream(a.Client, a.StreamClient, a.StreamIdleTimeout, req, stream)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode >= 400 {
-		defer resp.Body.Close()
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, newProviderHTTPError(resp.StatusCode, resp.Header, data)
-	}
-	return resp, nil
+	return a.core().doRaw(ctx, provider, method, "", endpoint, payload, stream)
 }
 
 func applyOpenAICompatibleAccountHeaders(req *http.Request, provider Provider) {
@@ -274,6 +357,34 @@ func applyOpenAICompatibleAccountHeaders(req *http.Request, provider Provider) {
 	}
 }
 
+// azureOpenAIDefaultAPIVersion is used when the provider does not pin one.
+const azureOpenAIDefaultAPIVersion = "2024-02-15-preview"
+
+// azureOpenAIRequest addresses one Azure OpenAI deployment: the model names a
+// deployment in the path, the API version is a query parameter, and the key is
+// an api-key header rather than a bearer token. Provider.Headers are not applied
+// here — Azure has never forwarded them, and adding that now would change which
+// headers reach every existing deployment.
+func azureOpenAIRequest(ctx context.Context, provider Provider, method string, deployment string, endpoint string, body []byte) (*http.Request, error) {
+	apiVersion := provider.Options["api_version"]
+	if apiVersion == "" {
+		apiVersion = azureOpenAIDefaultAPIVersion
+	}
+	u := fmt.Sprintf("%s/openai/deployments/%s%s?api-version=%s", strings.TrimRight(provider.BaseURL, "/"), url.PathEscape(deployment), endpoint, url.QueryEscape(apiVersion))
+	req, err := http.NewRequestWithContext(ctx, method, u, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("api-key", provider.APIKey)
+	return req, nil
+}
+
+// AzureOpenAIAdapter speaks the OpenAI wire format against Azure deployments. It
+// shares openAICompatibleCore with OpenAICompatibleAdapter but stays a separate
+// type on purpose: it must not acquire that adapter's Responses or
+// OpenResponses, which the /v1/responses paths dispatch on directly. See
+// openAICompatibleCore.
 type AzureOpenAIAdapter struct {
 	Client *http.Client
 	// StreamClient carries no total deadline; see provider_stream_timeout.go.
@@ -282,29 +393,23 @@ type AzureOpenAIAdapter struct {
 	StreamIdleTimeout time.Duration
 }
 
-func (a AzureOpenAIAdapter) Chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
-	req = withoutGatewayExtensions(req, false)
-	req.Model = providerModel
-	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
-	var body map[string]any
-	if err := a.doJSON(ctx, provider, providerModel, "/chat/completions", req, &body); err != nil {
-		return nil, Usage{}, err
+func (a AzureOpenAIAdapter) core() openAICompatibleCore {
+	return openAICompatibleCore{
+		client:                   a.Client,
+		streamClient:             a.StreamClient,
+		streamIdleTimeout:        a.StreamIdleTimeout,
+		baseURLRequired:          "Azure OpenAI base_url is required",
+		preserveReasoningContent: dropsReasoningContent,
+		build:                    azureOpenAIRequest,
 	}
-	return body, usageFromMap(body), nil
+}
+
+func (a AzureOpenAIAdapter) Chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
+	return a.core().chat(ctx, provider, providerModel, req)
 }
 
 func (a AzureOpenAIAdapter) ChatStream(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest, w io.Writer) (Usage, error) {
-	req = withoutGatewayExtensions(req, false)
-	req.Model = providerModel
-	req.Stream = true
-	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
-	req = includeOpenAIStreamUsage(req)
-	resp, err := a.doRaw(ctx, provider, providerModel, "/chat/completions", req, true)
-	if err != nil {
-		return Usage{}, err
-	}
-	defer resp.Body.Close()
-	return copyOpenAIStreamAndUsage(w, resp.Body)
+	return a.core().chatStream(ctx, provider, providerModel, req, w)
 }
 
 func (a AzureOpenAIAdapter) Responses(ctx context.Context, provider Provider, providerModel string, req ResponsesRequest) (any, Usage, error) {
@@ -312,52 +417,7 @@ func (a AzureOpenAIAdapter) Responses(ctx context.Context, provider Provider, pr
 }
 
 func (a AzureOpenAIAdapter) Embeddings(ctx context.Context, provider Provider, providerModel string, req EmbeddingsRequest) (any, Usage, error) {
-	req.Model = providerModel
-	var body map[string]any
-	if err := a.doJSON(ctx, provider, providerModel, "/embeddings", req, &body); err != nil {
-		return nil, Usage{}, err
-	}
-	return body, usageFromMap(body), nil
-}
-
-func (a AzureOpenAIAdapter) doJSON(ctx context.Context, provider Provider, deployment string, endpoint string, payload any, target any) error {
-	resp, err := a.doRaw(ctx, provider, deployment, endpoint, payload, false)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	return json.NewDecoder(resp.Body).Decode(target)
-}
-
-func (a AzureOpenAIAdapter) doRaw(ctx context.Context, provider Provider, deployment string, endpoint string, payload any, stream bool) (*http.Response, error) {
-	apiVersion := provider.Options["api_version"]
-	if apiVersion == "" {
-		apiVersion = "2024-02-15-preview"
-	}
-	if provider.BaseURL == "" {
-		return nil, newProviderMisconfigured("Azure OpenAI base_url is required")
-	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return nil, err
-	}
-	u := fmt.Sprintf("%s/openai/deployments/%s%s?api-version=%s", strings.TrimRight(provider.BaseURL, "/"), url.PathEscape(deployment), endpoint, url.QueryEscape(apiVersion))
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("content-type", "application/json")
-	req.Header.Set("api-key", provider.APIKey)
-	resp, err := sendUpstream(a.Client, a.StreamClient, a.StreamIdleTimeout, req, stream)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode >= 400 {
-		defer resp.Body.Close()
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, newProviderHTTPError(resp.StatusCode, resp.Header, data)
-	}
-	return resp, nil
+	return a.core().embeddings(ctx, provider, providerModel, req)
 }
 
 type AnthropicAdapter struct {
@@ -462,10 +522,8 @@ func (a AnthropicAdapter) doRaw(ctx context.Context, provider Provider, endpoint
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode >= 400 {
-		defer resp.Body.Close()
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, newProviderHTTPError(resp.StatusCode, resp.Header, data)
+	if err := checkProviderResponse(resp); err != nil {
+		return nil, err
 	}
 	return resp, nil
 }
@@ -595,10 +653,8 @@ func (a GeminiAdapter) doRaw(ctx context.Context, provider Provider, model strin
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode >= 400 {
-		defer resp.Body.Close()
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, newProviderHTTPError(resp.StatusCode, resp.Header, data)
+	if err := checkProviderResponse(resp); err != nil {
+		return nil, err
 	}
 	return resp, nil
 }


### PR DESCRIPTION
## Summary

Second of three stacked provider-layer PRs. `AzureOpenAIAdapter`'s `Chat`/`ChatStream`/`Embeddings`/`doJSON` were verbatim copies of `OpenAICompatibleAdapter`'s — the real difference was confined to request construction (deployment path + api-version + api-key vs joinURL + Bearer + account headers). Six response-check tails across the provider layer were also byte-identical. This PR collapses both duplications with no intended behavior change.

**Stacked on #116** — merge order: #115 → #116 → this. PR-C follows on top.

## Related Issue

N/A

## Changes

- New unexported `openAICompatibleCore` shared by both adapters via a per-call `core()` (per-call on purpose: the image path clones the adapter with an untimed client, which only works if the core reads fields at call time). Differences live in a `providerRequestBuilder` and a `preserveReasoningContent` strategy field, so each adapter's `reasoning_content` policy is declared where it lives instead of hanging on provider-type conventions.
- **Azure deliberately stays a separate type with its explicit `Responses` 501**: the non-streaming `/v1/responses` path dispatches on interface satisfaction without consulting capabilities, so folding Azure into the OpenAI type would silently turn that 501 into a real upstream call. Azure still does not satisfy `ResponsesStreamOpener` (asserted in tests).
- `checkProviderResponse` collapses the six identical tails (status ≥ 400 → 4 KiB body prefix → close → classify) and deliberately checks only responses someone else sent — sending policy (stream clients, idle budgets) stays with each adapter, so streaming calls keep their no-total-deadline client.
- All Azure construction details preserved and test-pinned: `PathEscape`/`QueryEscape`, empty api-key still `Set`, no Bearer/account/provider headers, Azure-specific error copy, default api-version.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...` pass (includes 19 new tests in `provider_openai_core_test.go`: Azure URL escaping table, header discipline, the 501, stream-client selection, OpenAI header order, `checkProviderResponse` truncation/classification/body ownership).
- `go vet` clean, `golangci-lint` 0 issues, `gofmt` clean, tools gates and `git diff --check` pass.
- Review: Codex design review (its two blocking constraints — keep the Azure 501, don't fold sending into the shared check — are load-bearing in this design), Codex pre-commit review (one finding, fixed), and an independent read-only review agent that mutation-tested 8 injected defects — all caught by the new tests. Its one Medium (a doc comment swallowed by the new function) is fixed; its suggestion to thread `providerModel` through the OpenAI shims was deliberately declined to avoid widening exported-adjacent signatures for an unused parameter.

## Compatibility, Security, and Operations

None. Internal-only refactor; request bytes, headers, error copy, timeouts, and the Azure `Responses` 501 are unchanged and test-pinned.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable. (None changed.)
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable. (No user-facing docs affected.)
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable. (Untouched.)
- [x] `git diff --check` passes.