### PR TITLE
refactor(server): unify finish-reason mapping and anthropic usage parsing

### DIFF
--- a/backend/internal/server/anthropic_messages.go
+++ b/backend/internal/server/anthropic_messages.go
@@ -832,22 +832,6 @@ func anySlice(value any) ([]any, bool) {
 	}
 }
 
-func openAIFinishReasonToAnthropic(reason string, hasTools bool) string {
-	if hasTools || reason == "tool_calls" || reason == "function_call" {
-		return "tool_use"
-	}
-	switch reason {
-	case "length":
-		return "max_tokens"
-	case "stop", "":
-		return "end_turn"
-	case "content_filter":
-		return "refusal"
-	default:
-		return "end_turn"
-	}
-}
-
 func anthropicUsageObject(usage Usage) map[string]any {
 	cachedInputTokens := minInt64(maxInt64(usage.CachedInputTokens, 0), maxInt64(usage.PromptTokens, 0))
 	return map[string]any{

--- a/backend/internal/server/anthropic_messages_stream.go
+++ b/backend/internal/server/anthropic_messages_stream.go
@@ -87,16 +87,24 @@ func copyNativeAnthropicStream(writer io.Writer, body io.Reader, model string) (
 	}
 }
 
+// mergeAnthropicStreamUsage folds one streamed usage snapshot into the running
+// total. A stream splits its usage across message_start and message_delta, and
+// a frame that reports nothing new omits the fields entirely, so a frame only
+// overwrites what it actually carries. The three input classes move together as
+// one group: any positive component replaces the whole input side, including
+// siblings the frame left out, because a frame that restates the input counts
+// restates all of them. The output count is merged on its own.
 func mergeAnthropicStreamUsage(current Usage, raw map[string]any) Usage {
-	inputTokens := int64FromAny(raw["input_tokens"])
-	cacheCreationInputTokens := int64FromAny(raw["cache_creation_input_tokens"])
-	cacheReadInputTokens := int64FromAny(raw["cache_read_input_tokens"])
-	if inputTokens > 0 || cacheCreationInputTokens > 0 || cacheReadInputTokens > 0 {
-		current.PromptTokens = inputTokens + cacheCreationInputTokens + cacheReadInputTokens
-		current.CachedInputTokens = cacheReadInputTokens
+	snapshot := anthropicUsageFromRawMap(raw)
+	if snapshot.PromptTokens > 0 || snapshot.CachedInputTokens > 0 || snapshot.CacheWriteInputTokens > 0 {
+		current.PromptTokens = snapshot.PromptTokens
+		current.CachedInputTokens = snapshot.CachedInputTokens
+		// CacheWriteInputTokens is knowingly left unmerged here. This path has
+		// never reported it, and starting to would change billed usage, which is
+		// a behavior change rather than part of consolidating the parsing.
 	}
-	if value := int64FromAny(raw["output_tokens"]); value > 0 {
-		current.CompletionTokens = value
+	if snapshot.CompletionTokens > 0 {
+		current.CompletionTokens = snapshot.CompletionTokens
 	}
 	current.TotalTokens = current.PromptTokens + current.CompletionTokens
 	return current

--- a/backend/internal/server/provider_anthropic_convert.go
+++ b/backend/internal/server/provider_anthropic_convert.go
@@ -394,37 +394,3 @@ func anthropicChatResponse(body map[string]any, model string, usage Usage) (map[
 		"usage": usage,
 	}, nil
 }
-
-// anthropicFinishReason maps a stop reason. Unknown values are surfaced as an
-// upstream error rather than being flattened to "stop", which would report a
-// truncated or refused generation as a normal completion.
-func anthropicFinishReason(stopReason string, hasToolCalls bool) (string, error) {
-	switch stopReason {
-	case "tool_use":
-		return "tool_calls", nil
-	case "pause_turn":
-		// A paused server-tool loop expects the assistant content to be replayed
-		// verbatim so the provider can resume it. That is not something an
-		// OpenAI-shaped client can do, and reporting tool_calls would tell the
-		// client to run a tool that was never requested.
-		return "", unsupportedCapabilityError("provider paused a server-side tool loop, which this route cannot resume")
-	case "end_turn", "stop_sequence":
-		if hasToolCalls {
-			return "tool_calls", nil
-		}
-		return "stop", nil
-	case "max_tokens", "model_context_window_exceeded":
-		return "length", nil
-	case "refusal":
-		return "content_filter", nil
-	case "":
-		// Streaming responses report the stop reason in message_delta; a
-		// non-streaming body without one is still in flight or malformed.
-		if hasToolCalls {
-			return "tool_calls", nil
-		}
-		return "stop", nil
-	default:
-		return "", invalidProviderResponseError(fmt.Sprintf("provider returned an unrecognized stop_reason %q", stopReason))
-	}
-}

--- a/backend/internal/server/provider_anthropic_convert_test.go
+++ b/backend/internal/server/provider_anthropic_convert_test.go
@@ -341,39 +341,6 @@ func TestAnthropicResponseUsesNullContentForToolOnlyTurn(t *testing.T) {
 	}
 }
 
-func TestAnthropicFinishReasonMapping(t *testing.T) {
-	cases := map[string]string{
-		"end_turn":                      "stop",
-		"stop_sequence":                 "stop",
-		"max_tokens":                    "length",
-		"model_context_window_exceeded": "length",
-		"tool_use":                      "tool_calls",
-		"refusal":                       "content_filter",
-	}
-	for stopReason, want := range cases {
-		got, err := anthropicFinishReason(stopReason, false)
-		if err != nil {
-			t.Fatalf("%s: %v", stopReason, err)
-		}
-		if got != want {
-			t.Fatalf("%s: expected %q, got %q", stopReason, want, got)
-		}
-	}
-
-	// pause_turn means a server-side tool loop paused and expects the assistant
-	// content to be replayed verbatim. Reporting tool_calls would tell the client
-	// to run a tool that was never requested.
-	if _, err := anthropicFinishReason("pause_turn", false); err == nil {
-		t.Fatalf("pause_turn must not be presented as a client tool call")
-	}
-
-	// An unrecognized value must not be flattened to "stop": that would report a
-	// truncated or refused generation as a normal completion.
-	if _, err := anthropicFinishReason("something_new", false); err == nil {
-		t.Fatalf("unknown stop reasons must surface as an upstream error")
-	}
-}
-
 func TestAnthropicRebuildsSignedThinkingBlockWithEmptyText(t *testing.T) {
 	// Models may return a signed thinking block with no visible text. The block
 	// still has to be replayed verbatim, so the signature alone gates rebuilding.

--- a/backend/internal/server/provider_anthropic_stream.go
+++ b/backend/internal/server/provider_anthropic_stream.go
@@ -284,7 +284,7 @@ func (d *anthropicStreamDecoder) mergeUsage(value any) {
 }
 
 func (d *anthropicStreamDecoder) currentUsage() Usage {
-	return anthropicUsage(map[string]any{"usage": d.usage})
+	return anthropicUsageFromRawMap(d.usage)
 }
 
 func anthropicStreamError(payload map[string]any) error {

--- a/backend/internal/server/provider_anthropic_usage.go
+++ b/backend/internal/server/provider_anthropic_usage.go
@@ -1,0 +1,26 @@
+package server
+
+// anthropicUsageFromRawMap reads one Anthropic usage snapshot. Anthropic reports
+// the three input classes disjointly, so prompt tokens are their sum.
+// Cache-creation tokens are also surfaced on their own field: they bill at a
+// premium over base input, and folding them into the total alone would lose the
+// distinction. A nil snapshot yields a zero usage.
+func anthropicUsageFromRawMap(raw map[string]any) Usage {
+	uncachedInputTokens := int64FromAny(raw["input_tokens"])
+	cacheCreationInputTokens := int64FromAny(raw["cache_creation_input_tokens"])
+	cachedInputTokens := int64FromAny(raw["cache_read_input_tokens"])
+	usage := Usage{
+		PromptTokens:          uncachedInputTokens + cacheCreationInputTokens + cachedInputTokens,
+		CachedInputTokens:     cachedInputTokens,
+		CacheWriteInputTokens: cacheCreationInputTokens,
+		CompletionTokens:      int64FromAny(raw["output_tokens"]),
+	}
+	usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+	return usage
+}
+
+// anthropicUsage reads the snapshot off a complete non-streaming response body.
+func anthropicUsage(body map[string]any) Usage {
+	usageMap, _ := body["usage"].(map[string]any)
+	return anthropicUsageFromRawMap(usageMap)
+}

--- a/backend/internal/server/provider_anthropic_usage_test.go
+++ b/backend/internal/server/provider_anthropic_usage_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAnthropicUsageFromRawMap(t *testing.T) {
+	// Anthropic reports the three input classes disjointly, so prompt tokens are
+	// their sum, and cache-creation tokens keep their own field because they bill
+	// at a premium over base input.
+	usage := anthropicUsageFromRawMap(map[string]any{
+		"input_tokens":                int64(10),
+		"cache_creation_input_tokens": int64(4),
+		"cache_read_input_tokens":     int64(6),
+		"output_tokens":               int64(5),
+	})
+	want := Usage{
+		PromptTokens:          20,
+		CachedInputTokens:     6,
+		CacheWriteInputTokens: 4,
+		CompletionTokens:      5,
+		TotalTokens:           25,
+	}
+	if !reflect.DeepEqual(usage, want) {
+		t.Fatalf("anthropicUsageFromRawMap() = %+v, want %+v", usage, want)
+	}
+
+	if empty := anthropicUsageFromRawMap(nil); !reflect.DeepEqual(empty, Usage{}) {
+		t.Fatalf("anthropicUsageFromRawMap(nil) = %+v, want a zero usage", empty)
+	}
+}
+
+// A stream splits usage across message_start and message_delta. A frame only
+// overwrites what it carries, and the three input classes move as one group: a
+// frame that restates any of them replaces the whole input side.
+func TestMergeAnthropicStreamUsageOnlyPositiveValuesOverwrite(t *testing.T) {
+	start := mergeAnthropicStreamUsage(Usage{}, map[string]any{
+		"input_tokens":            int64(30),
+		"cache_read_input_tokens": int64(10),
+		"output_tokens":           int64(1),
+	})
+	if start.PromptTokens != 40 || start.CachedInputTokens != 10 || start.CompletionTokens != 1 || start.TotalTokens != 41 {
+		t.Fatalf("message_start merge = %+v", start)
+	}
+
+	// message_delta reports only the final output count; the input fields it
+	// omits must not reset the totals the first frame established.
+	final := mergeAnthropicStreamUsage(start, map[string]any{"output_tokens": int64(120)})
+	if final.PromptTokens != 40 || final.CachedInputTokens != 10 || final.CompletionTokens != 120 || final.TotalTokens != 160 {
+		t.Fatalf("message_delta merge = %+v", final)
+	}
+
+	// An explicit zero is treated the same as an omission.
+	zeroed := mergeAnthropicStreamUsage(final, map[string]any{
+		"input_tokens":            int64(0),
+		"cache_read_input_tokens": int64(0),
+		"output_tokens":           int64(0),
+	})
+	if !reflect.DeepEqual(zeroed, final) {
+		t.Fatalf("zero-valued merge = %+v, want %+v", zeroed, final)
+	}
+
+	// Cache-creation tokens alone still count as an input update, and replacing
+	// the input side clears the sibling classes the frame left out. That clobbers
+	// the running totals; this pins inherited behavior, not a target semantic.
+	created := mergeAnthropicStreamUsage(final, map[string]any{"cache_creation_input_tokens": int64(7)})
+	if created.PromptTokens != 7 || created.CachedInputTokens != 0 || created.CompletionTokens != 120 {
+		t.Fatalf("cache-creation merge = %+v", created)
+	}
+	// This path has never billed cache-creation tokens on their own field.
+	// Changing that is a behavior change, so it must not happen by accident.
+	if created.CacheWriteInputTokens != 0 {
+		t.Fatalf("stream merge started reporting cache-write tokens: %+v", created)
+	}
+}

--- a/backend/internal/server/provider_finish_reason.go
+++ b/backend/internal/server/provider_finish_reason.go
@@ -1,0 +1,82 @@
+package server
+
+import "fmt"
+
+// Canonical finish/stop reason strings for the two protocols this package
+// translates between. The mapping is lossy in both directions, so the two
+// functions below stay explicit rather than being derived from one table:
+// end_turn and stop_sequence both become "stop", and max_tokens and
+// model_context_window_exceeded both become "length".
+const (
+	openAIFinishReasonStop          = "stop"
+	openAIFinishReasonLength        = "length"
+	openAIFinishReasonToolCalls     = "tool_calls"
+	openAIFinishReasonContentFilter = "content_filter"
+	// openAIFinishReasonFunctionCall is the pre-tool_calls spelling. It still
+	// arrives from older upstreams and means the same thing.
+	openAIFinishReasonFunctionCall = "function_call"
+
+	anthropicStopReasonEndTurn         = "end_turn"
+	anthropicStopReasonStopSequence    = "stop_sequence"
+	anthropicStopReasonMaxTokens       = "max_tokens"
+	anthropicStopReasonContextExceeded = "model_context_window_exceeded"
+	anthropicStopReasonToolUse         = "tool_use"
+	anthropicStopReasonRefusal         = "refusal"
+	anthropicStopReasonPauseTurn       = "pause_turn"
+)
+
+// anthropicFinishReason maps a stop reason. Unknown values are surfaced as an
+// upstream error rather than being flattened to "stop", which would report a
+// truncated or refused generation as a normal completion.
+func anthropicFinishReason(stopReason string, hasToolCalls bool) (string, error) {
+	switch stopReason {
+	case anthropicStopReasonToolUse:
+		return openAIFinishReasonToolCalls, nil
+	case anthropicStopReasonPauseTurn:
+		// A paused server-tool loop expects the assistant content to be replayed
+		// verbatim so the provider can resume it. That is not something an
+		// OpenAI-shaped client can do, and reporting tool_calls would tell the
+		// client to run a tool that was never requested.
+		return "", unsupportedCapabilityError("provider paused a server-side tool loop, which this route cannot resume")
+	case anthropicStopReasonEndTurn, anthropicStopReasonStopSequence:
+		if hasToolCalls {
+			return openAIFinishReasonToolCalls, nil
+		}
+		return openAIFinishReasonStop, nil
+	case anthropicStopReasonMaxTokens, anthropicStopReasonContextExceeded:
+		return openAIFinishReasonLength, nil
+	case anthropicStopReasonRefusal:
+		return openAIFinishReasonContentFilter, nil
+	case "":
+		// Streaming responses report the stop reason in message_delta; a
+		// non-streaming body without one is still in flight or malformed.
+		if hasToolCalls {
+			return openAIFinishReasonToolCalls, nil
+		}
+		return openAIFinishReasonStop, nil
+	default:
+		return "", invalidProviderResponseError(fmt.Sprintf("provider returned an unrecognized stop_reason %q", stopReason))
+	}
+}
+
+// openAIFinishReasonToAnthropic is deliberately lenient where
+// anthropicFinishReason is strict. It serves a downstream Anthropic client that
+// has already been handed content, so there is no point failing the response
+// over a reason string: an unknown value degrades to end_turn. Tool calls
+// present in the response outrank every reason, because the client still has to
+// be told to run them.
+func openAIFinishReasonToAnthropic(reason string, hasTools bool) string {
+	if hasTools || reason == openAIFinishReasonToolCalls || reason == openAIFinishReasonFunctionCall {
+		return anthropicStopReasonToolUse
+	}
+	switch reason {
+	case openAIFinishReasonLength:
+		return anthropicStopReasonMaxTokens
+	case openAIFinishReasonStop, "":
+		return anthropicStopReasonEndTurn
+	case openAIFinishReasonContentFilter:
+		return anthropicStopReasonRefusal
+	default:
+		return anthropicStopReasonEndTurn
+	}
+}

--- a/backend/internal/server/provider_finish_reason_test.go
+++ b/backend/internal/server/provider_finish_reason_test.go
@@ -1,0 +1,128 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// The two finish-reason directions are golden-locked rather than round-tripped:
+// the mapping is lossy on purpose. end_turn and stop_sequence both collapse to
+// "stop", and max_tokens and model_context_window_exceeded both collapse to
+// "length", so feeding an output back through the other direction does not
+// return the original value. Each direction is pinned to its own table instead.
+
+func TestAnthropicFinishReasonGolden(t *testing.T) {
+	cases := []struct {
+		stopReason   string
+		hasToolCalls bool
+		want         string
+	}{
+		{stopReason: "", hasToolCalls: false, want: "stop"},
+		{stopReason: "", hasToolCalls: true, want: "tool_calls"},
+		{stopReason: "end_turn", hasToolCalls: false, want: "stop"},
+		{stopReason: "end_turn", hasToolCalls: true, want: "tool_calls"},
+		{stopReason: "stop_sequence", hasToolCalls: false, want: "stop"},
+		{stopReason: "stop_sequence", hasToolCalls: true, want: "tool_calls"},
+		{stopReason: "max_tokens", hasToolCalls: false, want: "length"},
+		{stopReason: "max_tokens", hasToolCalls: true, want: "length"},
+		{stopReason: "model_context_window_exceeded", hasToolCalls: false, want: "length"},
+		{stopReason: "model_context_window_exceeded", hasToolCalls: true, want: "length"},
+		{stopReason: "tool_use", hasToolCalls: false, want: "tool_calls"},
+		{stopReason: "tool_use", hasToolCalls: true, want: "tool_calls"},
+		{stopReason: "refusal", hasToolCalls: false, want: "content_filter"},
+		{stopReason: "refusal", hasToolCalls: true, want: "content_filter"},
+	}
+	for _, tc := range cases {
+		got, err := anthropicFinishReason(tc.stopReason, tc.hasToolCalls)
+		if err != nil {
+			t.Fatalf("anthropicFinishReason(%q, %v) failed: %v", tc.stopReason, tc.hasToolCalls, err)
+		}
+		if got != tc.want {
+			t.Fatalf("anthropicFinishReason(%q, %v) = %q, want %q", tc.stopReason, tc.hasToolCalls, got, tc.want)
+		}
+	}
+}
+
+// A paused server-side tool loop and an unrecognized stop reason are the two
+// values this direction refuses to map. Both keep their own classification: the
+// pause is a capability gap another candidate may cover, the unknown value is a
+// malformed upstream response.
+func TestAnthropicFinishReasonGoldenErrors(t *testing.T) {
+	cases := []struct {
+		stopReason      string
+		wantStatus      int
+		wantCode        string
+		wantDisposition ProviderErrorDisposition
+	}{
+		{
+			stopReason:      "pause_turn",
+			wantStatus:      http.StatusNotImplemented,
+			wantCode:        "provider_capability_not_supported",
+			wantDisposition: ProviderErrorModelUnsupported,
+		},
+		{
+			stopReason: "something_new",
+			wantStatus: http.StatusBadGateway,
+			wantCode:   "provider_invalid_response",
+		},
+	}
+	for _, tc := range cases {
+		for _, hasToolCalls := range []bool{false, true} {
+			got, err := anthropicFinishReason(tc.stopReason, hasToolCalls)
+			if err == nil {
+				t.Fatalf("anthropicFinishReason(%q, %v) = %q, want an error", tc.stopReason, hasToolCalls, got)
+			}
+			if got != "" {
+				t.Fatalf("anthropicFinishReason(%q, %v) returned %q alongside an error", tc.stopReason, hasToolCalls, got)
+			}
+			httpErr := AsHTTPError(err)
+			if httpErr == nil || httpErr.Status != tc.wantStatus || httpErr.Code != tc.wantCode {
+				t.Fatalf("anthropicFinishReason(%q, %v) error = %+v, want %d/%s",
+					tc.stopReason, hasToolCalls, httpErr, tc.wantStatus, tc.wantCode)
+			}
+			var invocation *ProviderInvocationError
+			if errors.As(err, &invocation) {
+				if invocation.Disposition != tc.wantDisposition {
+					t.Fatalf("anthropicFinishReason(%q, %v) disposition = %q, want %q",
+						tc.stopReason, hasToolCalls, invocation.Disposition, tc.wantDisposition)
+				}
+			} else if tc.wantDisposition != "" {
+				t.Fatalf("anthropicFinishReason(%q, %v) lost disposition %q", tc.stopReason, hasToolCalls, tc.wantDisposition)
+			}
+		}
+	}
+}
+
+// The reverse direction is deliberately lenient where the forward one is strict:
+// it never fails. An unknown reason degrades to end_turn, and observed tool calls
+// outrank every reason including content_filter, because the Anthropic client has
+// to be told to run the tools the response already carries.
+func TestOpenAIFinishReasonToAnthropicGolden(t *testing.T) {
+	cases := []struct {
+		reason   string
+		hasTools bool
+		want     string
+	}{
+		{reason: "", hasTools: false, want: "end_turn"},
+		{reason: "", hasTools: true, want: "tool_use"},
+		{reason: "stop", hasTools: false, want: "end_turn"},
+		{reason: "stop", hasTools: true, want: "tool_use"},
+		{reason: "length", hasTools: false, want: "max_tokens"},
+		{reason: "length", hasTools: true, want: "tool_use"},
+		{reason: "tool_calls", hasTools: false, want: "tool_use"},
+		{reason: "tool_calls", hasTools: true, want: "tool_use"},
+		// The legacy function_call reason is mapped like tool_calls.
+		{reason: "function_call", hasTools: false, want: "tool_use"},
+		{reason: "function_call", hasTools: true, want: "tool_use"},
+		{reason: "content_filter", hasTools: false, want: "refusal"},
+		{reason: "content_filter", hasTools: true, want: "tool_use"},
+		{reason: "something_new", hasTools: false, want: "end_turn"},
+		{reason: "something_new", hasTools: true, want: "tool_use"},
+	}
+	for _, tc := range cases {
+		if got := openAIFinishReasonToAnthropic(tc.reason, tc.hasTools); got != tc.want {
+			t.Fatalf("openAIFinishReasonToAnthropic(%q, %v) = %q, want %q", tc.reason, tc.hasTools, got, tc.want)
+		}
+	}
+}

--- a/backend/internal/server/provider_gemini_convert.go
+++ b/backend/internal/server/provider_gemini_convert.go
@@ -453,13 +453,13 @@ func geminiFinishReason(reason string, hasToolCalls bool) (string, error) {
 	switch reason {
 	case "STOP", "":
 		if hasToolCalls {
-			return "tool_calls", nil
+			return openAIFinishReasonToolCalls, nil
 		}
-		return "stop", nil
+		return openAIFinishReasonStop, nil
 	case "MAX_TOKENS":
-		return "length", nil
+		return openAIFinishReasonLength, nil
 	case "SAFETY", "RECITATION", "BLOCKLIST", "PROHIBITED_CONTENT", "SPII", "IMAGE_SAFETY":
-		return "content_filter", nil
+		return openAIFinishReasonContentFilter, nil
 	case "MALFORMED_FUNCTION_CALL", "UNEXPECTED_TOOL_CALL", "MISSING_THOUGHT_SIGNATURE", "MALFORMED_RESPONSE":
 		return "", invalidProviderResponseError(fmt.Sprintf("Gemini reported a protocol failure: %s", reason))
 	default:

--- a/backend/internal/server/providers.go
+++ b/backend/internal/server/providers.go
@@ -872,25 +872,6 @@ func geminiVariantIs(variant string, family string) bool {
 	return variant == family || strings.HasPrefix(variant, family+"-")
 }
 
-func anthropicUsage(body map[string]any) Usage {
-	usageMap, _ := body["usage"].(map[string]any)
-	uncachedInputTokens := int64FromAny(usageMap["input_tokens"])
-	cacheCreationInputTokens := int64FromAny(usageMap["cache_creation_input_tokens"])
-	cachedInputTokens := int64FromAny(usageMap["cache_read_input_tokens"])
-	usage := Usage{
-		// Anthropic reports the three input classes disjointly, so prompt tokens are
-		// their sum. Cache-creation tokens are also surfaced on their own field: they
-		// bill at a premium over base input, and without this they were folded into
-		// the total and lost, leaving CacheWriteInputTokens dead on this path.
-		PromptTokens:          uncachedInputTokens + cacheCreationInputTokens + cachedInputTokens,
-		CachedInputTokens:     cachedInputTokens,
-		CacheWriteInputTokens: cacheCreationInputTokens,
-		CompletionTokens:      int64FromAny(usageMap["output_tokens"]),
-	}
-	usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
-	return usage
-}
-
 func geminiUsage(body map[string]any) Usage {
 	usageMap, _ := body["usageMetadata"].(map[string]any)
 	reasoningTokens := int64FromAny(usageMap["thoughtsTokenCount"])


### PR DESCRIPTION
## Summary

Third of three stacked provider-layer PRs. The two directions of Anthropic finish-reason mapping lived in separate files sharing vocabulary as scattered literals, and Anthropic usage-snapshot parsing was spelled out in three places. This PR gives each one home with zero semantic change, locked by golden tests written against the old implementations before the refactor.

**Stacked on #117** — merge order: #115 → #116 → #117 → this.

## Related Issue

N/A

## Changes

- `provider_finish_reason.go` holds both explicit direction functions — strict anthropic→openai (unknown reasons 502, `pause_turn` 501) and deliberately lenient openai→anthropic (unknown degrades to `end_turn`, tools trump everything) — plus shared canonical constants. **No derived reverse table**: the mapping is lossy both ways (`end_turn`/`stop_sequence` → `stop`; `max_tokens`/`model_context_window_exceeded` → `length`). Gemini's mapper keeps its own domain and file but now spells the shared OpenAI vocabulary with the constants.
- 32 golden assertions pin every (reason, tools) combination in both directions, including error status/code/disposition; they were run green against the unmodified old code first. The superseded `TestAnthropicFinishReasonMapping` is removed (strict subset of the new tables).
- `anthropicUsageFromRawMap` becomes the only parser of Anthropic usage snapshots, used by the non-streaming path, the stream decoder, and the native stream merge. The merge keeps its incremental semantics (input classes replace as a group, output merges independently), now documented and test-pinned.
- Known inconsistency surfaced, deliberately not fixed here: the native `/v1/messages` streaming merge leaves `CacheWriteInputTokens` at zero while the other two paths fill it. This affects **usage reporting** (records, metrics, traces) but not cost math — `providerCostUSD` has no cache-write price term. A test pins the current behavior so back-filling it must be a deliberate change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...` pass; `go vet` clean; `golangci-lint` 0 issues; `gofmt` clean; `node tools/check-source-lines.mjs` pass; `git diff --check` clean.
- Review: Codex design review (whose corrections shaped this scope — the three finish-reason functions are not duplicates, and only the Anthropic snapshot parsing is truly shareable), Codex pre-commit review (2 low findings, both applied), and an independent read-only review agent that replayed all 32 golden assertions against the old implementations transcribed from the diff — 0 mismatches; verdict submittable. Its two cosmetic suggestions (gemini constants, test-comment wording) are applied; its note that the merge guard now behaves more safely on impossible negative-token inputs is accepted as the only theoretical behavior difference.

## Compatibility, Security, and Operations

None. Internal-only; all mapping outputs and usage numbers are unchanged on every reachable input.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable. (None changed.)
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable. (No user-facing docs affected.)
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable. (Untouched.)
- [x] `git diff --check` passes.