### PR TITLE
fix(gateway): support native Codex image generation

### DIFF
--- a/backend/internal/server/image_generation.go
+++ b/backend/internal/server/image_generation.go
@@ -80,6 +80,12 @@ func (s *Server) handleImageGenerations(w http.ResponseWriter, r *http.Request) 
 		writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_request", err.Error()))
 		return
 	}
+	originator := strings.ToLower(strings.TrimSpace(r.Header.Get("originator")))
+	if strings.TrimSpace(request.Model) == openAIImageModelName &&
+		(strings.TrimSpace(r.Header.Get("x-codex-image-turn-id")) != "" || strings.HasPrefix(originator, "codex")) {
+		request.Model = codexImageModelName
+		request.ResponseFormat = "b64_json"
+	}
 	if err := normalizeImageGenerationRequest(&request); err != nil {
 		writeError(w, r, err)
 		return

--- a/backend/internal/server/image_generation_test.go
+++ b/backend/internal/server/image_generation_test.go
@@ -889,6 +889,88 @@ func TestImageQueueHonorsWorkerAndCapacityLimits(t *testing.T) {
 	}
 }
 
+func TestCodexImageRequestUsesSubscriptionCompatibleResponse(t *testing.T) {
+	imageBytes := realPNGFixture(t)
+	store := NewMemoryStore()
+	project := store.CreateProject(Project{Name: "Codex App Image Project"})
+	_, secret, err := store.CreateAPIKey(project.ID, APIKey{
+		Name:    "codex-app-image-key",
+		Allowed: []string{codexImageModelName},
+		Status:  StatusActive,
+	}, "thk_codex_app_image")
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := store.AddProvider(Provider{
+		ID: "prv_codex_app_image", Name: "Codex App Image", Type: ProviderOpenAICodex, Status: StatusActive, Healthy: true,
+	})
+	resource, err := store.AddProviderResource(ProviderResource{
+		ID: "rsrc_codex_app_image", ProviderID: provider.ID, Name: "Codex App Image Account",
+		ResourceType: ProviderResourceOpenAISubscription, Status: StatusActive, Healthy: true,
+		Options: map[string]string{codexImageCapabilityOption: codexImageCapabilitySupported},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.AddModel(Model{Name: codexImageModelName, Modality: "image", Status: StatusActive})
+
+	server := NewWithConfig(store, Config{
+		AdminToken: "test-admin-token", SecretKey: "codex-app-image-secret", ImageStorageDir: t.TempDir(),
+	})
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+	var selectedRoute RouteSelection
+	var selectedJob ImageJob
+	server.imageRunner = func(_ context.Context, route RouteSelection, job ImageJob) ([]byte, string, Usage, error) {
+		selectedRoute = route
+		selectedJob = job
+		return imageBytes, "", Usage{}, nil
+	}
+
+	markers := []struct {
+		name    string
+		headers map[string]string
+	}{
+		{name: "current originator", headers: map[string]string{"Originator": "codex_cli_rs"}},
+		{name: "image turn header", headers: map[string]string{"x-codex-image-turn-id": "turn_test"}},
+	}
+	for _, marker := range markers {
+		t.Run(marker.name, func(t *testing.T) {
+			selectedRoute = RouteSelection{}
+			selectedJob = ImageJob{}
+			response := doImageJSON(t, server.Handler(), http.MethodPost, "/v1/images/generations", map[string]any{
+				"model":      openAIImageModelName,
+				"prompt":     "Draw one red square.",
+				"background": "auto",
+				"quality":    "auto",
+				"size":       "auto",
+			}, secret, marker.headers)
+			if response.Code != http.StatusOK {
+				t.Fatalf("Codex image request: status=%d body=%s", response.Code, response.Body)
+			}
+			var payload struct {
+				Data []struct {
+					B64JSON string `json:"b64_json"`
+					URL     string `json:"url"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal([]byte(response.Body), &payload); err != nil {
+				t.Fatal(err)
+			}
+			if len(payload.Data) != 1 || payload.Data[0].B64JSON == "" || payload.Data[0].URL != "" {
+				t.Fatalf("Codex image response must contain b64_json and no URL: %s", response.Body)
+			}
+			decoded, err := base64.StdEncoding.DecodeString(payload.Data[0].B64JSON)
+			if err != nil || !bytes.Equal(decoded, imageBytes) {
+				t.Fatalf("Codex image response contains invalid image data: err=%v bytes=%d", err, len(decoded))
+			}
+			if selectedJob.Model != codexImageModelName || selectedRoute.Provider.Type != ProviderOpenAICodex ||
+				selectedRoute.Resource == nil || selectedRoute.Resource.ID != resource.ID {
+				t.Fatalf("Codex image request used the wrong route: job=%+v route=%+v", selectedJob, selectedRoute)
+			}
+		})
+	}
+}
+
 func TestImageGenerationAsyncUsesCodexSubscriptionAndPersistsImage(t *testing.T) {
 	imageBytes := realPNGFixture(t)
 	var upstreamMu sync.Mutex

--- a/docs/ja/user-guide.md
+++ b/docs/ja/user-guide.md
@@ -187,7 +187,7 @@ claude
 
 ## Codex サブスクリプション画像生成
 
-`POST /v1/images/generations` は OpenAI 互換の `model`、`prompt`、`quality`、`size`、`n`、`response_format` を受け付けます。公開仮想モデル `model: "codex-gpt-image-2"` と `n: 1` を使用してください。`gpt-image-2` は別の標準 API モデルであり、Codex サブスクリプションには決してルーティングされません。`Prefer: respond-async` を付けると画像ジョブが返り、`GET /v1/image-jobs/{id}` でポーリングできます。
+`POST /v1/images/generations` は OpenAI 互換の `model`、`prompt`、`quality`、`size`、`n`、`response_format` を受け付けます。公開仮想モデル `model: "codex-gpt-image-2"` と `n: 1` を使用してください。`gpt-image-2` は通常、別の標準 API モデルのままです。限定的な互換処理として、Codex の `originator` または `x-codex-image-turn-id` ヘッダーが付いた生成リクエストは `codex-gpt-image-2` にマッピングされ、`b64_json` が返されます。API キーでは `codex-gpt-image-2` を許可する必要があります。`Prefer: respond-async` を付けると画像ジョブが返り、`GET /v1/image-jobs/{id}` でポーリングできます。
 
 `POST /v1/images/edits` は multipart の `image` または `image[]` で参照画像を受け付けます。`gpt-image-2` は単一の `mask` を OpenAI API に転送できますが、Codex サブスクリプションではマスク編集は利用できません。TokenHub は Codex CLI をインストールまたは起動せず、Codex サブスクリプションの Images エンドポイントを直接呼び出します。プロンプトはデータベースで暗号化され、入力画像と出力画像はサーバーに保持されます。署名付きダウンロード URL の有効期間は 24 時間です。URL の期限後もファイルは残り、ジョブを再取得すると新しい URL が発行されます。選択された Codex アカウントには画像生成権限が必要です。
 
@@ -195,7 +195,7 @@ claude
 
 TokenHub はアカウントの実際の呼び出し結果から画像生成機能を記録します。対応確認済みのアカウントを優先し、`403` を返したアカウントは一時的に除外します。未確認のアカウントは初回利用時の検出対象として残ります。`TOKENHUB_IMAGE_CAPABILITY_RETRY_SECONDS`（既定 24 時間）の経過後、非対応アカウントはモデル検出とルーティングの対象に戻り、次の実リクエストで低頻度に再試行されます。回復確認のための画像をバックグラウンドで自動生成することはありません。
 
-正常な接続済み Codex アカウントのうち、少なくとも1つが画像生成対応済み、または低頻度の再試行期間に入った場合、`codex-gpt-image-2` が `GET /v1/models` に表示されます。これはサブスクリプション型の仮想モデルであり、通常の Provider モデルルートは不要です。別の `gpt-image-2` モデルは OpenAI API Provider を使用し、Codex サブスクリプション枠を消費しません。
+正常な接続済み Codex アカウントのうち、少なくとも1つが画像生成対応済み、または低頻度の再試行期間に入った場合、`codex-gpt-image-2` が `GET /v1/models` に表示されます。これはサブスクリプション型の仮想モデルであり、通常の Provider モデルルートは不要です。上記の Codex クライアント互換マッピングを除き、別の `gpt-image-2` モデルは OpenAI API Provider を使用し、Codex サブスクリプション枠を消費しません。
 
 ## SDK 設定
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -187,7 +187,7 @@ claude
 
 ## Codex subscription image generation
 
-`POST /v1/images/generations` accepts the OpenAI-compatible `model`, `prompt`, `quality`, `size`, `n`, and `response_format` fields. Use the public virtual model `model: "codex-gpt-image-2"` and `n: 1`. `gpt-image-2` is a separate standard API model and is never routed through Codex subscriptions. Add `Prefer: respond-async` to receive an image job, then poll `GET /v1/image-jobs/{id}`.
+`POST /v1/images/generations` accepts the OpenAI-compatible `model`, `prompt`, `quality`, `size`, `n`, and `response_format` fields. Use the public virtual model `model: "codex-gpt-image-2"` and `n: 1`. `gpt-image-2` normally remains a separate standard API model. As a narrow compatibility exception, TokenHub maps a generation request marked by a Codex `originator` or `x-codex-image-turn-id` header to `codex-gpt-image-2` and returns `b64_json`; the API key must allow `codex-gpt-image-2`. Add `Prefer: respond-async` to receive an image job, then poll `GET /v1/image-jobs/{id}`.
 
 `POST /v1/images/edits` accepts multipart reference images in `image` or `image[]`. `gpt-image-2` forwards one `mask` to the OpenAI API; mask edits are not available through Codex subscription accounts. TokenHub sends image requests directly to the Codex subscription Images endpoint without installing or starting Codex CLI, keeps prompts encrypted in the database, retains input and output images on the server, and returns signed download URLs valid for 24 hours. The files remain stored after a URL expires; polling the job creates a new URL. The selected Codex account must have image-generation entitlement.
 
@@ -195,7 +195,7 @@ Image jobs have a five-minute default execution timeout controlled by `TOKENHUB_
 
 TokenHub records image-generation capability from real account results. Accounts confirmed as supported are preferred, accounts returning `403` are temporarily skipped, and accounts that have not been checked remain eligible for first-use detection. After `TOKENHUB_IMAGE_CAPABILITY_RETRY_SECONDS` (24 hours by default), an unsupported account becomes discoverable and routable again so the next real request can retry it. TokenHub does not generate a background image merely to probe recovery.
 
-`codex-gpt-image-2` appears in `GET /v1/models` when a healthy connected Codex account is confirmed as supported or has reached its low-frequency retry window. It is a subscription-backed virtual model and does not require a conventional Provider model route. The separate `gpt-image-2` catalog model uses an OpenAI API provider and never consumes Codex subscription quota.
+`codex-gpt-image-2` appears in `GET /v1/models` when a healthy connected Codex account is confirmed as supported or has reached its low-frequency retry window. It is a subscription-backed virtual model and does not require a conventional Provider model route. Except for the Codex-client compatibility mapping above, the separate `gpt-image-2` catalog model uses an OpenAI API provider and does not consume Codex subscription quota.
 
 ## SDK Setup
 

--- a/docs/zh-CN/codex-image-generation-api.md
+++ b/docs/zh-CN/codex-image-generation-api.md
@@ -6,7 +6,7 @@
 
 `codex-gpt-image-2` 是 TokenHub 对外暴露的 Codex 订阅虚拟模型。它不会请求普通 OpenAI API Provider，而是由服务器选择已确认支持生图的 Codex 订阅账号，直接调用 Codex 订阅 Images 接口。服务器不需要安装或启动 Codex CLI。
 
-`gpt-image-2` 是独立的 OpenAI API 模型，必须配置 `openai` 类型 Provider、API Key 和模型路由。它调用 Provider 的标准 `/v1/images/generations` 与 `/v1/images/edits`，不会选择 Codex 订阅账号或消耗 Codex 额度。
+`gpt-image-2` 通常是独立的 OpenAI API 模型，必须配置 `openai` 类型 Provider、API Key 和模型路由。它调用 Provider 的标准 `/v1/images/generations` 与 `/v1/images/edits`，不会选择 Codex 订阅账号或消耗 Codex 额度。唯一例外是带 Codex `originator` 或 `x-codex-image-turn-id` 请求头的 `/v1/images/generations` 请求：TokenHub 会将其映射为 `codex-gpt-image-2` 并返回 `b64_json`，API Key 必须允许 `codex-gpt-image-2`。
 
 ## 1. 协议概览
 

--- a/docs/zh-CN/user-guide.md
+++ b/docs/zh-CN/user-guide.md
@@ -187,7 +187,7 @@ claude
 
 ## Codex 订阅生图
 
-`POST /v1/images/generations` 接受 OpenAI 兼容的 `model`、`prompt`、`quality`、`size`、`n` 和 `response_format` 字段。请使用对外虚拟模型 `model: "codex-gpt-image-2"` 与 `n: 1`。`gpt-image-2` 是独立的标准 API 模型，绝不会路由到 Codex 订阅能力。添加 `Prefer: respond-async` 可先获得图片任务，再轮询 `GET /v1/image-jobs/{id}`。
+`POST /v1/images/generations` 接受 OpenAI 兼容的 `model`、`prompt`、`quality`、`size`、`n` 和 `response_format` 字段。请使用对外虚拟模型 `model: "codex-gpt-image-2"` 与 `n: 1`。`gpt-image-2` 通常仍是独立的标准 API 模型；作为一个窄兼容例外，TokenHub 会把带 Codex `originator` 或 `x-codex-image-turn-id` 请求头的生图请求映射为 `codex-gpt-image-2` 并返回 `b64_json`，API Key 必须允许 `codex-gpt-image-2`。添加 `Prefer: respond-async` 可先获得图片任务，再轮询 `GET /v1/image-jobs/{id}`。
 
 `POST /v1/images/edits` 通过 multipart 的 `image` 或 `image[]` 接收参考图。`gpt-image-2` 可把单个 `mask` 转发给 OpenAI API；Codex 订阅账号暂不支持遮罩编辑。TokenHub 不安装或启动 Codex CLI，而是直接请求 Codex 订阅 Images 接口；提示词在数据库中加密保存，输入图与输出图保留在服务器上，下载 URL 签名有效期为 24 小时。URL 过期后文件仍会保留，再次查询任务即可获得新 URL。被选中的 Codex 账号必须具备生图权限。
 
@@ -195,7 +195,7 @@ claude
 
 TokenHub 根据账号的真实调用结果记录生图能力。已确认支持的账号会被优先选择；返回 `403` 的账号会被临时跳过；尚未检测的账号仍可在首次使用时完成检测。经过 `TOKENHUB_IMAGE_CAPABILITY_RETRY_SECONDS`（默认 24 小时）后，不支持的账号会重新进入模型发现和路由范围，由下一次真实请求低频复测。TokenHub 不会为了探测恢复而在后台自动生成图片。
 
-至少一个健康的 Codex 接入账号已确认支持生图或进入低频复测窗口时，`codex-gpt-image-2` 会出现在 `GET /v1/models` 中。它是订阅制虚拟模型，不需要配置普通 Provider 模型路由。独立的 `gpt-image-2` 模型使用 OpenAI API Provider，绝不会消耗 Codex 订阅额度。
+至少一个健康的 Codex 接入账号已确认支持生图或进入低频复测窗口时，`codex-gpt-image-2` 会出现在 `GET /v1/models` 中。它是订阅制虚拟模型，不需要配置普通 Provider 模型路由。除上述 Codex 客户端兼容映射外，独立的 `gpt-image-2` 模型使用 OpenAI API Provider，不会消耗 Codex 订阅额度。
 
 完整的 curl、异步轮询、参考图、Node.js 和 Python 测试流程见 [Codex 生图 API 调用与测试指南](codex-image-generation-api.md)。
 


### PR DESCRIPTION
## Summary

Native Codex image-generation requests use the public `gpt-image-2` model name and expect an inline `b64_json` result. TokenHub previously treated those requests as standard OpenAI API traffic, so they could select the wrong provider path and return the wrong response representation.

This change recognizes Codex-marked generation requests, maps them to the existing subscription-backed `codex-gpt-image-2` route before API-key authorization and job creation, and forces the response format expected by Codex.

## Related Issue

N/A

## Changes

- Detect native Codex image requests through either the current `Originator` header or `x-codex-image-turn-id`.
- Map only Codex-marked `gpt-image-2` generation requests to `codex-gpt-image-2` and force `b64_json`; ordinary OpenAI image requests remain unchanged.
- Add an integration regression test covering both request markers, the internal-model API-key allowlist, Codex subscription routing, and the Base64-only response.
- Document the compatibility mapping consistently in English, Simplified Chinese, and Japanese.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [x] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [ ] Frontend: `npm run typecheck` and `npm run build`
- [ ] SDK smoke tests against a compatible backend
- [ ] Docker Compose configuration rendered successfully
- [x] Other focused or manual verification described below

Verification details:

- `go test ./internal/server -run '^TestCodexImageRequestUsesSubscriptionCompatibleResponse$' -count=1`
- Red/green check: the focused test fails with `model_not_allowed` for both Codex markers when the compatibility block is removed, then passes when restored.
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check`
- Manual production check: deployed the compatibility patch from source and successfully generated an image through native Codex.
- Frontend, SDK, and Compose checks were not run because this change is limited to backend request normalization and documentation; Docker is unavailable in the validation environment.

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: Only `POST /v1/images/generations` requests carrying a Codex marker and `model: "gpt-image-2"` are remapped. Unmarked OpenAI API requests retain their existing model, provider route, and default response behavior.
- Security or credential-handling impact: No credential changes. Mapping occurs before `StartCall`, so the API key must explicitly allow `codex-gpt-image-2`.
- Database, environment, or deployment impact: None. No migrations, environment variables, or deployment configuration changes.
- Rollout and rollback considerations: Normal backend rollout; revert this commit to remove the compatibility mapping.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
