### PR TITLE
feat(observability): attribute failover attempts and upstream latency

### DIFF
--- a/backend/internal/server/gateway_completion.go
+++ b/backend/internal/server/gateway_completion.go
@@ -95,6 +95,11 @@ func (s *Server) finishCall(completion GatewayCallCompletion) {
 	// the caller's Usage afterwards would report a zero cost. priceUsage is pure and
 	// idempotent, which makes the store's own call a no-op rather than a conflict.
 	completion.Usage = priceUsage(completion.Call.Model, completion.Usage)
+	// Thread the attempt outcomes into the call context so the single metrics
+	// observation point can report per-candidate counts and upstream latency.
+	// Only the bounded outcome fields are consumed there, so the upstream error
+	// text stays out of this path the same way it stays out of traces.
+	completion.Call.RouteAttempts = attemptsWithoutErrorText(completion.Attempts)
 	s.store.RecordRouteAttempts(completion.Call.RequestID, completion.Attempts)
 	switch completion.Kind {
 	case CompletionKindPlayground:

--- a/backend/internal/server/gateway_http.go
+++ b/backend/internal/server/gateway_http.go
@@ -664,6 +664,10 @@ func executeRoutedWithStore[T any](
 		}
 		omitReasoningEffort := false
 		for {
+			// The attempt window covers the whole routed callback, including stream
+			// translation and writing to the client: a slow reader blocks the
+			// gateway here, and that backpressure is part of the attempt duration,
+			// not of the gateway overhead reported in overhead_seconds.
 			attemptStartedAt := time.Now()
 			resp, usage, err := call(leaseCtx, route, omitReasoningEffort, len(attempts)+1)
 			cumulativeTokens = saturatingAddNonNegative(cumulativeTokens, meteredTokens(usage))

--- a/backend/internal/server/image_generation.go
+++ b/backend/internal/server/image_generation.go
@@ -577,6 +577,11 @@ func (s *Server) processImageJob(work imageJobWork) {
 		return imageRunResult{data: imageBytes, revisedPrompt: revisedPrompt}, responseUsage, nil
 	})
 	s.store.RecordRouteAttempts(work.call.RequestID, attempts)
+	// Thread the attempt outcomes into the call context so the shared observation
+	// point reports per-candidate counts and upstream latency for image jobs the
+	// same way it does for chat and embedding calls. Both completion paths below
+	// reach observeGatewayCall through call, which carries these attempts.
+	work.call.RouteAttempts = attempts
 	if invokeErr != nil {
 		if errors.Is(invokeErr, context.DeadlineExceeded) {
 			message := fmt.Sprintf("Image generation exceeded the configured %d second timeout", s.config.ImageJobTimeoutSeconds)

--- a/backend/internal/server/metrics.go
+++ b/backend/internal/server/metrics.go
@@ -28,6 +28,11 @@ const (
 // 10s and would put almost every LLM request in +Inf.
 var gatewayDurationBuckets = []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20, 30, 60, 120, 300}
 
+// gatewayOverheadBuckets is sized for gateway-only work: auth, routing, DB and
+// serialization. Values below a millisecond are rounded away by the attempt
+// latency clamp, and multi-second overhead is already a clear outlier.
+var gatewayOverheadBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
 // GatewayMetrics holds the Prometheus collectors for the model API.
 //
 // It owns its registry rather than using the default one, so tests get an isolated
@@ -52,6 +57,25 @@ type GatewayMetrics struct {
 	// like a gateway that received no traffic.
 	traceCompletions *prometheus.CounterVec
 	traceSpans       *prometheus.CounterVec
+
+	// routeAttempts counts every candidate the router considered, including
+	// capacity-skipped attempts. It is the physical attempt count behind the
+	// logical request count in routed_requests_total.
+	routeAttempts *prometheus.CounterVec
+	// attemptDuration records only invoked attempts, split by outcome. It measures
+	// the whole routed attempt — upstream transport, stream translation and
+	// writing to the client — so streaming calls include slow-client backpressure;
+	// the upstream boundary itself is not separately timed here.
+	attemptDuration *prometheus.HistogramVec
+	// routedRequests counts logical requests that made at least one candidate
+	// attempt. It is the denominator for the failover-depth ratio: requests_total
+	// also counts refusals that never reached a provider.
+	routedRequests *prometheus.CounterVec
+	// overhead is the gateway's own cost: max(0, elapsed - sum(invoked attempt
+	// duration)). A request admitted for routing that fails before any attempt
+	// contributes its full elapsed time. It is an approximation because attempt
+	// durations are rounded to whole milliseconds and clamped to a positive floor.
+	overhead *prometheus.HistogramVec
 }
 
 const (
@@ -61,6 +85,19 @@ const (
 	traceSpanOutcomeExported = "exported"
 	traceSpanOutcomeFailed   = "failed"
 )
+
+// GatewayAttemptSample is one candidate attempt, reduced to the fields the
+// metrics layer needs. Keeping it separate from RouteAttempt avoids pulling the
+// full routing structure into the metrics package.
+type GatewayAttemptSample struct {
+	ProviderType string
+	ProviderID   string
+	ResourceID   string
+	StatusCode   int
+	ErrorCode    string
+	Invoked      bool
+	Duration     time.Duration
+}
 
 // GatewayCallSample is one finished gateway request, successful or not.
 type GatewayCallSample struct {
@@ -74,6 +111,10 @@ type GatewayCallSample struct {
 	Stream       bool
 	Duration     time.Duration
 	Usage        Usage
+	// Attempts is the per-candidate outcome slice. Empty means no candidate was
+	// tried — the request was refused before routing or failed during route
+	// selection — and both still count in requests_total.
+	Attempts []GatewayAttemptSample
 }
 
 // NewGatewayMetrics builds the collectors. When projectLabel is true every metric
@@ -141,7 +182,34 @@ func NewGatewayMetrics(projectLabel bool) *GatewayMetrics {
 		Help:      "Spans by what the OTLP exporter did with them. \"failed\" means the trace backend rejected them or could not be reached.",
 	}, []string{"outcome"})
 
-	m.registry.MustRegister(m.requests, m.duration, m.inFlight, m.tokens, m.cost, m.rateLimitHits, m.traceCompletions, m.traceSpans)
+	m.routeAttempts = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "route_attempts_total",
+		Help:      "Candidate attempts by outcome. Counts physical attempts, so a request that failed over across several candidates counts each candidate. The ratio rate(route_attempts_total) / rate(routed_requests_total) is the average failover depth; routed_requests_total counts only requests that made an attempt, so refusals that never reached a provider cannot dilute it. status_code is the gateway-mapped status (an upstream 401 is reported as 502); the raw upstream status is in the RouteAttemptLog.",
+	}, withProject("model", "provider_type", "provider_id", "resource_id", "status_code", "error_code", "invoked"))
+	m.attemptDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "attempt_duration_seconds",
+		Help:      "Duration of one invoked routed attempt, measured around the whole attempt: upstream transport, stream translation, and writing to the client. Streaming calls therefore include slow-client backpressure; gateway overhead is reported separately in overhead_seconds. Excludes candidates skipped for capacity.",
+		Buckets:   gatewayDurationBuckets,
+	}, withProject("model", "provider_type", "outcome"))
+	m.routedRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "routed_requests_total",
+		Help:      "Logical model API requests that made at least one candidate attempt. It is the attempt-bearing denominator for the failover-depth ratio; requests_total also counts refusals that never reached a provider. Its provider_type label is the last candidate attempted, so aggregate the depth ratio by model rather than by provider_type when requests fail over across providers.",
+	}, withProject("model", "provider_type", "stream"))
+	m.overhead = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsSubsystem,
+		Name:      "overhead_seconds",
+		Help:      "Approximate gateway overhead per request: elapsed end-to-end time minus the sum of invoked attempt durations. Clamped at zero. A request admitted for routing that fails before any attempt contributes its full elapsed time. For image jobs the elapsed time includes queue wait, so overhead there is an upper bound.",
+		Buckets:   gatewayOverheadBuckets,
+	}, withProject("stream"))
+
+	m.registry.MustRegister(m.requests, m.duration, m.inFlight, m.tokens, m.cost, m.rateLimitHits, m.traceCompletions, m.traceSpans, m.routeAttempts, m.attemptDuration, m.routedRequests, m.overhead)
 	// Process and Go runtime metrics are what an operator reaches for first when the
 	// gateway itself is the suspect, and they cost nothing to collect.
 	m.registry.MustRegister(collectors.NewGoCollector(), collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
@@ -274,6 +342,56 @@ func (m *GatewayMetrics) ObserveGatewayCall(sample GatewayCallSample) {
 
 	if sample.Usage.CostUSD > 0 {
 		m.cost.WithLabelValues(m.labels(sample.ProjectID, model, providerType, providerID)...).Add(sample.Usage.CostUSD)
+	}
+
+	// Per-candidate attempt counts and attempt duration. A rejected request has no
+	// attempts, so this block naturally does nothing for that path.
+	var attemptSum time.Duration
+	for _, attempt := range sample.Attempts {
+		attemptProviderType := metricsLabel(attempt.ProviderType)
+		attemptProviderID := metricsLabel(attempt.ProviderID)
+		attemptResourceID := metricsLabel(attempt.ResourceID)
+		attemptStatusCode := strconv.Itoa(attempt.StatusCode)
+		attemptErrorCode := metricsLabel(attempt.ErrorCode)
+		invoked := strconv.FormatBool(attempt.Invoked)
+		m.routeAttempts.WithLabelValues(m.labels(
+			sample.ProjectID,
+			model,
+			attemptProviderType,
+			attemptProviderID,
+			attemptResourceID,
+			attemptStatusCode,
+			attemptErrorCode,
+			invoked,
+		)...).Inc()
+
+		if attempt.Invoked && attempt.Duration > 0 {
+			attemptSum += attempt.Duration
+			m.attemptDuration.WithLabelValues(m.labels(
+				sample.ProjectID,
+				model,
+				attemptProviderType,
+				metricsOutcome(attempt.StatusCode),
+			)...).Observe(attempt.Duration.Seconds())
+		}
+	}
+
+	// routed_requests_total is the attempt-bearing denominator for the
+	// failover-depth ratio: only requests that actually tried a candidate count.
+	if len(sample.Attempts) > 0 {
+		m.routedRequests.WithLabelValues(m.labels(sample.ProjectID, model, providerType, stream)...).Inc()
+	}
+
+	// Overhead is reported for every admitted request: with no attempts the sum is
+	// zero, so a request that failed during route selection contributes its full
+	// elapsed time. Rejected requests never reach this gate — their duration is
+	// zero by convention (see RecordRejectedRequest), and zeroes create no series.
+	if sample.Duration > 0 {
+		overhead := sample.Duration - attemptSum
+		if overhead < 0 {
+			overhead = 0
+		}
+		m.overhead.WithLabelValues(m.labels(sample.ProjectID, stream)...).Observe(overhead.Seconds())
 	}
 }
 

--- a/backend/internal/server/metrics_test.go
+++ b/backend/internal/server/metrics_test.go
@@ -1,13 +1,20 @@
 package server
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
@@ -321,7 +328,11 @@ func TestMetricsTokenMatching(t *testing.T) {
 
 func TestGatewayMetricsNilIsSafe(t *testing.T) {
 	var m *GatewayMetrics
-	m.ObserveGatewayCall(GatewayCallSample{Model: "x", Duration: time.Second})
+	m.ObserveGatewayCall(GatewayCallSample{
+		Model:    "x",
+		Duration: time.Second,
+		Attempts: []GatewayAttemptSample{{ProviderType: "t", Invoked: true, Duration: time.Second}},
+	})
 	m.incInFlight()
 	m.decInFlight()
 	if m.Handler() == nil {
@@ -414,5 +425,486 @@ func TestMetricsRejectedStreamingCallKeepsStreamLabel(t *testing.T) {
 	))
 	if sameButNotStreaming != 0 {
 		t.Fatalf("it must not also appear as stream=false, got %v", sameButNotStreaming)
+	}
+}
+
+// newMetricsFailoverGateway wires one model to two openai_compatible upstreams in
+// priority order and enables metrics. It mirrors newStreamFailoverGateway but uses
+// NewWithConfig so the /metrics endpoint is available.
+func newMetricsFailoverGateway(t *testing.T, primaryURL string, secondaryURL string) (*Server, string) {
+	t.Helper()
+	store := NewMemoryStore()
+	project := store.CreateProject(Project{Name: "metrics-failover", Status: StatusActive})
+	const model = "metrics-failover-model"
+	_, secret, err := store.CreateAPIKey(project.ID, APIKey{
+		Name:    "metrics-failover-key",
+		Allowed: []string{model},
+		Status:  StatusActive,
+	}, "thk_metrics_failover")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.AddModel(Model{Name: model, Modality: "chat", Status: StatusActive})
+	for index, upstreamURL := range []string{primaryURL, secondaryURL} {
+		provider := store.AddProvider(Provider{
+			ID:      fmt.Sprintf("prv_metrics_%d", index),
+			Name:    fmt.Sprintf("metrics-%d", index),
+			Type:    ProviderOpenAICompatible,
+			BaseURL: upstreamURL,
+			Status:  StatusActive,
+			Healthy: true,
+		})
+		resource, err := store.AddProviderResource(ProviderResource{
+			ID:             fmt.Sprintf("rsrc_metrics_%d", index),
+			ProviderID:     provider.ID,
+			Name:           fmt.Sprintf("metrics-resource-%d", index),
+			ResourceType:   "openai",
+			Status:         StatusActive,
+			Healthy:        true,
+			Priority:       1,
+			Weight:         100,
+			MaxConcurrency: 10,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		store.AddRoute(ModelRoute{
+			ID:                 fmt.Sprintf("route_metrics_%d", index),
+			ModelName:          model,
+			ProviderID:         provider.ID,
+			ProviderResourceID: resource.ID,
+			ProviderModel:      fmt.Sprintf("upstream-model-%d", index),
+			Priority:           index + 1,
+			Weight:             100,
+			Status:             StatusActive,
+			Strategy:           RouteStrategyPriorityOnly,
+		})
+	}
+	server := NewWithConfig(store, Config{
+		AdminToken:     "dev_admin_token",
+		MetricsEnabled: true,
+	})
+	if server.metrics == nil {
+		t.Fatal("expected metrics to be enabled")
+	}
+	return server, secret
+}
+
+// findMetricLine returns the first /metrics exposition line containing every fragment.
+// It avoids importing the prometheus client_model package (indirect dependency) and is
+// resilient to label ordering.
+func findMetricLine(body string, fragments ...string) string {
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		ok := true
+		for _, f := range fragments {
+			if !strings.Contains(line, f) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return line
+		}
+	}
+	return ""
+}
+
+// metricLineValue parses the trailing float from an exposition line.
+func metricLineValue(t *testing.T, line string) float64 {
+	t.Helper()
+	line = strings.TrimSpace(line)
+	idx := strings.LastIndexByte(line, ' ')
+	if idx < 0 {
+		t.Fatalf("no value in metric line: %q", line)
+	}
+	v, err := strconv.ParseFloat(line[idx+1:], 64)
+	if err != nil {
+		t.Fatalf("parse metric value %q: %v", line[idx+1:], err)
+	}
+	return v
+}
+
+func scrapeMetrics(t *testing.T, handler http.Handler) string {
+	t.Helper()
+	resp := doRawRequest(t, handler, http.MethodGet, "/metrics", map[string]string{"Authorization": "Bearer dev_admin_token"})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("metrics scrape failed: %d %s", resp.Code, resp.Body)
+	}
+	return resp.Body
+}
+
+// A failover produces two route_attempts_total series but only one requests_total.
+func TestMetricsFailoverAttributesEveryAttempt(t *testing.T) {
+	var secondaryHits int32
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"message":"rate limited"}}`)
+	}))
+	defer primary.Close()
+	secondary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&secondaryHits, 1)
+		writeChatStreamChunk(w, "recovered")
+	}))
+	defer secondary.Close()
+
+	server, secret := newMetricsFailoverGateway(t, primary.URL, secondary.URL)
+	resp := postStream(t, server.Handler(), "/v1/chat/completions", map[string]any{
+		"model":    "metrics-failover-model",
+		"messages": []map[string]any{{"role": "user", "content": "hi"}},
+		"stream":   true,
+	}, secret)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected fallback to succeed, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	body := scrapeMetrics(t, server.Handler())
+
+	primaryAttempt := findMetricLine(body, "tokenhub_gateway_route_attempts_total", `provider_id="prv_metrics_0"`, `invoked="true"`, `status_code="429"`)
+	if primaryAttempt == "" {
+		t.Fatalf("missing primary attempt series in metrics:\n%s", body)
+	}
+	if metricLineValue(t, primaryAttempt) != 1 {
+		t.Fatalf("expected exactly one primary attempt")
+	}
+	secondaryAttempt := findMetricLine(body, "tokenhub_gateway_route_attempts_total", `provider_id="prv_metrics_1"`, `invoked="true"`, `status_code="200"`)
+	if secondaryAttempt == "" {
+		t.Fatalf("missing secondary attempt series in metrics:\n%s", body)
+	}
+
+	if got := testutil.ToFloat64(server.metrics.requests.WithLabelValues(
+		"metrics-failover-model", ProviderOpenAICompatible, "prv_metrics_1", "rsrc_metrics_1", "200", metricsLabelUnset, "true",
+	)); got != 1 {
+		t.Fatalf("expected one logical request, got %v", got)
+	}
+
+	upstreamPrimary := findMetricLine(body, "tokenhub_gateway_attempt_duration_seconds", `provider_type="openai_compatible"`)
+	if upstreamPrimary == "" {
+		t.Fatalf("missing attempt duration series in metrics:\n%s", body)
+	}
+
+	overhead := findMetricLine(body, "tokenhub_gateway_overhead_seconds_bucket")
+	if overhead == "" {
+		t.Fatalf("missing overhead series in metrics:\n%s", body)
+	}
+}
+
+// A single successful request records exactly one invoked attempt.
+func TestMetricsDirectSuccessRecordsSingleAttempt(t *testing.T) {
+	_, server, secret := newMetricsTestServer(t, false)
+	app := server.Handler()
+	if code := chatOnce(t, app, secret, false); code != http.StatusOK {
+		t.Fatalf("chat failed: %d", code)
+	}
+
+	body := scrapeMetrics(t, app)
+	attempt := findMetricLine(body, "tokenhub_gateway_route_attempts_total", `provider_id="prv_`+ProviderMock+`"`, `invoked="true"`, `status_code="200"`)
+	if attempt == "" {
+		t.Fatalf("missing direct attempt series in metrics:\n%s", body)
+	}
+	if metricLineValue(t, attempt) != 1 {
+		t.Fatalf("expected exactly one direct attempt")
+	}
+}
+
+// A capacity-skipped attempt contributes to route_attempts_total with invoked="false"
+// but does not create an attempt_duration_seconds series.
+func TestMetricsNonInvokedAttemptSkipsAttemptDuration(t *testing.T) {
+	m := NewGatewayMetrics(false)
+	m.ObserveGatewayCall(GatewayCallSample{
+		Model:        "m",
+		ProviderType: "t",
+		ProviderID:   "p",
+		ResourceID:   "r",
+		StatusCode:   200,
+		Duration:     time.Second,
+		Attempts: []GatewayAttemptSample{
+			{ProviderType: "t", ProviderID: "p1", ResourceID: "r1", StatusCode: 429, ErrorCode: "capacity_exceeded", Invoked: false},
+			{ProviderType: "t", ProviderID: "p2", ResourceID: "r2", StatusCode: 200, Invoked: true, Duration: 500 * time.Millisecond},
+		},
+	})
+
+	if got := testutil.ToFloat64(m.routeAttempts.WithLabelValues("m", "t", "p1", "r1", "429", "capacity_exceeded", "false")); got != 1 {
+		t.Fatalf("expected non-invoked attempt counter to be 1, got %v", got)
+	}
+	if got := testutil.ToFloat64(m.routeAttempts.WithLabelValues("m", "t", "p2", "r2", "200", metricsLabelUnset, "true")); got != 1 {
+		t.Fatalf("expected invoked attempt counter to be 1, got %v", got)
+	}
+	if got := testutil.CollectAndCount(m.attemptDuration); got != 1 {
+		t.Fatalf("expected one attempt_duration series (only invoked), got %d", got)
+	}
+}
+
+// Overhead is clamped at zero when the sum of attempt latencies exceeds elapsed time.
+func TestMetricsOverheadClampsAtZero(t *testing.T) {
+	m := NewGatewayMetrics(false)
+	m.ObserveGatewayCall(GatewayCallSample{
+		Model:      "m",
+		StatusCode: 200,
+		Duration:   time.Second,
+		Attempts: []GatewayAttemptSample{
+			{StatusCode: 200, Invoked: true, Duration: 1500 * time.Millisecond},
+		},
+	})
+
+	handler := promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("scrape failed: %d", rec.Code)
+	}
+	sumLine := findMetricLine(rec.Body.String(), "tokenhub_gateway_overhead_seconds_sum")
+	if sumLine == "" {
+		t.Fatal("missing overhead sum")
+	}
+	if got := metricLineValue(t, sumLine); got != 0 {
+		t.Fatalf("overhead must be clamped at 0, got %v", got)
+	}
+}
+
+// A rejected request never reached a provider, so it must not create attempt series.
+func TestMetricsRejectedRequestAddsNoAttemptSeries(t *testing.T) {
+	_, server, _ := newMetricsTestServer(t, false)
+	app := server.Handler()
+
+	doJSON(t, app, http.MethodPost, "/v1/chat/completions", map[string]any{
+		"model":    "gpt-4.1-mini",
+		"messages": []map[string]any{{"role": "user", "content": "hi"}},
+	}, "thk_not_a_real_key")
+
+	body := scrapeMetrics(t, app)
+	if strings.Contains(body, "tokenhub_gateway_route_attempts_total{") {
+		t.Fatalf("rejected request must not produce route_attempts_total series:\n%s", body)
+	}
+	if strings.Contains(body, "tokenhub_gateway_attempt_duration_seconds{") {
+		t.Fatalf("rejected request must not produce attempt_duration_seconds series:\n%s", body)
+	}
+	if strings.Contains(body, "tokenhub_gateway_overhead_seconds{") {
+		t.Fatalf("rejected request must not produce overhead_seconds series:\n%s", body)
+	}
+	if strings.Contains(body, "tokenhub_gateway_routed_requests_total{") {
+		t.Fatalf("rejected request must not produce routed_requests_total series:\n%s", body)
+	}
+}
+
+// An image job reaches the same observation funnel as chat: requests_total counts
+// once and the routed attempts produce attempt, upstream-duration and overhead
+// series, so the failover-depth ratio is not diluted by image traffic.
+func TestMetricsImageJobAttributesAttempts(t *testing.T) {
+	store := NewMemoryStore()
+	project := store.CreateProject(Project{Name: "Metrics Image Project", Status: StatusActive})
+	_, secret, err := store.CreateAPIKey(project.ID, APIKey{
+		Name: "metrics-image-key", Allowed: []string{openAIImageModelName}, Status: StatusActive,
+	}, "thk_metrics_image")
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := store.AddProvider(Provider{
+		ID: "prv_metrics_image", Name: "Metrics Image Provider", Type: ProviderOpenAI, Status: StatusActive, Healthy: true,
+	})
+	resource, err := store.AddProviderResource(ProviderResource{
+		ID: "rsrc_metrics_image", ProviderID: provider.ID, Name: "Metrics Image Resource",
+		ResourceType: "openai", Status: StatusActive, Healthy: true,
+		Priority: 1, Weight: 100, MaxConcurrency: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.AddModel(Model{Name: openAIImageModelName, Modality: "image", Status: StatusActive})
+	store.AddRoute(ModelRoute{
+		ModelName: openAIImageModelName, ProviderID: provider.ID, ProviderResourceID: resource.ID,
+		ProviderModel: openAIImageModelName, Priority: 1, Weight: 100, Status: StatusActive,
+	})
+	server := NewWithConfig(store, Config{
+		AdminToken: "dev_admin_token", SecretKey: "metrics-image-secret",
+		MetricsEnabled: true, ImageStorageDir: t.TempDir(),
+	})
+	if server.metrics == nil {
+		t.Fatal("expected metrics to be enabled")
+	}
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+	server.imageRunner = func(_ context.Context, _ RouteSelection, _ ImageJob) ([]byte, string, Usage, error) {
+		return realPNGFixture(t), "", Usage{PromptTokens: 7, CompletionTokens: 13, TotalTokens: 20}, nil
+	}
+	handler := server.Handler()
+
+	create := doImageJSON(t, handler, http.MethodPost, "/v1/images/generations", map[string]any{
+		"model": openAIImageModelName, "prompt": "metrics image",
+	}, secret, map[string]string{"Prefer": "respond-async"})
+	if create.Code != http.StatusAccepted {
+		t.Fatalf("create image job: status=%d body=%s", create.Code, create.Body)
+	}
+	var created map[string]any
+	if err := json.Unmarshal([]byte(create.Body), &created); err != nil {
+		t.Fatal(err)
+	}
+	jobID, _ := created["id"].(string)
+	if jobID == "" {
+		t.Fatalf("missing image job id: %s", create.Body)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		job, ok := store.GetImageJob(jobID)
+		if ok && job.Status == imageJobStatusCompleted {
+			break
+		}
+		if ok && job.Status == imageJobStatusFailed {
+			t.Fatalf("image job failed: %+v", job)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("image job did not complete")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if got := testutil.ToFloat64(server.metrics.requests.WithLabelValues(
+		openAIImageModelName, ProviderOpenAI, provider.ID, resource.ID, "200", metricsLabelUnset, "false",
+	)); got != 1 {
+		t.Fatalf("expected the image request to be counted once, got %v", got)
+	}
+	if got := testutil.ToFloat64(server.metrics.routeAttempts.WithLabelValues(
+		openAIImageModelName, ProviderOpenAI, provider.ID, resource.ID, "200", metricsLabelUnset, "true",
+	)); got != 1 {
+		t.Fatalf("expected one invoked attempt series, got %v", got)
+	}
+	if got := testutil.CollectAndCount(server.metrics.attemptDuration); got != 1 {
+		t.Fatalf("expected one attempt duration series, got %d", got)
+	}
+	if got := testutil.CollectAndCount(server.metrics.overhead); got != 1 {
+		t.Fatalf("expected one overhead series, got %d", got)
+	}
+	if got := testutil.ToFloat64(server.metrics.routedRequests.WithLabelValues(
+		openAIImageModelName, ProviderOpenAI, "false",
+	)); got != 1 {
+		t.Fatalf("expected one routed request, got %v", got)
+	}
+}
+
+// A request admitted for routing that fails before any candidate attempt — route
+// selection, image claim, no-route handling — still records overhead: with no
+// attempts the sum is zero, so overhead is the full elapsed time. Rejected
+// requests keep the zero-duration convention and stay out of the histogram.
+func TestMetricsAdmittedZeroAttemptFailureRecordsOverhead(t *testing.T) {
+	m := NewGatewayMetrics(false)
+	m.ObserveGatewayCall(GatewayCallSample{
+		Model: "m", ProviderType: "t", ProviderID: "p", ResourceID: "r",
+		StatusCode: 503, ErrorCode: "no_route", Duration: 250 * time.Millisecond,
+	})
+
+	if got := testutil.CollectAndCount(m.attemptDuration); got != 0 {
+		t.Fatalf("a failed route selection must not create attempt_duration series, got %d", got)
+	}
+	if got := testutil.CollectAndCount(m.overhead); got != 1 {
+		t.Fatalf("an admitted zero-attempt failure must record overhead, got %d series", got)
+	}
+	handler := promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	handler.ServeHTTP(rec, req)
+	sumLine := findMetricLine(rec.Body.String(), "tokenhub_gateway_overhead_seconds_sum")
+	if sumLine == "" {
+		t.Fatal("missing overhead sum")
+	}
+	if got := metricLineValue(t, sumLine); got != 0.25 {
+		t.Fatalf("overhead must equal the full elapsed time when no attempt ran, got %v", got)
+	}
+}
+
+// routed_requests_total is the attempt-bearing denominator for the failover-depth
+// ratio: only requests that actually tried a candidate count, so a rejection burst
+// cannot make the ratio dip below 1 for perfectly healthy traffic.
+func TestMetricsRoutedRequestsCountsOnlyAttemptBearingRequests(t *testing.T) {
+	m := NewGatewayMetrics(false)
+	m.ObserveGatewayCall(GatewayCallSample{
+		Model: "m", ProviderType: "t", Duration: time.Second,
+		Attempts: []GatewayAttemptSample{{StatusCode: 200, Invoked: true}},
+	})
+	// Admitted but no candidate tried: routed traffic, not a routed request.
+	m.ObserveGatewayCall(GatewayCallSample{
+		Model: "m", ProviderType: "t", ProviderID: "p", StatusCode: 503, ErrorCode: "no_route", Duration: time.Second,
+	})
+	// Refused before routing: zero duration by convention.
+	m.ObserveGatewayCall(GatewayCallSample{
+		Model: "m", ProviderType: "t", ProviderID: "p", StatusCode: 429, ErrorCode: "quota_exceeded",
+	})
+
+	if got := testutil.ToFloat64(m.routedRequests.WithLabelValues("m", "t", "false")); got != 1 {
+		t.Fatalf("expected exactly one attempt-bearing request, got %v", got)
+	}
+	if got := testutil.ToFloat64(m.requests.WithLabelValues(
+		"m", "t", "p", metricsLabelUnset, "503", "no_route", "false",
+	)); got != 1 {
+		t.Fatalf("the admitted failure must still count in requests_total, got %v", got)
+	}
+}
+
+// The attempt window covers writing the stream to the client, so a slow reader
+// blocks the gateway inside the attempt and that backpressure must appear in
+// attempt_duration_seconds — not be misattributed to overhead. This is the
+// documented semantics of the metric, pinned by a regression test.
+func TestMetricsStreamAttemptDurationIncludesClientBackpressure(t *testing.T) {
+	const backpressure = 500 * time.Millisecond
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		// Enough payload to fill the socket buffers: the gateway blocks writing it
+		// while the client below stalls, which is the slow-writer scenario.
+		chunk := strings.Repeat("x", 4096)
+		for i := 0; i < 6000; i++ {
+			_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\""+chunk+"\"}}]}\n\n")
+			if i%32 == 0 {
+				flusher.Flush()
+			}
+		}
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	server, secret := newMetricsFailoverGateway(t, upstream.URL, upstream.URL)
+	gateway := httptest.NewServer(server.Handler())
+	defer gateway.Close()
+
+	payload, err := json.Marshal(map[string]any{
+		"model":    "metrics-failover-model",
+		"messages": []map[string]any{{"role": "user", "content": "hi"}},
+		"stream":   true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, gateway.URL+"/v1/chat/completions", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("authorization", "Bearer "+secret)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Stall like a slow client: headers are in hand, but the body is not read for
+	// a while, so the gateway's stream copy blocks and the attempt window grows.
+	time.Sleep(backpressure)
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	body := scrapeMetrics(t, server.Handler())
+	sumLine := findMetricLine(body, "tokenhub_gateway_attempt_duration_seconds_sum")
+	if sumLine == "" {
+		t.Fatalf("missing attempt duration sum:\n%s", body)
+	}
+	if got := metricLineValue(t, sumLine); got < backpressure.Seconds()*0.6 {
+		t.Fatalf("attempt duration must include the client backpressure, got %v", got)
+	}
+	overheadLine := findMetricLine(body, "tokenhub_gateway_overhead_seconds_sum")
+	if overheadLine == "" {
+		t.Fatalf("missing overhead sum:\n%s", body)
+	}
+	if got := metricLineValue(t, overheadLine); got >= backpressure.Seconds()*0.6 {
+		t.Fatalf("overhead must not include client backpressure, got %v", got)
 	}
 }

--- a/backend/internal/server/store_routing_calls.go
+++ b/backend/internal/server/store_routing_calls.go
@@ -941,8 +941,37 @@ func (s *GormStore) observeGatewayCall(call CallContext, route RouteSelection, u
 		Stream:       call.Stream,
 		Usage:        usage,
 		Duration:     elapsed,
+		Attempts:     gatewayAttemptSamples(call.RouteAttempts),
 	}
 	s.metrics.ObserveGatewayCall(sample)
+}
+
+// gatewayAttemptSamples maps the per-candidate routing outcomes into the slim
+// sample shape the metrics layer accepts. LatencyMS is the authoritative local
+// measurement covering the whole routed attempt — upstream transport, stream
+// translation and writing to the client — so streaming calls include slow-client
+// backpressure; StartedAt/EndedAt are UTC wall-clock readings and are not used
+// for duration here.
+func gatewayAttemptSamples(attempts []RouteAttempt) []GatewayAttemptSample {
+	if len(attempts) == 0 {
+		return nil
+	}
+	out := make([]GatewayAttemptSample, 0, len(attempts))
+	for _, attempt := range attempts {
+		sample := GatewayAttemptSample{
+			ProviderType: attempt.Selection.Provider.Type,
+			ProviderID:   attempt.Selection.Provider.ID,
+			ResourceID:   routeResourceID(attempt.Selection),
+			StatusCode:   attempt.Status,
+			ErrorCode:    attempt.ErrorCode,
+			Invoked:      attempt.Invoked,
+		}
+		if attempt.Invoked {
+			sample.Duration = time.Duration(attempt.LatencyMS) * time.Millisecond
+		}
+		out = append(out, sample)
+	}
+	return out
 }
 
 // knownModelLabel keeps a model name as a label only when the catalog knows it,

--- a/backend/internal/server/types.go
+++ b/backend/internal/server/types.go
@@ -1148,7 +1148,11 @@ type CallContext struct {
 	StreamOutputCommitted bool
 	// Stream records whether the client asked for a streamed response. It only
 	// labels observability output and never influences routing.
-	Stream         bool
+	Stream bool
+	// RouteAttempts carries the per-candidate outcomes for observability output.
+	// It is filled from the completion's Attempts just before FinishCall and never
+	// influences routing.
+	RouteAttempts  []RouteAttempt
 	Affinity       *RequestAffinity
 	requestContext context.Context
 }

--- a/docs/administrator-guide.md
+++ b/docs/administrator-guide.md
@@ -159,6 +159,10 @@ TokenHub can expose Prometheus metrics at `GET /metrics`. Collection is off by d
 | --- | --- | --- |
 | `tokenhub_gateway_requests_total` | counter | Logical model API requests. A request that failed over across several candidates counts once. |
 | `tokenhub_gateway_request_duration_seconds` | histogram | End-to-end latency including failover attempts. Buckets run to 300s. |
+| `tokenhub_gateway_route_attempts_total` | counter | Physical candidate attempts. The ratio `rate(route_attempts_total) / rate(routed_requests_total)` is the average failover depth; `routed_requests_total` counts only requests that made an attempt, so refusals that never reached a provider cannot dilute it. Labels include `invoked` so capacity-skipped candidates are visible separately. `status_code` is the gateway-mapped status (an upstream 401 is reported as 502); the raw upstream status is in the `RouteAttemptLog`. |
+| `tokenhub_gateway_attempt_duration_seconds` | histogram | Duration of one invoked routed attempt, measured around the whole attempt: upstream transport, stream translation, and writing to the client. Streaming calls therefore include slow-client backpressure; gateway overhead is reported separately in `overhead_seconds`. Excludes candidates skipped for capacity. |
+| `tokenhub_gateway_routed_requests_total` | counter | Logical requests that made at least one candidate attempt — the attempt-bearing denominator for the failover-depth ratio. Its `provider_type` label is the last candidate attempted, so when a request fails over across providers, aggregate the depth ratio by `model` rather than by `provider_type`. |
+| `tokenhub_gateway_overhead_seconds` | histogram | Approximate gateway overhead: elapsed end-to-end time minus the sum of invoked attempt durations. Clamped at zero. A request admitted for routing that fails before any attempt contributes its full elapsed time. For image jobs the elapsed time includes queue wait, so overhead there is an upper bound. |
 | `tokenhub_gateway_requests_in_flight` | gauge | Model API requests currently being served. Admin traffic and scrapes are excluded. |
 | `tokenhub_gateway_tokens_total` | counter | Tokens by kind: `prompt`, `completion`, `cached`, `cache_write`, `reasoning`. |
 | `tokenhub_gateway_cost_usd_total` | counter | Unified external billing estimate from Model Directory prices. Provider actual cost remains in privileged request audit rather than this metric. |
@@ -170,9 +174,28 @@ Go runtime and process metrics are exposed alongside them.
 
 **Token kinds are not a partition and must not be summed.** `prompt` already contains the `cached` and `cache_write` tokens, and `reasoning` is a subset of `completion`. Summing the kinds double-counts.
 
-Requests refused before routing — a bad API key, an exhausted quota, an unknown model — increment the request counter only. They never reached a provider, so they contribute no tokens, cost or duration. A model name that the catalog does not know is reported as `unknown` rather than verbatim, so a client looping over invented model names cannot inflate the series count.
+Requests refused before routing — a bad API key, an exhausted quota, an unknown model — increment the request counter only. They never reached a provider, so they contribute no tokens, cost or duration. The attempt-bearing counterpart `routed_requests_total` counts only requests that reached at least one candidate, so a rejection burst does not dilute the failover-depth ratio. A model name that the catalog does not know is reported as `unknown` rather than verbatim, so a client looping over invented model names cannot inflate the series count.
 
 Labels are `model`, `provider_type`, `provider_id`, `resource_id`, `status_code`, `error_code` and `stream`. Upstream failures no longer report a single `provider_error` at `status_code="502"`; they carry the codes and statuses listed under Upstream Error Classification, so dashboards and alerts that match on the old pair need updating. Upstream failures no longer report a single `provider_error` at `status_code="502"`; they carry the codes and statuses listed under Upstream Error Classification, so dashboards and alerts that match on the old pair need updating. Setting `TOKENHUB_METRICS_PROJECT_LABEL=true` adds `project_id`, which multiplies the series count of every gateway metric by the number of active projects; leave it off unless you need per-project dashboards, and use the usage reports for per-key attribution instead.
+
+Useful PromQL examples:
+
+```promql
+# Average failover depth per model.
+sum by (model) (rate(tokenhub_gateway_route_attempts_total[5m]))
+/
+sum by (model) (rate(tokenhub_gateway_routed_requests_total[5m]))
+
+# 99th percentile gateway overhead. Histograms must be aggregated by bucket
+# before calling histogram_quantile; subtracting aggregated percentiles is
+# mathematically invalid.
+histogram_quantile(
+  0.99,
+  sum by (le, stream) (rate(tokenhub_gateway_overhead_seconds_bucket[5m]))
+)
+```
+
+When running multiple gateway instances, histogram quantiles can be computed from `sum(rate(..._bucket)) by (le)` across all instances because each bucket is a counter. `tokenhub_gateway_requests_in_flight` is a gauge and should be aggregated with `instance` if you want per-instance concurrency; summing it across instances gives total in-flight requests.
 
 To push metrics instead of having them scraped, point an OpenTelemetry Collector's `prometheus` receiver at this endpoint and forward from there. Traces are a separate signal and are pushed directly; see below.
 

--- a/docs/ja/administrator-guide.md
+++ b/docs/ja/administrator-guide.md
@@ -159,6 +159,10 @@ TokenHub は `GET /metrics` で Prometheus メトリクスを公開できます�
 | --- | --- | --- |
 | `tokenhub_gateway_requests_total` | counter | 論理的なモデル API リクエスト数。複数候補へのフェイルオーバーが発生しても 1 回として数えます。 |
 | `tokenhub_gateway_request_duration_seconds` | histogram | フェイルオーバーを含むエンドツーエンドのレイテンシ。バケットは 300 秒まで。 |
+| `tokenhub_gateway_route_attempts_total` | counter | 物理的な候補試行数。`rate(route_attempts_total) / rate(routed_requests_total)` が平均フェイルオーバー深度です。`routed_requests_total` は試行を 1 回以上行ったリクエストのみを数えるため、Provider に到達しなかった拒否トラフィックで比率が希釈されることはありません。`invoked` ラベルで容量不足によりスキップされた候補を区別できます。`status_code` はゲートウェイがマッピングしたステータスです（上流の 401 は 502 として報告されます）。元の上流ステータスは `RouteAttemptLog` にあります。 |
+| `tokenhub_gateway_attempt_duration_seconds` | histogram | 呼び出された（invoked）1 試行の全所要時間。試行全体を囲む測定で、上流トランスポート・ストリーム変換・クライアントへの書き込みを含みます。ストリーミング呼び出しでは遅いクライアントの背圧を含むため、ゲートウェイのオーバーヘッドは `overhead_seconds` に別途報告されます。容量スキップ候補は含みません。 |
+| `tokenhub_gateway_routed_requests_total` | counter | 候補を 1 回以上試行した論理リクエスト数。フェイルオーバー深度比率の試行分母です。`provider_type` ラベルは最後に試行した候補です。Provider をまたぐフェイルオーバーでは、深度比率は `provider_type` ではなく `model` で集約してください。 |
+| `tokenhub_gateway_overhead_seconds` | histogram | ゲートウェイ自身のオーバーヘッドの近似値：エンドツーエンド所要時間から invoked な試行の所要時間合計を差し引き、負値は 0 にクリップします。ルーティングに受理されたものの試行前に失敗したリクエストは、その全所要時間をオーバーヘッドとして計上します。画像ジョブの所要時間にはキューの待機が含まれるため、画像のオーバーヘッドは上限値です。 |
 | `tokenhub_gateway_requests_in_flight` | gauge | 処理中のモデル API リクエスト数。管理トラフィックとスクレイプは含みません。 |
 | `tokenhub_gateway_tokens_total` | counter | 種別ごとの Token：`prompt`、`completion`、`cached`、`cache_write`、`reasoning`。 |
 | `tokenhub_gateway_cost_usd_total` | counter | Model Directory 価格による統一外部請求見積もり。Provider 実コストは権限付きリクエスト監査にのみ保持され、このメトリクスには含まれません。 |
@@ -170,9 +174,27 @@ TokenHub は `GET /metrics` で Prometheus メトリクスを公開できます�
 
 **Token の種別は排他的な分割ではないため、合計してはいけません。** `prompt` はすでに `cached` と `cache_write` を含み、`reasoning` は `completion` の一部です。合計すると二重計上になります。
 
-ルーティング前に拒否されたリクエスト（無効な API Key、クォータ超過、未知のモデル）はリクエスト数のみを増やします。Provider に到達していないため、Token・コスト・所要時間は記録しません。カタログに存在しないモデル名はそのまま記録せず `unknown` として扱うため、任意のモデル名を大量に送っても系列数を増やすことはできません。
+ルーティング前に拒否されたリクエスト（無効な API Key、クォータ超過、未知のモデル）はリクエスト数のみを増やします。Provider に到達していないため、Token・コスト・所要時間は記録しません。試行分母の `routed_requests_total` は候補に 1 回以上到達したリクエストのみを数えるため、拒否トラフィックの急増でフェイルオーバー深度の比率が希釈されることはありません。カタログに存在しないモデル名はそのまま記録せず `unknown` として扱うため、任意のモデル名を大量に送っても系列数を増やすことはできません。
 
 ラベルは `model`、`provider_type`、`provider_id`、`resource_id`、`status_code`、`error_code`、`stream` です。上流の失敗は `status_code="502"` と `provider_error` の 1 組にまとめて報告されなくなり、「上流エラーの分類」に記載のステータスとエラーコードを持ちます。旧来の値で一致させているダッシュボードやアラートは更新が必要です。`TOKENHUB_METRICS_PROJECT_LABEL=true` を設定すると `project_id` が追加され、各ゲートウェイメトリクスの系列数がアクティブなプロジェクト数だけ増加します。プロジェクト単位のダッシュボードが必要な場合を除き無効のままにし、Key 単位の集計には使用量レポートを利用してください。
+
+よく使う PromQL 例：
+
+```promql
+# モデルごとの平均フェイルオーバー深度。
+sum by (model) (rate(tokenhub_gateway_route_attempts_total[5m]))
+/
+sum by (model) (rate(tokenhub_gateway_routed_requests_total[5m]))
+
+# ゲートウェイオーバーヘッドの P99。histogram_quantile を呼ぶ前に bucket で
+# 集約する必要があります。集約後のパーセンタイル同士を引くのは数学的に無効です。
+histogram_quantile(
+  0.99,
+  sum by (le, stream) (rate(tokenhub_gateway_overhead_seconds_bucket[5m]))
+)
+```
+
+複数インスタンス構成では、各 bucket がカウンタなので全インスタンスの `sum(rate(..._bucket)) by (le)` からヒストグラムのパーセンタイルを計算できます。`tokenhub_gateway_requests_in_flight` は gauge なので、インスタンスごとの同時実行数が必要な場合は `instance` ラベルを保持して集約してください。インスタンスをまたいで合計すると総同時リクエスト数になります。
 
 メトリクスをスクレイプではなく push したい場合は、OpenTelemetry Collector の `prometheus` receiver でこのエンドポイントを収集して転送してください。トレースは別のシグナルで、ゲートウェイが直接送信します。次節を参照してください。
 

--- a/docs/zh-CN/administrator-guide.md
+++ b/docs/zh-CN/administrator-guide.md
@@ -159,6 +159,10 @@ TokenHub 可以在 `GET /metrics` 暴露 Prometheus 指标。该功能默认关�
 | --- | --- | --- |
 | `tokenhub_gateway_requests_total` | counter | 逻辑模型 API 请求数。一次请求即使经过多个候选失败转移也只计一次。 |
 | `tokenhub_gateway_request_duration_seconds` | histogram | 端到端耗时，包含失败转移。分桶上限为 300 秒。 |
+| `tokenhub_gateway_route_attempts_total` | counter | 物理候选尝试数。`rate(route_attempts_total) / rate(routed_requests_total)` 即为平均失败转移深度；`routed_requests_total` 只统计真正发起过尝试的请求，因此从未到达任何 Provider 的拒绝流量不会稀释该比率。`invoked` 标签可单独区分因容量不足被跳过的候选。`status_code` 为网关映射后的状态（上游 401 会报告为 502）；原始上游状态见 `RouteAttemptLog`。 |
+| `tokenhub_gateway_attempt_duration_seconds` | histogram | 单个被调用（invoked）尝试的完整耗时，围绕整个尝试测量：上游传输、流式翻译与写入客户端。流式调用因此包含慢客户端背压时间；网关自身开销单独见 `overhead_seconds`。不包含因容量被跳过的候选。 |
+| `tokenhub_gateway_routed_requests_total` | counter | 至少发起过一次候选尝试的逻辑请求数——失败转移深度比率的尝试承载分母。其 `provider_type` 标签为最后一个尝试的候选；跨 Provider 失败转移时，请按 `model` 而非 `provider_type` 聚合深度比率。 |
+| `tokenhub_gateway_overhead_seconds` | histogram | 网关自身开销的近似值：端到端耗时减去被调用尝试耗时之和，负值截断为 0。已在路由阶段被接纳、但在任何尝试前失败的请求，其开销计为完整端到端耗时。图像作业的端到端耗时包含队列等待，因此其开销为上限估计。 |
 | `tokenhub_gateway_requests_in_flight` | gauge | 正在处理的模型 API 请求数，不含管理后台流量和抓取请求。 |
 | `tokenhub_gateway_tokens_total` | counter | 按类型统计的 Token：`prompt`、`completion`、`cached`、`cache_write`、`reasoning`。 |
 | `tokenhub_gateway_cost_usd_total` | counter | 使用模型目录价格计算的统一对外计费估算；Provider 真实成本只保留在有权限的请求审计中，不进入该指标。 |
@@ -170,9 +174,27 @@ TokenHub 可以在 `GET /metrics` 暴露 Prometheus 指标。该功能默认关�
 
 **Token 各类型之间不是互斥划分，不能相加。** `prompt` 已经包含 `cached` 和 `cache_write`，`reasoning` 是 `completion` 的子集，相加会重复计算。
 
-在路由之前就被拒绝的请求（API Key 无效、额度耗尽、模型不存在）只增加请求计数。它们没有到达任何 Provider，因此不产生 Token、成本和耗时。目录中不存在的模型名会被记为 `unknown` 而不是原样上报，避免客户端用随机模型名刷高时间序列数量。
+在路由之前就被拒绝的请求（API Key 无效、额度耗尽、模型不存在）只增加请求计数。它们没有到达任何 Provider，因此不产生 Token、成本和耗时。对应的尝试承载计数 `routed_requests_total` 只统计到达过至少一个候选的请求，因此拒绝流量突发不会稀释失败转移深度比率。目录中不存在的模型名会被记为 `unknown` 而不是原样上报，避免客户端用随机模型名刷高时间序列数量。
 
 标签为 `model`、`provider_type`、`provider_id`、`resource_id`、`status_code`、`error_code` 和 `stream`。上游失败不再统一上报为 `status_code="502"` 加 `provider_error`，而是使用「上游错误分类」一节列出的状态码与错误码，按旧取值匹配的看板和告警需要相应更新。设置 `TOKENHUB_METRICS_PROJECT_LABEL=true` 会追加 `project_id`，使每个网关指标的时间序列数量按活跃项目数成倍增长；除非确实需要按项目看板，否则建议保持关闭，按 Key 的归因请改用用量报表。
+
+常用 PromQL 示例：
+
+```promql
+# 每个模型的平均失败转移深度。
+sum by (model) (rate(tokenhub_gateway_route_attempts_total[5m]))
+/
+sum by (model) (rate(tokenhub_gateway_routed_requests_total[5m]))
+
+# 网关开销的 P99。必须先按 bucket 聚合再调用 histogram_quantile；
+# 两个聚合后的分位数相减在数学上是无效的。
+histogram_quantile(
+  0.99,
+  sum by (le, stream) (rate(tokenhub_gateway_overhead_seconds_bucket[5m]))
+)
+```
+
+多实例部署时，直方图分位数可基于所有实例的 `sum(rate(..._bucket)) by (le)` 计算，因为每个 bucket 都是计数器。`tokenhub_gateway_requests_in_flight` 是 gauge，若需要按实例并发则聚合时需保留 `instance` 标签；跨实例求和得到的是总并发请求数。
 
 如果指标需要 push 而不是被抓取，可以让 OpenTelemetry Collector 的 `prometheus` receiver 抓取该端点再转发。链路追踪是另一路信号，由网关直接推送，见下节。
 


### PR DESCRIPTION
## Summary

The gateway metrics introduced in #57 answer "how many requests, how fast, how many errors" — but they cannot answer where the latency comes from or how hard the router is working. A logical request that failed over three times looks identical to one that succeeded on the first try, and `tokenhub_gateway_request_duration_seconds` blends gateway overhead (auth, routing, DB, serialization) with upstream provider time.

This PR adds three metrics on the existing `GatewayMetrics` funnel to close that gap:

| Metric | Type | What it answers |
| --- | --- | --- |
| `tokenhub_gateway_route_attempts_total` | Counter (`model, provider_type, provider_id, resource_id, status_code, error_code, invoked`) | Physical candidate attempts. The ratio `rate(route_attempts_total) / rate(routed_requests_total)` is the failover depth; per-provider slices show who is being retried away from. |
| `tokenhub_gateway_routed_requests_total` | Counter (`model, provider_type, stream`) | Attempt-bearing logical requests: the denominator for the failover-depth ratio. `requests_total` also counts refusals that never reached a provider, which would dilute the ratio; this counter does not. |
| `tokenhub_gateway_attempt_duration_seconds` | Histogram (`model, provider_type, outcome`) | Duration of one invoked routed attempt. Measured around the whole attempt — upstream transport, stream translation, and writing to the client — so streaming calls include slow-client backpressure. Separated from end-to-end duration; the dedicated upstream-boundary signal is the TTFB metric. |
| `tokenhub_gateway_overhead_seconds` | Histogram (`stream`) | Gateway's own cost: `max(0, elapsed − Σ invoked attempt duration)`, computed per request server-side. A request admitted for routing that fails before any attempt contributes its full elapsed time. |

Design notes:

- **Overhead must be computed server-side.** Histogram quantiles cannot be subtracted in PromQL (`histogram_quantile(P99 end-to-end) − P99 attempt` is mathematically invalid), so the per-request subtraction happens before observation.
- **Single observation funnel.** Attempts ride the existing `GatewayCallCompletion.Attempts` slice; `finishCall` copies them into `CallContext.RouteAttempts` so the existing `FinishCall → observeGatewayCall` path can map them. Playground and rejected traffic are naturally excluded by `CompletionKindPlayground` / `CompletionKindRejected`.
- **Bounded cardinality.** `model` comes from the catalog-validated model name, `error_code` is the bounded internal enum from `statusAndCode`/`routeAttemptStatusAndCode`. The attempt counter's label set is the same order of magnitude as `requests_total`; the attempt histogram deliberately omits `provider_id`/`resource_id` (each histogram label layer costs ×14 series; per-resource latency is already queryable via `RouteAttemptLog` in the DB). `status_code` is the gateway-mapped status (an upstream 401 is reported as 502) to stay comparable with `requests_total`; the raw upstream status is in `RouteAttemptLog`.
- **Attempt duration semantics are documented, not overloaded.** The attempt window is the routed callback (upstream transport, stream translation, client writes), so for streaming calls it includes slow-client backpressure; the help text, docs and a slow-writer regression test pin that semantics, and the upstream boundary itself is the TTFB metric's job. The failover-depth denominator is `routed_requests_total`, which counts only attempt-bearing requests, so a rejection burst cannot dilute the ratio below 1 for healthy traffic.
- **Image jobs are wired too.** `processImageJob` threads its routed attempts into the call context on both the success and failure paths, so the failover-depth ratio is not diluted by image traffic. One caveat is documented in the metric help and docs: an image job's elapsed time includes queue wait, so its `overhead_seconds` value is an upper bound.

## Related Issue

N/A (follow-up to #57)

## Changes

- Backend
  - `types.go`: `CallContext.RouteAttempts` observability-only field.
  - `metrics.go`: 4 new collectors (`route_attempts_total`, `routed_requests_total`, `attempt_duration_seconds`, `overhead_seconds`), `GatewayAttemptSample`, `gatewayOverheadBuckets`; `ObserveGatewayCall` keeps the nil-safe and "zero value produces no series" conventions.
  - `store_routing_calls.go`: `observeGatewayCall` remains the single label-mapping point (`RouteAttempt → GatewayAttemptSample`).
  - `gateway_completion.go`: one-line `completion.Call.RouteAttempts = attemptsWithoutErrorText(completion.Attempts)` in `finishCall`, replacing the 10 per-handler assignments from the original plan and keeping upstream error text out of the observability path.
  - `image_generation.go`: `processImageJob` fills `work.call.RouteAttempts` from its routed attempts so image jobs report attempt and attempt-duration series on both completion paths.
- Tests (`metrics_test.go`): failover produces 2 attempt series while `requests_total` +1; non-invoked (capacity-rejected) attempts skip the attempt histogram; overhead clamps at 0 and is recorded for admitted zero-attempt failures (route selection, image claim); `routed_requests_total` counts only attempt-bearing requests; a slow-reading client blocks the stream copy and that backpressure lands in `attempt_duration_seconds` (documented semantics, pinned by regression) rather than overhead; rejected requests produce no new series; an end-to-end image job produces one request, one attempt, one attempt-duration and one overhead series; nil-safety extended.
- Docs: metric tables + PromQL examples (failover depth, overhead P99) + multi-instance aggregation note in `docs/administrator-guide.md`, `docs/zh-CN/…`, `docs/ja/…`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor or maintenance
- [x] Documentation
- [ ] Deployment or configuration

## Verification

- [x] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [ ] Frontend: `npm run typecheck` and `npm run build` — not applicable, no frontend changes
- [ ] SDK smoke tests against a compatible backend — not applicable, no API contract changes
- [ ] Docker Compose configuration rendered successfully — not applicable, no config changes
- [x] Other focused or manual verification described below

Verification details:

- `cd backend && gofmt -l . && go vet ./... && go test ./...` — all pass.
- New tests: `TestMetricsAdmittedZeroAttemptFailureRecordsOverhead`, `TestMetricsRoutedRequestsCountsOnlyAttemptBearingRequests`, `TestMetricsStreamAttemptDurationIncludesClientBackpressure` (slow-writer regression).
- Existing `stream_failover_test.go` and `routing_policy_test.go` pass **unmodified** (behavior regression gates).
- `git diff --check` clean.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: None. Observability-only; no request/response changes.
- Security or credential-handling impact: None. No new data leaves the process; labels use bounded internal enums.
- Database, environment, or deployment impact: None. Reuses `TOKENHUB_METRICS_ENABLED`; no new env vars, no migrations, no compose changes.
- Rollout and rollback considerations: Metrics appear immediately after deploy when metrics are enabled; rollback simply removes the series. Existing metric names/labels/buckets untouched.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable. (No env changes.)
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable. (Untouched.)
- [x] `git diff --check` passes.
