### PR TITLE
refactor(server): re-land adapter core sharing and finish-reason unification

### DIFF
--- a/backend/internal/server/anthropic_messages.go
+++ b/backend/internal/server/anthropic_messages.go
@@ -929,10 +929,8 @@ func (s *Server) doNativeAnthropicRequest(
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode >= 400 {
-		defer resp.Body.Close()
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, newProviderHTTPError(resp.StatusCode, resp.Header, data)
+	if err := checkProviderResponse(resp); err != nil {
+		return nil, err
 	}
 	return resp, nil
 }

--- a/backend/internal/server/anthropic_messages.go
+++ b/backend/internal/server/anthropic_messages.go
@@ -836,22 +836,6 @@ func anySlice(value any) ([]any, bool) {
 	}
 }
 
-func openAIFinishReasonToAnthropic(reason string, hasTools bool) string {
-	if hasTools || reason == "tool_calls" || reason == "function_call" {
-		return "tool_use"
-	}
-	switch reason {
-	case "length":
-		return "max_tokens"
-	case "stop", "":
-		return "end_turn"
-	case "content_filter":
-		return "refusal"
-	default:
-		return "end_turn"
-	}
-}
-
 func anthropicUsageObject(usage Usage) map[string]any {
 	cachedInputTokens := minInt64(maxInt64(usage.CachedInputTokens, 0), maxInt64(usage.PromptTokens, 0))
 	return map[string]any{

--- a/backend/internal/server/anthropic_messages_stream.go
+++ b/backend/internal/server/anthropic_messages_stream.go
@@ -87,16 +87,24 @@ func copyNativeAnthropicStream(writer io.Writer, body io.Reader, model string) (
 	}
 }
 
+// mergeAnthropicStreamUsage folds one streamed usage snapshot into the running
+// total. A stream splits its usage across message_start and message_delta, and
+// a frame that reports nothing new omits the fields entirely, so a frame only
+// overwrites what it actually carries. The three input classes move together as
+// one group: any positive component replaces the whole input side, including
+// siblings the frame left out, because a frame that restates the input counts
+// restates all of them. The output count is merged on its own.
 func mergeAnthropicStreamUsage(current Usage, raw map[string]any) Usage {
-	inputTokens := int64FromAny(raw["input_tokens"])
-	cacheCreationInputTokens := int64FromAny(raw["cache_creation_input_tokens"])
-	cacheReadInputTokens := int64FromAny(raw["cache_read_input_tokens"])
-	if inputTokens > 0 || cacheCreationInputTokens > 0 || cacheReadInputTokens > 0 {
-		current.PromptTokens = inputTokens + cacheCreationInputTokens + cacheReadInputTokens
-		current.CachedInputTokens = cacheReadInputTokens
+	snapshot := anthropicUsageFromRawMap(raw)
+	if snapshot.PromptTokens > 0 || snapshot.CachedInputTokens > 0 || snapshot.CacheWriteInputTokens > 0 {
+		current.PromptTokens = snapshot.PromptTokens
+		current.CachedInputTokens = snapshot.CachedInputTokens
+		// CacheWriteInputTokens is knowingly left unmerged here. This path has
+		// never reported it, and starting to would change billed usage, which is
+		// a behavior change rather than part of consolidating the parsing.
 	}
-	if value := int64FromAny(raw["output_tokens"]); value > 0 {
-		current.CompletionTokens = value
+	if snapshot.CompletionTokens > 0 {
+		current.CompletionTokens = snapshot.CompletionTokens
 	}
 	current.TotalTokens = current.PromptTokens + current.CompletionTokens
 	return current

--- a/backend/internal/server/image_openai_http.go
+++ b/backend/internal/server/image_openai_http.go
@@ -206,10 +206,8 @@ func (a OpenAICompatibleAdapter) doMultipartRaw(
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode >= http.StatusBadRequest {
-		defer resp.Body.Close()
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, newProviderHTTPError(resp.StatusCode, resp.Header, data)
+	if err := checkProviderResponse(resp); err != nil {
+		return nil, err
 	}
 	return resp, nil
 }

--- a/backend/internal/server/provider_anthropic_convert.go
+++ b/backend/internal/server/provider_anthropic_convert.go
@@ -394,37 +394,3 @@ func anthropicChatResponse(body map[string]any, model string, usage Usage) (map[
 		"usage": usage,
 	}, nil
 }
-
-// anthropicFinishReason maps a stop reason. Unknown values are surfaced as an
-// upstream error rather than being flattened to "stop", which would report a
-// truncated or refused generation as a normal completion.
-func anthropicFinishReason(stopReason string, hasToolCalls bool) (string, error) {
-	switch stopReason {
-	case "tool_use":
-		return "tool_calls", nil
-	case "pause_turn":
-		// A paused server-tool loop expects the assistant content to be replayed
-		// verbatim so the provider can resume it. That is not something an
-		// OpenAI-shaped client can do, and reporting tool_calls would tell the
-		// client to run a tool that was never requested.
-		return "", unsupportedCapabilityError("provider paused a server-side tool loop, which this route cannot resume")
-	case "end_turn", "stop_sequence":
-		if hasToolCalls {
-			return "tool_calls", nil
-		}
-		return "stop", nil
-	case "max_tokens", "model_context_window_exceeded":
-		return "length", nil
-	case "refusal":
-		return "content_filter", nil
-	case "":
-		// Streaming responses report the stop reason in message_delta; a
-		// non-streaming body without one is still in flight or malformed.
-		if hasToolCalls {
-			return "tool_calls", nil
-		}
-		return "stop", nil
-	default:
-		return "", invalidProviderResponseError(fmt.Sprintf("provider returned an unrecognized stop_reason %q", stopReason))
-	}
-}

--- a/backend/internal/server/provider_anthropic_convert_test.go
+++ b/backend/internal/server/provider_anthropic_convert_test.go
@@ -341,39 +341,6 @@ func TestAnthropicResponseUsesNullContentForToolOnlyTurn(t *testing.T) {
 	}
 }
 
-func TestAnthropicFinishReasonMapping(t *testing.T) {
-	cases := map[string]string{
-		"end_turn":                      "stop",
-		"stop_sequence":                 "stop",
-		"max_tokens":                    "length",
-		"model_context_window_exceeded": "length",
-		"tool_use":                      "tool_calls",
-		"refusal":                       "content_filter",
-	}
-	for stopReason, want := range cases {
-		got, err := anthropicFinishReason(stopReason, false)
-		if err != nil {
-			t.Fatalf("%s: %v", stopReason, err)
-		}
-		if got != want {
-			t.Fatalf("%s: expected %q, got %q", stopReason, want, got)
-		}
-	}
-
-	// pause_turn means a server-side tool loop paused and expects the assistant
-	// content to be replayed verbatim. Reporting tool_calls would tell the client
-	// to run a tool that was never requested.
-	if _, err := anthropicFinishReason("pause_turn", false); err == nil {
-		t.Fatalf("pause_turn must not be presented as a client tool call")
-	}
-
-	// An unrecognized value must not be flattened to "stop": that would report a
-	// truncated or refused generation as a normal completion.
-	if _, err := anthropicFinishReason("something_new", false); err == nil {
-		t.Fatalf("unknown stop reasons must surface as an upstream error")
-	}
-}
-
 func TestAnthropicRebuildsSignedThinkingBlockWithEmptyText(t *testing.T) {
 	// Models may return a signed thinking block with no visible text. The block
 	// still has to be replayed verbatim, so the signature alone gates rebuilding.

--- a/backend/internal/server/provider_anthropic_stream.go
+++ b/backend/internal/server/provider_anthropic_stream.go
@@ -284,7 +284,7 @@ func (d *anthropicStreamDecoder) mergeUsage(value any) {
 }
 
 func (d *anthropicStreamDecoder) currentUsage() Usage {
-	return anthropicUsage(map[string]any{"usage": d.usage})
+	return anthropicUsageFromRawMap(d.usage)
 }
 
 func anthropicStreamError(payload map[string]any) error {

--- a/backend/internal/server/provider_anthropic_usage.go
+++ b/backend/internal/server/provider_anthropic_usage.go
@@ -1,0 +1,26 @@
+package server
+
+// anthropicUsageFromRawMap reads one Anthropic usage snapshot. Anthropic reports
+// the three input classes disjointly, so prompt tokens are their sum.
+// Cache-creation tokens are also surfaced on their own field: they bill at a
+// premium over base input, and folding them into the total alone would lose the
+// distinction. A nil snapshot yields a zero usage.
+func anthropicUsageFromRawMap(raw map[string]any) Usage {
+	uncachedInputTokens := int64FromAny(raw["input_tokens"])
+	cacheCreationInputTokens := int64FromAny(raw["cache_creation_input_tokens"])
+	cachedInputTokens := int64FromAny(raw["cache_read_input_tokens"])
+	usage := Usage{
+		PromptTokens:          uncachedInputTokens + cacheCreationInputTokens + cachedInputTokens,
+		CachedInputTokens:     cachedInputTokens,
+		CacheWriteInputTokens: cacheCreationInputTokens,
+		CompletionTokens:      int64FromAny(raw["output_tokens"]),
+	}
+	usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+	return usage
+}
+
+// anthropicUsage reads the snapshot off a complete non-streaming response body.
+func anthropicUsage(body map[string]any) Usage {
+	usageMap, _ := body["usage"].(map[string]any)
+	return anthropicUsageFromRawMap(usageMap)
+}

--- a/backend/internal/server/provider_anthropic_usage_test.go
+++ b/backend/internal/server/provider_anthropic_usage_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAnthropicUsageFromRawMap(t *testing.T) {
+	// Anthropic reports the three input classes disjointly, so prompt tokens are
+	// their sum, and cache-creation tokens keep their own field because they bill
+	// at a premium over base input.
+	usage := anthropicUsageFromRawMap(map[string]any{
+		"input_tokens":                int64(10),
+		"cache_creation_input_tokens": int64(4),
+		"cache_read_input_tokens":     int64(6),
+		"output_tokens":               int64(5),
+	})
+	want := Usage{
+		PromptTokens:          20,
+		CachedInputTokens:     6,
+		CacheWriteInputTokens: 4,
+		CompletionTokens:      5,
+		TotalTokens:           25,
+	}
+	if !reflect.DeepEqual(usage, want) {
+		t.Fatalf("anthropicUsageFromRawMap() = %+v, want %+v", usage, want)
+	}
+
+	if empty := anthropicUsageFromRawMap(nil); !reflect.DeepEqual(empty, Usage{}) {
+		t.Fatalf("anthropicUsageFromRawMap(nil) = %+v, want a zero usage", empty)
+	}
+}
+
+// A stream splits usage across message_start and message_delta. A frame only
+// overwrites what it carries, and the three input classes move as one group: a
+// frame that restates any of them replaces the whole input side.
+func TestMergeAnthropicStreamUsageOnlyPositiveValuesOverwrite(t *testing.T) {
+	start := mergeAnthropicStreamUsage(Usage{}, map[string]any{
+		"input_tokens":            int64(30),
+		"cache_read_input_tokens": int64(10),
+		"output_tokens":           int64(1),
+	})
+	if start.PromptTokens != 40 || start.CachedInputTokens != 10 || start.CompletionTokens != 1 || start.TotalTokens != 41 {
+		t.Fatalf("message_start merge = %+v", start)
+	}
+
+	// message_delta reports only the final output count; the input fields it
+	// omits must not reset the totals the first frame established.
+	final := mergeAnthropicStreamUsage(start, map[string]any{"output_tokens": int64(120)})
+	if final.PromptTokens != 40 || final.CachedInputTokens != 10 || final.CompletionTokens != 120 || final.TotalTokens != 160 {
+		t.Fatalf("message_delta merge = %+v", final)
+	}
+
+	// An explicit zero is treated the same as an omission.
+	zeroed := mergeAnthropicStreamUsage(final, map[string]any{
+		"input_tokens":            int64(0),
+		"cache_read_input_tokens": int64(0),
+		"output_tokens":           int64(0),
+	})
+	if !reflect.DeepEqual(zeroed, final) {
+		t.Fatalf("zero-valued merge = %+v, want %+v", zeroed, final)
+	}
+
+	// Cache-creation tokens alone still count as an input update, and replacing
+	// the input side clears the sibling classes the frame left out. That clobbers
+	// the running totals; this pins inherited behavior, not a target semantic.
+	created := mergeAnthropicStreamUsage(final, map[string]any{"cache_creation_input_tokens": int64(7)})
+	if created.PromptTokens != 7 || created.CachedInputTokens != 0 || created.CompletionTokens != 120 {
+		t.Fatalf("cache-creation merge = %+v", created)
+	}
+	// This path has never billed cache-creation tokens on their own field.
+	// Changing that is a behavior change, so it must not happen by accident.
+	if created.CacheWriteInputTokens != 0 {
+		t.Fatalf("stream merge started reporting cache-write tokens: %+v", created)
+	}
+}

--- a/backend/internal/server/provider_error_classification.go
+++ b/backend/internal/server/provider_error_classification.go
@@ -1,9 +1,15 @@
 package server
 
 import (
+	"io"
 	"net/http"
 	"strings"
 )
+
+// providerErrorBodyPrefix is how much of a failed upstream response is read for
+// the error message. Provider error bodies are small; the bound is what keeps a
+// misbehaving upstream from making the gateway buffer an arbitrary amount.
+const providerErrorBodyPrefix = 4096
 
 // An upstream failure has to answer three separate questions, and collapsing them
 // into one status code answers none of them well:
@@ -96,6 +102,23 @@ func newProviderMisconfigured(message string) error {
 		Err:         NewHTTPError(http.StatusServiceUnavailable, "provider_not_configured", message),
 		Disposition: ProviderErrorResourceBroken,
 	}
+}
+
+// checkProviderResponse reports whether an upstream response carries a failure,
+// and if so consumes it: a bounded prefix of the body becomes the error message
+// and the body is closed. It deliberately only inspects a response someone else
+// sent, because how a request is sent is not shared — a streaming call runs on a
+// client with no total deadline and an idle budget, and folding sending into
+// this check would put every caller on one policy.
+//
+// A nil error leaves the body open and owned by the caller.
+func checkProviderResponse(resp *http.Response) error {
+	if resp.StatusCode < http.StatusBadRequest {
+		return nil
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, providerErrorBodyPrefix))
+	return newProviderHTTPError(resp.StatusCode, resp.Header, data)
 }
 
 // newProviderHTTPError turns one upstream failure into the error the rest of the

--- a/backend/internal/server/provider_finish_reason.go
+++ b/backend/internal/server/provider_finish_reason.go
@@ -1,0 +1,82 @@
+package server
+
+import "fmt"
+
+// Canonical finish/stop reason strings for the two protocols this package
+// translates between. The mapping is lossy in both directions, so the two
+// functions below stay explicit rather than being derived from one table:
+// end_turn and stop_sequence both become "stop", and max_tokens and
+// model_context_window_exceeded both become "length".
+const (
+	openAIFinishReasonStop          = "stop"
+	openAIFinishReasonLength        = "length"
+	openAIFinishReasonToolCalls     = "tool_calls"
+	openAIFinishReasonContentFilter = "content_filter"
+	// openAIFinishReasonFunctionCall is the pre-tool_calls spelling. It still
+	// arrives from older upstreams and means the same thing.
+	openAIFinishReasonFunctionCall = "function_call"
+
+	anthropicStopReasonEndTurn         = "end_turn"
+	anthropicStopReasonStopSequence    = "stop_sequence"
+	anthropicStopReasonMaxTokens       = "max_tokens"
+	anthropicStopReasonContextExceeded = "model_context_window_exceeded"
+	anthropicStopReasonToolUse         = "tool_use"
+	anthropicStopReasonRefusal         = "refusal"
+	anthropicStopReasonPauseTurn       = "pause_turn"
+)
+
+// anthropicFinishReason maps a stop reason. Unknown values are surfaced as an
+// upstream error rather than being flattened to "stop", which would report a
+// truncated or refused generation as a normal completion.
+func anthropicFinishReason(stopReason string, hasToolCalls bool) (string, error) {
+	switch stopReason {
+	case anthropicStopReasonToolUse:
+		return openAIFinishReasonToolCalls, nil
+	case anthropicStopReasonPauseTurn:
+		// A paused server-tool loop expects the assistant content to be replayed
+		// verbatim so the provider can resume it. That is not something an
+		// OpenAI-shaped client can do, and reporting tool_calls would tell the
+		// client to run a tool that was never requested.
+		return "", unsupportedCapabilityError("provider paused a server-side tool loop, which this route cannot resume")
+	case anthropicStopReasonEndTurn, anthropicStopReasonStopSequence:
+		if hasToolCalls {
+			return openAIFinishReasonToolCalls, nil
+		}
+		return openAIFinishReasonStop, nil
+	case anthropicStopReasonMaxTokens, anthropicStopReasonContextExceeded:
+		return openAIFinishReasonLength, nil
+	case anthropicStopReasonRefusal:
+		return openAIFinishReasonContentFilter, nil
+	case "":
+		// Streaming responses report the stop reason in message_delta; a
+		// non-streaming body without one is still in flight or malformed.
+		if hasToolCalls {
+			return openAIFinishReasonToolCalls, nil
+		}
+		return openAIFinishReasonStop, nil
+	default:
+		return "", invalidProviderResponseError(fmt.Sprintf("provider returned an unrecognized stop_reason %q", stopReason))
+	}
+}
+
+// openAIFinishReasonToAnthropic is deliberately lenient where
+// anthropicFinishReason is strict. It serves a downstream Anthropic client that
+// has already been handed content, so there is no point failing the response
+// over a reason string: an unknown value degrades to end_turn. Tool calls
+// present in the response outrank every reason, because the client still has to
+// be told to run them.
+func openAIFinishReasonToAnthropic(reason string, hasTools bool) string {
+	if hasTools || reason == openAIFinishReasonToolCalls || reason == openAIFinishReasonFunctionCall {
+		return anthropicStopReasonToolUse
+	}
+	switch reason {
+	case openAIFinishReasonLength:
+		return anthropicStopReasonMaxTokens
+	case openAIFinishReasonStop, "":
+		return anthropicStopReasonEndTurn
+	case openAIFinishReasonContentFilter:
+		return anthropicStopReasonRefusal
+	default:
+		return anthropicStopReasonEndTurn
+	}
+}

--- a/backend/internal/server/provider_finish_reason_test.go
+++ b/backend/internal/server/provider_finish_reason_test.go
@@ -1,0 +1,128 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// The two finish-reason directions are golden-locked rather than round-tripped:
+// the mapping is lossy on purpose. end_turn and stop_sequence both collapse to
+// "stop", and max_tokens and model_context_window_exceeded both collapse to
+// "length", so feeding an output back through the other direction does not
+// return the original value. Each direction is pinned to its own table instead.
+
+func TestAnthropicFinishReasonGolden(t *testing.T) {
+	cases := []struct {
+		stopReason   string
+		hasToolCalls bool
+		want         string
+	}{
+		{stopReason: "", hasToolCalls: false, want: "stop"},
+		{stopReason: "", hasToolCalls: true, want: "tool_calls"},
+		{stopReason: "end_turn", hasToolCalls: false, want: "stop"},
+		{stopReason: "end_turn", hasToolCalls: true, want: "tool_calls"},
+		{stopReason: "stop_sequence", hasToolCalls: false, want: "stop"},
+		{stopReason: "stop_sequence", hasToolCalls: true, want: "tool_calls"},
+		{stopReason: "max_tokens", hasToolCalls: false, want: "length"},
+		{stopReason: "max_tokens", hasToolCalls: true, want: "length"},
+		{stopReason: "model_context_window_exceeded", hasToolCalls: false, want: "length"},
+		{stopReason: "model_context_window_exceeded", hasToolCalls: true, want: "length"},
+		{stopReason: "tool_use", hasToolCalls: false, want: "tool_calls"},
+		{stopReason: "tool_use", hasToolCalls: true, want: "tool_calls"},
+		{stopReason: "refusal", hasToolCalls: false, want: "content_filter"},
+		{stopReason: "refusal", hasToolCalls: true, want: "content_filter"},
+	}
+	for _, tc := range cases {
+		got, err := anthropicFinishReason(tc.stopReason, tc.hasToolCalls)
+		if err != nil {
+			t.Fatalf("anthropicFinishReason(%q, %v) failed: %v", tc.stopReason, tc.hasToolCalls, err)
+		}
+		if got != tc.want {
+			t.Fatalf("anthropicFinishReason(%q, %v) = %q, want %q", tc.stopReason, tc.hasToolCalls, got, tc.want)
+		}
+	}
+}
+
+// A paused server-side tool loop and an unrecognized stop reason are the two
+// values this direction refuses to map. Both keep their own classification: the
+// pause is a capability gap another candidate may cover, the unknown value is a
+// malformed upstream response.
+func TestAnthropicFinishReasonGoldenErrors(t *testing.T) {
+	cases := []struct {
+		stopReason      string
+		wantStatus      int
+		wantCode        string
+		wantDisposition ProviderErrorDisposition
+	}{
+		{
+			stopReason:      "pause_turn",
+			wantStatus:      http.StatusNotImplemented,
+			wantCode:        "provider_capability_not_supported",
+			wantDisposition: ProviderErrorModelUnsupported,
+		},
+		{
+			stopReason: "something_new",
+			wantStatus: http.StatusBadGateway,
+			wantCode:   "provider_invalid_response",
+		},
+	}
+	for _, tc := range cases {
+		for _, hasToolCalls := range []bool{false, true} {
+			got, err := anthropicFinishReason(tc.stopReason, hasToolCalls)
+			if err == nil {
+				t.Fatalf("anthropicFinishReason(%q, %v) = %q, want an error", tc.stopReason, hasToolCalls, got)
+			}
+			if got != "" {
+				t.Fatalf("anthropicFinishReason(%q, %v) returned %q alongside an error", tc.stopReason, hasToolCalls, got)
+			}
+			httpErr := AsHTTPError(err)
+			if httpErr == nil || httpErr.Status != tc.wantStatus || httpErr.Code != tc.wantCode {
+				t.Fatalf("anthropicFinishReason(%q, %v) error = %+v, want %d/%s",
+					tc.stopReason, hasToolCalls, httpErr, tc.wantStatus, tc.wantCode)
+			}
+			var invocation *ProviderInvocationError
+			if errors.As(err, &invocation) {
+				if invocation.Disposition != tc.wantDisposition {
+					t.Fatalf("anthropicFinishReason(%q, %v) disposition = %q, want %q",
+						tc.stopReason, hasToolCalls, invocation.Disposition, tc.wantDisposition)
+				}
+			} else if tc.wantDisposition != "" {
+				t.Fatalf("anthropicFinishReason(%q, %v) lost disposition %q", tc.stopReason, hasToolCalls, tc.wantDisposition)
+			}
+		}
+	}
+}
+
+// The reverse direction is deliberately lenient where the forward one is strict:
+// it never fails. An unknown reason degrades to end_turn, and observed tool calls
+// outrank every reason including content_filter, because the Anthropic client has
+// to be told to run the tools the response already carries.
+func TestOpenAIFinishReasonToAnthropicGolden(t *testing.T) {
+	cases := []struct {
+		reason   string
+		hasTools bool
+		want     string
+	}{
+		{reason: "", hasTools: false, want: "end_turn"},
+		{reason: "", hasTools: true, want: "tool_use"},
+		{reason: "stop", hasTools: false, want: "end_turn"},
+		{reason: "stop", hasTools: true, want: "tool_use"},
+		{reason: "length", hasTools: false, want: "max_tokens"},
+		{reason: "length", hasTools: true, want: "tool_use"},
+		{reason: "tool_calls", hasTools: false, want: "tool_use"},
+		{reason: "tool_calls", hasTools: true, want: "tool_use"},
+		// The legacy function_call reason is mapped like tool_calls.
+		{reason: "function_call", hasTools: false, want: "tool_use"},
+		{reason: "function_call", hasTools: true, want: "tool_use"},
+		{reason: "content_filter", hasTools: false, want: "refusal"},
+		{reason: "content_filter", hasTools: true, want: "tool_use"},
+		{reason: "something_new", hasTools: false, want: "end_turn"},
+		{reason: "something_new", hasTools: true, want: "tool_use"},
+	}
+	for _, tc := range cases {
+		if got := openAIFinishReasonToAnthropic(tc.reason, tc.hasTools); got != tc.want {
+			t.Fatalf("openAIFinishReasonToAnthropic(%q, %v) = %q, want %q", tc.reason, tc.hasTools, got, tc.want)
+		}
+	}
+}

--- a/backend/internal/server/provider_gemini_convert.go
+++ b/backend/internal/server/provider_gemini_convert.go
@@ -453,13 +453,13 @@ func geminiFinishReason(reason string, hasToolCalls bool) (string, error) {
 	switch reason {
 	case "STOP", "":
 		if hasToolCalls {
-			return "tool_calls", nil
+			return openAIFinishReasonToolCalls, nil
 		}
-		return "stop", nil
+		return openAIFinishReasonStop, nil
 	case "MAX_TOKENS":
-		return "length", nil
+		return openAIFinishReasonLength, nil
 	case "SAFETY", "RECITATION", "BLOCKLIST", "PROHIBITED_CONTENT", "SPII", "IMAGE_SAFETY":
-		return "content_filter", nil
+		return openAIFinishReasonContentFilter, nil
 	case "MALFORMED_FUNCTION_CALL", "UNEXPECTED_TOOL_CALL", "MISSING_THOUGHT_SIGNATURE", "MALFORMED_RESPONSE":
 		return "", invalidProviderResponseError(fmt.Sprintf("Gemini reported a protocol failure: %s", reason))
 	default:

--- a/backend/internal/server/provider_openai_core_test.go
+++ b/backend/internal/server/provider_openai_core_test.go
@@ -1,0 +1,487 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// capturedRequest is what an upstream saw, recorded before the handler answers.
+type capturedRequest struct {
+	method      string
+	escapedPath string
+	rawQuery    string
+	header      http.Header
+	body        map[string]any
+}
+
+// chatUpstream answers one non-streaming chat or embeddings call and records the
+// request the adapter built.
+func chatUpstream(t *testing.T, captured *capturedRequest) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.method = r.Method
+		captured.escapedPath = r.URL.EscapedPath()
+		captured.rawQuery = r.URL.RawQuery
+		captured.header = r.Header.Clone()
+		decodeFixtureRequest(t, r.Body, &captured.body)
+		w.Header().Set("content-type", "application/json")
+		writeFixture(t, w, `{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{}}`)
+	}))
+}
+
+func azureProvider(baseURL string, apiVersion string) Provider {
+	provider := Provider{Type: ProviderAzureOpenAI, BaseURL: baseURL, APIKey: "azure-key"}
+	if apiVersion != "" {
+		provider.Options = map[string]string{"api_version": apiVersion}
+	}
+	return provider
+}
+
+func simpleChatRequest() ChatCompletionRequest {
+	return ChatCompletionRequest{Model: "gateway-model", Messages: []ChatMessage{{Role: "user", Content: "hi"}}}
+}
+
+// Azure addresses a deployment by name in the path, so a deployment containing a
+// slash, a space or a percent sign must not be able to reshape the URL.
+func TestAzureOpenAIAdapterChatEscapesDeploymentAndAPIVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		deployment string
+		apiVersion string
+		wantPath   string
+		wantQuery  string
+	}{
+		{
+			name:       "default api version",
+			deployment: "gpt-4o",
+			wantPath:   "/openai/deployments/gpt-4o/chat/completions",
+			wantQuery:  "api-version=" + azureOpenAIDefaultAPIVersion,
+		},
+		{
+			name:       "slash in deployment",
+			deployment: "team/gpt-4o",
+			apiVersion: "2025-01-01-preview",
+			wantPath:   "/openai/deployments/team%2Fgpt-4o/chat/completions",
+			wantQuery:  "api-version=2025-01-01-preview",
+		},
+		{
+			name:       "space in deployment",
+			deployment: "gpt 4o",
+			apiVersion: "2025-01-01-preview",
+			wantPath:   "/openai/deployments/gpt%204o/chat/completions",
+			wantQuery:  "api-version=2025-01-01-preview",
+		},
+		{
+			name:       "percent in deployment",
+			deployment: "gpt%4o",
+			apiVersion: "2025-01-01-preview",
+			wantPath:   "/openai/deployments/gpt%254o/chat/completions",
+			wantQuery:  "api-version=2025-01-01-preview",
+		},
+		{
+			name:       "api version cannot add query parameters",
+			deployment: "gpt-4o",
+			apiVersion: "2025-01-01-preview&api-key=leak",
+			wantPath:   "/openai/deployments/gpt-4o/chat/completions",
+			wantQuery:  "api-version=2025-01-01-preview%26api-key%3Dleak",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured capturedRequest
+			upstream := chatUpstream(t, &captured)
+			defer upstream.Close()
+
+			adapter := AzureOpenAIAdapter{Client: upstream.Client()}
+			_, _, err := adapter.Chat(context.Background(), azureProvider(upstream.URL, tt.apiVersion), tt.deployment, simpleChatRequest())
+			if err != nil {
+				t.Fatalf("Chat: %v", err)
+			}
+
+			if captured.method != http.MethodPost {
+				t.Fatalf("method = %s, want POST", captured.method)
+			}
+			if captured.escapedPath != tt.wantPath {
+				t.Fatalf("path = %q, want %q", captured.escapedPath, tt.wantPath)
+			}
+			if captured.rawQuery != tt.wantQuery {
+				t.Fatalf("query = %q, want %q", captured.rawQuery, tt.wantQuery)
+			}
+			// The deployment names the URL; the body still carries the provider model.
+			if captured.body["model"] != tt.deployment {
+				t.Fatalf("body model = %v, want %q", captured.body["model"], tt.deployment)
+			}
+		})
+	}
+}
+
+// Azure authenticates with api-key and has never forwarded Provider.Headers or
+// the OpenAI account headers. Sharing request machinery with the OpenAI adapter
+// must not start sending either.
+func TestAzureOpenAIAdapterSendsOnlyAzureHeaders(t *testing.T) {
+	var captured capturedRequest
+	upstream := chatUpstream(t, &captured)
+	defer upstream.Close()
+
+	provider := azureProvider(upstream.URL, "")
+	provider.Headers = map[string]string{"x-custom": "forwarded-by-openai-only"}
+	provider.Options = map[string]string{
+		"organization_id":   "org-1",
+		"openai_project_id": "proj-1",
+		"account_id":        "acct-1",
+	}
+
+	adapter := AzureOpenAIAdapter{Client: upstream.Client()}
+	if _, _, err := adapter.Chat(context.Background(), provider, "gpt-4o", simpleChatRequest()); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if got := captured.header.Get("api-key"); got != "azure-key" {
+		t.Fatalf("api-key = %q, want azure-key", got)
+	}
+	if got := captured.header.Get("content-type"); got != "application/json" {
+		t.Fatalf("content-type = %q, want application/json", got)
+	}
+	for _, name := range []string{"authorization", "x-custom", "OpenAI-Organization", "OpenAI-Project", "X-TokenHub-Upstream-Account"} {
+		if got := captured.header.Get(name); got != "" {
+			t.Fatalf("Azure request carried %s = %q", name, got)
+		}
+	}
+}
+
+// An empty API key still sets the header, which is what makes a misconfigured
+// deployment fail at Azure with its own error rather than silently anonymously.
+func TestAzureOpenAIAdapterSetsAPIKeyHeaderEvenWhenEmpty(t *testing.T) {
+	var captured capturedRequest
+	upstream := chatUpstream(t, &captured)
+	defer upstream.Close()
+
+	provider := azureProvider(upstream.URL, "")
+	provider.APIKey = ""
+
+	adapter := AzureOpenAIAdapter{Client: upstream.Client()}
+	if _, _, err := adapter.Chat(context.Background(), provider, "gpt-4o", simpleChatRequest()); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if _, present := captured.header["Api-Key"]; !present {
+		t.Fatalf("api-key header was omitted: %v", captured.header)
+	}
+}
+
+func TestAzureOpenAIAdapterEmbeddingsUsesDeploymentURL(t *testing.T) {
+	var captured capturedRequest
+	upstream := chatUpstream(t, &captured)
+	defer upstream.Close()
+
+	adapter := AzureOpenAIAdapter{Client: upstream.Client()}
+	_, _, err := adapter.Embeddings(context.Background(), azureProvider(upstream.URL, ""), "text-embed", EmbeddingsRequest{Model: "gateway-embed", Input: "hi"})
+	if err != nil {
+		t.Fatalf("Embeddings: %v", err)
+	}
+
+	if captured.escapedPath != "/openai/deployments/text-embed/embeddings" {
+		t.Fatalf("path = %q", captured.escapedPath)
+	}
+	if captured.body["model"] != "text-embed" {
+		t.Fatalf("body model = %v, want text-embed", captured.body["model"])
+	}
+}
+
+// reasoning_content is a TokenHub extension that only DeepSeek understands, so
+// Azure must keep stripping it along with the other gateway-local fields.
+func TestAzureOpenAIAdapterDoesNotForwardGatewayExtensions(t *testing.T) {
+	var captured capturedRequest
+	upstream := chatUpstream(t, &captured)
+	defer upstream.Close()
+
+	adapter := AzureOpenAIAdapter{Client: upstream.Client()}
+	_, _, err := adapter.Chat(context.Background(), azureProvider(upstream.URL, ""), "gpt-4o", ChatCompletionRequest{
+		Model: "gateway-model",
+		Messages: []ChatMessage{{
+			Role:                     "assistant",
+			Content:                  "answer",
+			ReasoningContent:         "thinking",
+			ReasoningSignature:       "anthropic:sig",
+			RedactedReasoningContent: "opaque",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	messages, _ := captured.body["messages"].([]any)
+	if len(messages) == 0 {
+		t.Fatalf("no messages were forwarded: %v", captured.body)
+	}
+	message, _ := messages[0].(map[string]any)
+	for _, field := range []string{"reasoning_content", "reasoning_signature", "redacted_reasoning_content"} {
+		if _, present := message[field]; present {
+			t.Fatalf("%s must remain gateway-local: %v", field, message)
+		}
+	}
+}
+
+// Stripping is the Azure adapter's own rule, not something inferred from the
+// provider type: nothing enforces which types an adapter is registered under,
+// so a provider row typed "deepseek" must not talk the Azure adapter into
+// forwarding the extension.
+func TestAzureOpenAIAdapterStripsReasoningContentForAnyProviderType(t *testing.T) {
+	var captured capturedRequest
+	upstream := chatUpstream(t, &captured)
+	defer upstream.Close()
+
+	provider := azureProvider(upstream.URL, "")
+	provider.Type = "deepseek"
+
+	adapter := AzureOpenAIAdapter{Client: upstream.Client()}
+	_, _, err := adapter.Chat(context.Background(), provider, "gpt-4o", ChatCompletionRequest{
+		Model:    "gateway-model",
+		Messages: []ChatMessage{{Role: "assistant", Content: "answer", ReasoningContent: "thinking"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	messages, _ := captured.body["messages"].([]any)
+	message, _ := messages[0].(map[string]any)
+	if _, present := message["reasoning_content"]; present {
+		t.Fatalf("Azure forwarded reasoning_content: %v", message)
+	}
+}
+
+func TestAzureOpenAIAdapterRequiresBaseURL(t *testing.T) {
+	adapter := AzureOpenAIAdapter{}
+	_, _, err := adapter.Chat(context.Background(), Provider{Type: ProviderAzureOpenAI, APIKey: "azure-key"}, "gpt-4o", simpleChatRequest())
+
+	httpErr := AsHTTPError(err)
+	if httpErr == nil || httpErr.Message != "Azure OpenAI base_url is required" {
+		t.Fatalf("error = %v, want the Azure-specific misconfiguration message", err)
+	}
+	if httpErr.Code != "provider_not_configured" {
+		t.Fatalf("code = %q, want provider_not_configured", httpErr.Code)
+	}
+}
+
+// /v1/responses dispatches on the adapter's Responses method without consulting
+// the capability registry, so Azure's explicit 501 is the only thing standing
+// between a caller and a request to an endpoint Azure deployments do not serve.
+func TestAzureOpenAIAdapterResponsesIsNotImplemented(t *testing.T) {
+	adapter := AzureOpenAIAdapter{}
+	_, _, err := adapter.Responses(context.Background(), azureProvider("https://example.invalid", ""), "gpt-4o", ResponsesRequest{Model: "gateway-model"})
+
+	httpErr := AsHTTPError(err)
+	if httpErr == nil || httpErr.Status != 501 {
+		t.Fatalf("error = %v, want a 501", err)
+	}
+	if httpErr.Code != "provider_capability_not_supported" {
+		t.Fatalf("code = %q, want provider_capability_not_supported", httpErr.Code)
+	}
+	if httpErr.Message != "Azure responses adapter is not implemented in MVP" {
+		t.Fatalf("message = %q", httpErr.Message)
+	}
+}
+
+// The streaming half of the same rule: the responses streaming path picks its
+// adapter by interface, so Azure must not satisfy ResponsesStreamOpener.
+func TestAzureOpenAIAdapterIsNotAResponsesStreamOpener(t *testing.T) {
+	var adapter any = AzureOpenAIAdapter{}
+	if _, ok := adapter.(ResponsesStreamOpener); ok {
+		t.Fatal("AzureOpenAIAdapter must not implement ResponsesStreamOpener: /v1/responses would stream from an endpoint Azure does not serve")
+	}
+	if _, ok := adapter.(ProviderAdapter); !ok {
+		t.Fatal("AzureOpenAIAdapter must still be a ProviderAdapter")
+	}
+}
+
+// Streaming runs on StreamClient precisely so the non-streaming total deadline
+// cannot truncate a live stream. Azure shares that machinery and must keep the
+// same policy.
+func TestAzureChatStreamOutlivesTheNonStreamingTimeout(t *testing.T) {
+	upstream := sseUpstream(t, 0, []time.Duration{80 * time.Millisecond, 80 * time.Millisecond, 80 * time.Millisecond})
+	defer upstream.Close()
+
+	client := upstream.Client()
+	client.Timeout = 100 * time.Millisecond
+	adapter := AzureOpenAIAdapter{
+		Client:            client,
+		StreamClient:      &http.Client{Transport: client.Transport},
+		StreamIdleTimeout: time.Second,
+	}
+
+	var out bytes.Buffer
+	_, err := adapter.ChatStream(context.Background(), azureProvider(upstream.URL, ""), "gpt-4o", simpleChatRequest(), &out)
+	if err != nil {
+		t.Fatalf("an active Azure stream was cut short: %v", err)
+	}
+	if !strings.Contains(out.String(), "[DONE]") {
+		t.Fatalf("stream was truncated before [DONE]: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "chunk-2") {
+		t.Fatalf("stream lost its last chunk: %q", out.String())
+	}
+}
+
+func TestAzureOpenAIAdapterChatStreamUsesDeploymentURL(t *testing.T) {
+	var captured capturedRequest
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.escapedPath = r.URL.EscapedPath()
+		captured.rawQuery = r.URL.RawQuery
+		captured.header = r.Header.Clone()
+		decodeFixtureRequest(t, r.Body, &captured.body)
+		w.Header().Set("content-type", "text/event-stream")
+		writeFixture(t, w, "data: [DONE]\n\n")
+	}))
+	defer upstream.Close()
+
+	adapter := AzureOpenAIAdapter{Client: upstream.Client()}
+	var out bytes.Buffer
+	if _, err := adapter.ChatStream(context.Background(), azureProvider(upstream.URL, ""), "gpt-4o", simpleChatRequest(), &out); err != nil {
+		t.Fatalf("ChatStream: %v", err)
+	}
+
+	if captured.escapedPath != "/openai/deployments/gpt-4o/chat/completions" {
+		t.Fatalf("path = %q", captured.escapedPath)
+	}
+	if captured.rawQuery != "api-version="+azureOpenAIDefaultAPIVersion {
+		t.Fatalf("query = %q", captured.rawQuery)
+	}
+	if captured.body["stream"] != true {
+		t.Fatalf("stream flag = %v, want true", captured.body["stream"])
+	}
+	streamOptions, _ := captured.body["stream_options"].(map[string]any)
+	if streamOptions["include_usage"] != true {
+		t.Fatalf("include_usage = %v, want true", streamOptions["include_usage"])
+	}
+	if got := captured.header.Get("api-key"); got != "azure-key" {
+		t.Fatalf("api-key = %q", got)
+	}
+}
+
+// Adapters are initialised as struct literals across the repository, so the zero
+// value has to reach an upstream on its own: no client and no configured
+// request builder.
+func TestZeroValueOpenAICompatibleAdapterCallsUpstream(t *testing.T) {
+	var captured capturedRequest
+	upstream := chatUpstream(t, &captured)
+	defer upstream.Close()
+
+	adapter := OpenAICompatibleAdapter{}
+	provider := Provider{Type: ProviderOpenAICompatible, BaseURL: upstream.URL, APIKey: "openai-key"}
+	if _, _, err := adapter.Chat(context.Background(), provider, "model-x", simpleChatRequest()); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	if captured.escapedPath != "/chat/completions" {
+		t.Fatalf("path = %q, want /chat/completions", captured.escapedPath)
+	}
+	if got := captured.header.Get("authorization"); got != "Bearer openai-key" {
+		t.Fatalf("authorization = %q", got)
+	}
+}
+
+func TestOpenAICompatibleAdapterSendsAccountAndProviderHeaders(t *testing.T) {
+	var captured capturedRequest
+	upstream := chatUpstream(t, &captured)
+	defer upstream.Close()
+
+	provider := Provider{
+		Type:    ProviderOpenAICompatible,
+		BaseURL: upstream.URL,
+		APIKey:  "openai-key",
+		Headers: map[string]string{"x-custom": "kept"},
+		Options: map[string]string{
+			"organization_id":   "org-1",
+			"openai_project_id": "proj-1",
+			"account_id":        "acct-1",
+		},
+	}
+
+	adapter := OpenAICompatibleAdapter{Client: upstream.Client()}
+	if _, _, err := adapter.Chat(context.Background(), provider, "model-x", simpleChatRequest()); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+
+	for name, want := range map[string]string{
+		"authorization":               "Bearer openai-key",
+		"OpenAI-Organization":         "org-1",
+		"OpenAI-Project":              "proj-1",
+		"X-TokenHub-Upstream-Account": "acct-1",
+		"x-custom":                    "kept",
+	} {
+		if got := captured.header.Get(name); got != want {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestOpenAICompatibleAdapterRequiresBaseURL(t *testing.T) {
+	adapter := OpenAICompatibleAdapter{}
+	_, _, err := adapter.Chat(context.Background(), Provider{Type: ProviderOpenAICompatible, APIKey: "openai-key"}, "model-x", simpleChatRequest())
+
+	httpErr := AsHTTPError(err)
+	if httpErr == nil || httpErr.Message != "Provider base_url is required" {
+		t.Fatalf("error = %v, want the provider misconfiguration message", err)
+	}
+}
+
+// closeTrackingBody reports whether the response body was closed.
+type closeTrackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+func TestCheckProviderResponseClassifiesAndBoundsTheBody(t *testing.T) {
+	body := &closeTrackingBody{Reader: strings.NewReader(strings.Repeat("x", providerErrorBodyPrefix*3))}
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Retry-After": []string{"7"}},
+		Body:       body,
+	}
+
+	err := checkProviderResponse(resp)
+	if err == nil {
+		t.Fatal("a 429 must be reported as a provider error")
+	}
+	httpErr := AsHTTPError(err)
+	if httpErr.Code != "provider_rate_limited" || httpErr.UpstreamStatus != http.StatusTooManyRequests {
+		t.Fatalf("error = %+v, want a rate-limit classification", httpErr)
+	}
+	if len(httpErr.Message) != providerErrorBodyPrefix {
+		t.Fatalf("message length = %d, want the body read to stop at %d", len(httpErr.Message), providerErrorBodyPrefix)
+	}
+	var invocation *ProviderInvocationError
+	if !errors.As(err, &invocation) || invocation.RetryAfter != 7*time.Second {
+		t.Fatalf("retry-after was lost: %v", err)
+	}
+	if !body.closed {
+		t.Fatal("a failed response body must be closed")
+	}
+}
+
+// The success path hands the body back still open, because the caller streams or
+// decodes it.
+func TestCheckProviderResponseLeavesSuccessfulResponsesAlone(t *testing.T) {
+	body := &closeTrackingBody{Reader: strings.NewReader("{}")}
+	resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: body}
+
+	if err := checkProviderResponse(resp); err != nil {
+		t.Fatalf("checkProviderResponse: %v", err)
+	}
+	if body.closed {
+		t.Fatal("a successful response body must stay open for the caller")
+	}
+}

--- a/backend/internal/server/providers.go
+++ b/backend/internal/server/providers.go
@@ -159,6 +159,133 @@ func (a MockAdapter) Embeddings(ctx context.Context, provider Provider, provider
 	}, usage, nil
 }
 
+// preservesReasoningContent reports whether an OpenAI-compatible upstream
+// understands the reasoning_content it produced being handed back on the next
+// turn. DeepSeek does and needs it for multi-turn reasoning; for everyone else
+// the field is a TokenHub-local extension and is stripped.
+func preservesReasoningContent(provider Provider) bool {
+	return provider.Type == "deepseek"
+}
+
+// dropsReasoningContent is the Azure policy: reasoning_content never reaches a
+// deployment. It is stated as the adapter's own rule rather than inferred from
+// the provider type, because nothing enforces which types an adapter is
+// registered under and Azure's answer does not depend on that.
+func dropsReasoningContent(Provider) bool {
+	return false
+}
+
+// providerRequestBuilder builds the upstream request for one OpenAI-shaped call.
+// The URL and the auth headers are the whole wire-format difference between the
+// OpenAI-compatible and Azure OpenAI adapters; everything around it — sending,
+// failure checking, decoding, streaming — is shared by openAICompatibleCore.
+type providerRequestBuilder func(ctx context.Context, provider Provider, method string, model string, endpoint string, body []byte) (*http.Request, error)
+
+// openAICompatibleCore is the request machinery the OpenAI-compatible and Azure
+// OpenAI adapters share. The adapters hold it through a core() method rather
+// than embedding it, and it stays unexported, because embedding would also hand
+// AzureOpenAIAdapter the OpenAI adapter's Responses and OpenResponses methods:
+// /v1/responses dispatches on those interfaces without consulting the
+// capability registry, so Azure would stop answering 501 and start calling an
+// endpoint Azure deployments do not serve.
+type openAICompatibleCore struct {
+	client *http.Client
+	// streamClient carries no total deadline; see provider_stream_timeout.go.
+	// Streaming calls fall back to client when it is unset.
+	streamClient      *http.Client
+	streamIdleTimeout time.Duration
+	// baseURLRequired is the misconfiguration reported when the provider has no
+	// base URL. Both adapters require one; only the wording differs.
+	baseURLRequired string
+	// preserveReasoningContent is the adapter's rule for whether TokenHub's
+	// reasoning_content extension may be forwarded to this provider.
+	preserveReasoningContent func(provider Provider) bool
+	build                    providerRequestBuilder
+}
+
+func (c openAICompatibleCore) chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
+	req = withoutGatewayExtensions(req, c.preserveReasoningContent(provider))
+	req.Model = providerModel
+	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
+	var body map[string]any
+	if err := c.doJSON(ctx, provider, http.MethodPost, providerModel, "/chat/completions", req, &body); err != nil {
+		return nil, Usage{}, err
+	}
+	return body, usageFromMap(body), nil
+}
+
+func (c openAICompatibleCore) chatStream(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest, w io.Writer) (Usage, error) {
+	req = withoutGatewayExtensions(req, c.preserveReasoningContent(provider))
+	req.Model = providerModel
+	req.Stream = true
+	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
+	req = includeOpenAIStreamUsage(req)
+	resp, err := c.doRaw(ctx, provider, http.MethodPost, providerModel, "/chat/completions", req, true)
+	if err != nil {
+		return Usage{}, err
+	}
+	defer resp.Body.Close()
+	return copyOpenAIStreamAndUsage(w, resp.Body)
+}
+
+func (c openAICompatibleCore) embeddings(ctx context.Context, provider Provider, providerModel string, req EmbeddingsRequest) (any, Usage, error) {
+	req.Model = providerModel
+	var body map[string]any
+	if err := c.doJSON(ctx, provider, http.MethodPost, providerModel, "/embeddings", req, &body); err != nil {
+		return nil, Usage{}, err
+	}
+	return body, usageFromMap(body), nil
+}
+
+func (c openAICompatibleCore) doJSON(ctx context.Context, provider Provider, method string, model string, endpoint string, payload any, target any) error {
+	resp, err := c.doRaw(ctx, provider, method, model, endpoint, payload, false)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+func (c openAICompatibleCore) doRaw(ctx context.Context, provider Provider, method string, model string, endpoint string, payload any, stream bool) (*http.Response, error) {
+	if provider.BaseURL == "" {
+		return nil, newProviderMisconfigured(c.baseURLRequired)
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	req, err := c.build(ctx, provider, method, model, endpoint, body)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := sendUpstream(c.client, c.streamClient, c.streamIdleTimeout, req, stream)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkProviderResponse(resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// openAICompatibleRequest addresses an OpenAI-compatible base URL directly: the
+// model travels in the body, so the model argument is unused here.
+func openAICompatibleRequest(ctx context.Context, provider Provider, method string, _ string, endpoint string, body []byte) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, joinURL(provider.BaseURL, endpoint), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("content-type", "application/json")
+	if provider.APIKey != "" {
+		req.Header.Set("authorization", "Bearer "+provider.APIKey)
+	}
+	applyOpenAICompatibleAccountHeaders(req, provider)
+	for key, value := range provider.Headers {
+		req.Header.Set(key, value)
+	}
+	return req, nil
+}
+
 type OpenAICompatibleAdapter struct {
 	Client *http.Client
 	// StreamClient carries no total deadline; see provider_stream_timeout.go.
@@ -167,29 +294,23 @@ type OpenAICompatibleAdapter struct {
 	StreamIdleTimeout time.Duration
 }
 
-func (a OpenAICompatibleAdapter) Chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
-	req = withoutGatewayExtensions(req, provider.Type == "deepseek")
-	req.Model = providerModel
-	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
-	var body map[string]any
-	if err := a.doJSON(ctx, provider, http.MethodPost, "/chat/completions", req, &body); err != nil {
-		return nil, Usage{}, err
+func (a OpenAICompatibleAdapter) core() openAICompatibleCore {
+	return openAICompatibleCore{
+		client:                   a.Client,
+		streamClient:             a.StreamClient,
+		streamIdleTimeout:        a.StreamIdleTimeout,
+		baseURLRequired:          "Provider base_url is required",
+		preserveReasoningContent: preservesReasoningContent,
+		build:                    openAICompatibleRequest,
 	}
-	return body, usageFromMap(body), nil
+}
+
+func (a OpenAICompatibleAdapter) Chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
+	return a.core().chat(ctx, provider, providerModel, req)
 }
 
 func (a OpenAICompatibleAdapter) ChatStream(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest, w io.Writer) (Usage, error) {
-	req = withoutGatewayExtensions(req, provider.Type == "deepseek")
-	req.Model = providerModel
-	req.Stream = true
-	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
-	req = includeOpenAIStreamUsage(req)
-	resp, err := a.doRaw(ctx, provider, http.MethodPost, "/chat/completions", req, true)
-	if err != nil {
-		return Usage{}, err
-	}
-	defer resp.Body.Close()
-	return copyOpenAIStreamAndUsage(w, resp.Body)
+	return a.core().chatStream(ctx, provider, providerModel, req, w)
 }
 
 func (a OpenAICompatibleAdapter) Responses(ctx context.Context, provider Provider, providerModel string, req ResponsesRequest) (any, Usage, error) {
@@ -210,53 +331,15 @@ func (a OpenAICompatibleAdapter) OpenResponses(ctx context.Context, provider Pro
 }
 
 func (a OpenAICompatibleAdapter) Embeddings(ctx context.Context, provider Provider, providerModel string, req EmbeddingsRequest) (any, Usage, error) {
-	req.Model = providerModel
-	var body map[string]any
-	if err := a.doJSON(ctx, provider, http.MethodPost, "/embeddings", req, &body); err != nil {
-		return nil, Usage{}, err
-	}
-	return body, usageFromMap(body), nil
+	return a.core().embeddings(ctx, provider, providerModel, req)
 }
 
 func (a OpenAICompatibleAdapter) doJSON(ctx context.Context, provider Provider, method, endpoint string, payload any, target any) error {
-	resp, err := a.doRaw(ctx, provider, method, endpoint, payload, false)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	return json.NewDecoder(resp.Body).Decode(target)
+	return a.core().doJSON(ctx, provider, method, "", endpoint, payload, target)
 }
 
 func (a OpenAICompatibleAdapter) doRaw(ctx context.Context, provider Provider, method, endpoint string, payload any, stream bool) (*http.Response, error) {
-	if provider.BaseURL == "" {
-		return nil, newProviderMisconfigured("Provider base_url is required")
-	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequestWithContext(ctx, method, joinURL(provider.BaseURL, endpoint), bytes.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("content-type", "application/json")
-	if provider.APIKey != "" {
-		req.Header.Set("authorization", "Bearer "+provider.APIKey)
-	}
-	applyOpenAICompatibleAccountHeaders(req, provider)
-	for key, value := range provider.Headers {
-		req.Header.Set(key, value)
-	}
-	resp, err := sendUpstream(a.Client, a.StreamClient, a.StreamIdleTimeout, req, stream)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode >= 400 {
-		defer resp.Body.Close()
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, newProviderHTTPError(resp.StatusCode, resp.Header, data)
-	}
-	return resp, nil
+	return a.core().doRaw(ctx, provider, method, "", endpoint, payload, stream)
 }
 
 func applyOpenAICompatibleAccountHeaders(req *http.Request, provider Provider) {
@@ -274,6 +357,34 @@ func applyOpenAICompatibleAccountHeaders(req *http.Request, provider Provider) {
 	}
 }
 
+// azureOpenAIDefaultAPIVersion is used when the provider does not pin one.
+const azureOpenAIDefaultAPIVersion = "2024-02-15-preview"
+
+// azureOpenAIRequest addresses one Azure OpenAI deployment: the model names a
+// deployment in the path, the API version is a query parameter, and the key is
+// an api-key header rather than a bearer token. Provider.Headers are not applied
+// here — Azure has never forwarded them, and adding that now would change which
+// headers reach every existing deployment.
+func azureOpenAIRequest(ctx context.Context, provider Provider, method string, deployment string, endpoint string, body []byte) (*http.Request, error) {
+	apiVersion := provider.Options["api_version"]
+	if apiVersion == "" {
+		apiVersion = azureOpenAIDefaultAPIVersion
+	}
+	u := fmt.Sprintf("%s/openai/deployments/%s%s?api-version=%s", strings.TrimRight(provider.BaseURL, "/"), url.PathEscape(deployment), endpoint, url.QueryEscape(apiVersion))
+	req, err := http.NewRequestWithContext(ctx, method, u, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("api-key", provider.APIKey)
+	return req, nil
+}
+
+// AzureOpenAIAdapter speaks the OpenAI wire format against Azure deployments. It
+// shares openAICompatibleCore with OpenAICompatibleAdapter but stays a separate
+// type on purpose: it must not acquire that adapter's Responses or
+// OpenResponses, which the /v1/responses paths dispatch on directly. See
+// openAICompatibleCore.
 type AzureOpenAIAdapter struct {
 	Client *http.Client
 	// StreamClient carries no total deadline; see provider_stream_timeout.go.
@@ -282,29 +393,23 @@ type AzureOpenAIAdapter struct {
 	StreamIdleTimeout time.Duration
 }
 
-func (a AzureOpenAIAdapter) Chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
-	req = withoutGatewayExtensions(req, false)
-	req.Model = providerModel
-	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
-	var body map[string]any
-	if err := a.doJSON(ctx, provider, providerModel, "/chat/completions", req, &body); err != nil {
-		return nil, Usage{}, err
+func (a AzureOpenAIAdapter) core() openAICompatibleCore {
+	return openAICompatibleCore{
+		client:                   a.Client,
+		streamClient:             a.StreamClient,
+		streamIdleTimeout:        a.StreamIdleTimeout,
+		baseURLRequired:          "Azure OpenAI base_url is required",
+		preserveReasoningContent: dropsReasoningContent,
+		build:                    azureOpenAIRequest,
 	}
-	return body, usageFromMap(body), nil
+}
+
+func (a AzureOpenAIAdapter) Chat(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest) (any, Usage, error) {
+	return a.core().chat(ctx, provider, providerModel, req)
 }
 
 func (a AzureOpenAIAdapter) ChatStream(ctx context.Context, provider Provider, providerModel string, req ChatCompletionRequest, w io.Writer) (Usage, error) {
-	req = withoutGatewayExtensions(req, false)
-	req.Model = providerModel
-	req.Stream = true
-	req.ReasoningEffort = normalizedReasoningEffort(req.ReasoningEffort)
-	req = includeOpenAIStreamUsage(req)
-	resp, err := a.doRaw(ctx, provider, providerModel, "/chat/completions", req, true)
-	if err != nil {
-		return Usage{}, err
-	}
-	defer resp.Body.Close()
-	return copyOpenAIStreamAndUsage(w, resp.Body)
+	return a.core().chatStream(ctx, provider, providerModel, req, w)
 }
 
 func (a AzureOpenAIAdapter) Responses(ctx context.Context, provider Provider, providerModel string, req ResponsesRequest) (any, Usage, error) {
@@ -312,52 +417,7 @@ func (a AzureOpenAIAdapter) Responses(ctx context.Context, provider Provider, pr
 }
 
 func (a AzureOpenAIAdapter) Embeddings(ctx context.Context, provider Provider, providerModel string, req EmbeddingsRequest) (any, Usage, error) {
-	req.Model = providerModel
-	var body map[string]any
-	if err := a.doJSON(ctx, provider, providerModel, "/embeddings", req, &body); err != nil {
-		return nil, Usage{}, err
-	}
-	return body, usageFromMap(body), nil
-}
-
-func (a AzureOpenAIAdapter) doJSON(ctx context.Context, provider Provider, deployment string, endpoint string, payload any, target any) error {
-	resp, err := a.doRaw(ctx, provider, deployment, endpoint, payload, false)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	return json.NewDecoder(resp.Body).Decode(target)
-}
-
-func (a AzureOpenAIAdapter) doRaw(ctx context.Context, provider Provider, deployment string, endpoint string, payload any, stream bool) (*http.Response, error) {
-	apiVersion := provider.Options["api_version"]
-	if apiVersion == "" {
-		apiVersion = "2024-02-15-preview"
-	}
-	if provider.BaseURL == "" {
-		return nil, newProviderMisconfigured("Azure OpenAI base_url is required")
-	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return nil, err
-	}
-	u := fmt.Sprintf("%s/openai/deployments/%s%s?api-version=%s", strings.TrimRight(provider.BaseURL, "/"), url.PathEscape(deployment), endpoint, url.QueryEscape(apiVersion))
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("content-type", "application/json")
-	req.Header.Set("api-key", provider.APIKey)
-	resp, err := sendUpstream(a.Client, a.StreamClient, a.StreamIdleTimeout, req, stream)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode >= 400 {
-		defer resp.Body.Close()
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, newProviderHTTPError(resp.StatusCode, resp.Header, data)
-	}
-	return resp, nil
+	return a.core().embeddings(ctx, provider, providerModel, req)
 }
 
 type AnthropicAdapter struct {
@@ -462,10 +522,8 @@ func (a AnthropicAdapter) doRaw(ctx context.Context, provider Provider, endpoint
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode >= 400 {
-		defer resp.Body.Close()
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, newProviderHTTPError(resp.StatusCode, resp.Header, data)
+	if err := checkProviderResponse(resp); err != nil {
+		return nil, err
 	}
 	return resp, nil
 }
@@ -595,10 +653,8 @@ func (a GeminiAdapter) doRaw(ctx context.Context, provider Provider, model strin
 	if err != nil {
 		return nil, err
 	}
-	if resp.StatusCode >= 400 {
-		defer resp.Body.Close()
-		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, newProviderHTTPError(resp.StatusCode, resp.Header, data)
+	if err := checkProviderResponse(resp); err != nil {
+		return nil, err
 	}
 	return resp, nil
 }

--- a/backend/internal/server/providers.go
+++ b/backend/internal/server/providers.go
@@ -872,25 +872,6 @@ func geminiVariantIs(variant string, family string) bool {
 	return variant == family || strings.HasPrefix(variant, family+"-")
 }
 
-func anthropicUsage(body map[string]any) Usage {
-	usageMap, _ := body["usage"].(map[string]any)
-	uncachedInputTokens := int64FromAny(usageMap["input_tokens"])
-	cacheCreationInputTokens := int64FromAny(usageMap["cache_creation_input_tokens"])
-	cachedInputTokens := int64FromAny(usageMap["cache_read_input_tokens"])
-	usage := Usage{
-		// Anthropic reports the three input classes disjointly, so prompt tokens are
-		// their sum. Cache-creation tokens are also surfaced on their own field: they
-		// bill at a premium over base input, and without this they were folded into
-		// the total and lost, leaving CacheWriteInputTokens dead on this path.
-		PromptTokens:          uncachedInputTokens + cacheCreationInputTokens + cachedInputTokens,
-		CachedInputTokens:     cachedInputTokens,
-		CacheWriteInputTokens: cacheCreationInputTokens,
-		CompletionTokens:      int64FromAny(usageMap["output_tokens"]),
-	}
-	usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
-	return usage
-}
-
 func geminiUsage(body map[string]any) Usage {
 	usageMap, _ := body["usageMetadata"].(map[string]any)
 	reasoningTokens := int64FromAny(usageMap["thoughtsTokenCount"])


### PR DESCRIPTION
## Summary

Re-lands #117 and #119, whose content never reached `main`: they were merged into their stacked base branches (`fix/sse-parsing-bounds` and `refactor/provider-adapter-dedup` respectively) instead of `main` — the same stranding that hit #114. This PR cherry-picks both squash commits onto current `main` (zero conflicts) and re-verifies against the code merged since (#118, #121).

See #117 and #119 for the full change lists, review history, and compatibility notes; they apply unchanged.

## Related Issue

#117, #119 (content stranded on merged stacked branches)

## Changes

- Identical to #117: unexported `openAICompatibleCore` shared by the OpenAI and Azure adapters (Azure keeps its own type and explicit `Responses` 501), `checkProviderResponse` collapsing six identical response-check tails.
- Identical to #119: both finish-reason direction functions in `provider_finish_reason.go` with shared canonical constants and 32 golden assertions; `anthropicUsageFromRawMap` as the only Anthropic usage-snapshot parser.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

Re-run in full on top of current `main` (includes #118 and #121):

- `go test ./...": pass (server suite 58s). `go vet`: clean. `golangci-lint run ./...`: 0 issues.
- `node tools/check-source-lines.mjs`: pass (312 files, 2 frozen baselines). `git diff --check`: clean.
- Frontend untouched by these commits; no frontend re-run needed beyond CI.

## Compatibility, Security, and Operations

Same as #117/#119: internal-only refactors, no runtime behavior change; all mapping outputs, request bytes, and usage numbers are unchanged and test-pinned.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented. (Tests come along from #117/#119.)
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable. (None changed.)
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable. (No user-facing docs affected.)
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable. (Untouched.)
- [x] `git diff --check` passes.