### PR TITLE
fix(codex): filter unsupported responses generation controls

### DIFF
--- a/backend/internal/server/provider_account_codex.go
+++ b/backend/internal/server/provider_account_codex.go
@@ -183,6 +183,7 @@ func (a CodexSubscriptionAdapter) openResponsesWithCredentials(ctx context.Conte
 	if strings.EqualFold(strings.TrimSpace(request.ServiceTier), "fast") {
 		request.ServiceTier = "priority"
 	}
+	request = withoutUnsupportedCodexGenerationControls(request)
 	applyCodexRequestEnvelope(&request, incoming)
 	payload, err := json.Marshal(request)
 	if err != nil {
@@ -218,6 +219,17 @@ func (a CodexSubscriptionAdapter) openResponsesWithCredentials(ctx context.Conte
 	}
 	resp.Body = newIdleTimeoutReadCloser(resp.Body, a.streamIdleTimeout(), errCodexStreamIdle)
 	return resp, nil
+}
+
+func withoutUnsupportedCodexGenerationControls(request ResponsesRequest) ResponsesRequest {
+	request.MaxTokens = 0
+	request.Temperature = nil
+	if request.raw != nil {
+		request.raw = cloneRawJSON(request.raw, 0)
+		delete(request.raw, "max_output_tokens")
+		delete(request.raw, "temperature")
+	}
+	return request
 }
 
 func codexResponsesEndpoint(provider Provider) (string, error) {

--- a/backend/internal/server/provider_account_codex_test.go
+++ b/backend/internal/server/provider_account_codex_test.go
@@ -424,6 +424,142 @@ func TestCodexUnsupportedModelFailsOverAndUpdatesAccountModels(t *testing.T) {
 	}
 }
 
+func TestResponsesRawGenerationControlsAreFilteredOnlyForCodex(t *testing.T) {
+	var normalPayload map[string]any
+	normalUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPost || req.URL.Path != "/responses" {
+			t.Errorf("unexpected normal provider request: %s %s", req.Method, req.URL.Path)
+			return
+		}
+		if err := json.NewDecoder(req.Body).Decode(&normalPayload); err != nil {
+			t.Errorf("decode normal provider request: %v", err)
+			return
+		}
+		w.Header().Set("content-type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"resp_normal","object":"response","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`)
+	}))
+	t.Cleanup(normalUpstream.Close)
+
+	store := NewMemoryStore()
+	project := store.CreateProject(Project{Name: "Codex raw controls"})
+	_, secret, err := store.CreateAPIKey(project.ID, APIKey{
+		Name:    "Codex raw controls key",
+		Allowed: []string{"gpt-raw-controls"},
+		Status:  StatusActive,
+	}, "thk_codex_raw_controls")
+	if err != nil {
+		t.Fatal(err)
+	}
+	codex := store.AddProvider(Provider{
+		ID:      "prv_codex_raw_controls",
+		Name:    "Codex raw controls",
+		Type:    ProviderOpenAICodex,
+		Status:  StatusActive,
+		Healthy: true,
+	})
+	resource, err := store.AddProviderResource(ProviderResource{
+		ID:           "rsrc_codex_raw_controls",
+		ProviderID:   codex.ID,
+		Name:         "Codex raw controls account",
+		ResourceType: ProviderResourceOpenAISubscription,
+		Status:       StatusActive,
+		Healthy:      true,
+		Priority:     1,
+		Weight:       100,
+		Options:      codexCapabilityOptionsForTest("gpt-raw-controls"),
+		Credentials: &ProviderResourceCredentials{
+			AccessToken: "access_raw_controls",
+			AccountID:   "account_raw_controls",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	normal := store.AddProvider(Provider{
+		ID:      "prv_normal_raw_controls",
+		Name:    "Normal raw controls fallback",
+		Type:    ProviderOpenAI,
+		BaseURL: normalUpstream.URL,
+		APIKey:  "normal_raw_controls_key",
+		Status:  StatusActive,
+		Healthy: true,
+	})
+	store.AddModel(Model{Name: "gpt-raw-controls", Modality: "chat", Status: StatusActive})
+	store.AddRoute(ModelRoute{
+		ID:                 "route_codex_raw_controls",
+		ModelName:          "gpt-raw-controls",
+		ProviderID:         codex.ID,
+		ProviderResourceID: resource.ID,
+		ProviderModel:      "gpt-raw-controls",
+		Priority:           1,
+		Weight:             100,
+		Status:             StatusActive,
+		Strategy:           "priority_only",
+	})
+	store.AddRoute(ModelRoute{
+		ID:            "route_normal_raw_controls",
+		ModelName:     "gpt-raw-controls",
+		ProviderID:    normal.ID,
+		ProviderModel: "gpt-raw-controls",
+		Priority:      2,
+		Weight:        100,
+		Status:        StatusActive,
+		Strategy:      "priority_only",
+	})
+
+	server := New(store)
+	var codexPayloads []map[string]any
+	server.codexSubscription.MaxRequestRetries = 1
+	server.codexSubscription.Client = &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var payload map[string]any
+		if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode Codex request: %v", err)
+		}
+		codexPayloads = append(codexPayloads, payload)
+		return &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"error":"retry normal provider"}`)),
+			Request:    req,
+		}, nil
+	})}
+
+	response := doJSON(t, server.Handler(), http.MethodPost, "/v1/responses", map[string]any{
+		"model":             "gpt-raw-controls",
+		"input":             "preserve the raw request for failover",
+		"max_output_tokens": 321,
+		"temperature":       0.25,
+		"x_test_passthrough": map[string]any{
+			"mode": "retain",
+		},
+	}, secret)
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected normal provider failover, got %d: %s", response.Code, response.Body)
+	}
+	if len(codexPayloads) != 2 {
+		t.Fatalf("expected two Codex attempts before failover, got %d", len(codexPayloads))
+	}
+	for _, payload := range codexPayloads {
+		if _, ok := payload["max_output_tokens"]; ok {
+			t.Fatalf("Codex request must not send max_output_tokens: %#v", payload)
+		}
+		if _, ok := payload["temperature"]; ok {
+			t.Fatalf("Codex request must not send temperature: %#v", payload)
+		}
+		passthrough := mapFromAny(payload["x_test_passthrough"])
+		if passthrough["mode"] != "retain" {
+			t.Fatalf("Codex request lost unknown raw field: %#v", payload)
+		}
+	}
+	if normalPayload["max_output_tokens"] != float64(321) || normalPayload["temperature"] != 0.25 {
+		t.Fatalf("normal provider failover lost generation controls: %#v", normalPayload)
+	}
+	passthrough := mapFromAny(normalPayload["x_test_passthrough"])
+	if passthrough["mode"] != "retain" {
+		t.Fatalf("normal provider failover lost unknown raw field: %#v", normalPayload)
+	}
+}
+
 func TestCodexSessionAffinityPersistsRebindsAndPreservesProtocol(t *testing.T) {
 	store := NewMemoryStore()
 	project := store.CreateProject(Project{Name: "Codex Session Project", Status: StatusActive})


### PR DESCRIPTION
## Summary

修复 OpenAI 兼容 `/v1/responses` 请求经 Codex Subscription Adapter 转发时，将 Codex 私有上游不支持的 `max_output_tokens` 和 `temperature` 原样发送，导致整个请求失败的问题。

此前已合并的 [PR #61](https://github.com/astaxie/TokenHub/pull/61) 在管理后台 Playground 路径中主动省略了这两个参数，但标准 Responses 客户端仍会经过透明字段保留逻辑将它们带入 Codex 上游。本 PR 将兼容处理收敛到 Codex Adapter 出站边界，因此 OpenClaw 等标准客户端无需维护专用补丁。

## Related Issue

N/A

## Changes

- 仅在 Codex Subscription 请求序列化前清除 `max_output_tokens` 和 `temperature`。
- 同时清理结构化字段和透明保留的原始 JSON 字段，避免 `ResponsesRequest.MarshalJSON` 将参数重新补回。
- 不修改普通 OpenAI-compatible Provider 的 Responses 请求行为。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [x] Backend: `gofmt` on changed Go files, `go test ./...`, and `go vet ./...`
- [ ] Frontend: `npm run typecheck` and `npm run build`（未修改前端）
- [ ] SDK smoke tests against a compatible backend（未运行独立 SDK smoke test）
- [ ] Docker Compose configuration rendered successfully（未修改部署配置）
- [x] Other focused or manual verification described below

Verification details:

- `go test ./...` 通过。
- `go vet ./...` 通过。
- `git diff --check upstream/main...HEAD` 通过。
- 在实际 TokenHub 环境中，向 Codex Subscription 路由发送同时包含 `max_output_tokens` 和 `temperature` 的 `/v1/responses` 请求，成功返回 `status: completed` 和预期文本。
- 撤销 OpenClaw 客户端临时兼容补丁后，`gpt-5.6-sol` 和 `gpt-5.6-terra` 连续请求均返回 HTTP 200。
- 按最小核心代码范围提交，本 PR 未增加测试文件；相关参数不受 Codex 上游支持及其省略行为已有 PR #61 的回归覆盖，本次另以全量后端检查和真实端到端请求验证标准客户端路径。

## Compatibility, Security, and Operations

- OpenAI-compatible `/v1` API impact: 标准 Responses 请求仍可携带这两个字段；当路由到 Codex Subscription 时字段会被忽略，路由到其他 Provider 时行为不变。
- Security or credential-handling impact: 无。未修改 OAuth 凭据、请求头或日志处理。
- Database, environment, or deployment impact: 无数据库、环境变量或部署配置变更。
- Rollout and rollback considerations: 常规部署即可；回滚时撤销本提交。

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.（无相关变更）
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.（无文档变更）
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.（未修改）
- [x] `git diff --check` passes.
