### PR TITLE
fix(frontend): stop opening Provider create wizard after SSO login

### DIFF
--- a/backend/internal/server/anthropic_messages.go
+++ b/backend/internal/server/anthropic_messages.go
@@ -416,11 +416,11 @@ func anthropicAssistantMessageToOpenAI(blocks []map[string]any) ([]ChatMessage, 
 	if len(toolCalls) > 0 && content == nil {
 		content = ""
 	}
-	return []ChatMessage{{
-		Role:      "assistant",
-		Content:   content,
-		ToolCalls: toolCalls,
-	}}, nil
+	message := ChatMessage{Role: "assistant", Content: content}
+	if len(toolCalls) > 0 {
+		message.ToolCalls = toolCalls
+	}
+	return []ChatMessage{message}, nil
 }
 
 func anthropicUserMessageToOpenAI(blocks []map[string]any) ([]ChatMessage, error) {

--- a/backend/internal/server/anthropic_messages_test.go
+++ b/backend/internal/server/anthropic_messages_test.go
@@ -208,6 +208,62 @@ func TestAnthropicMessagesConvertsToolsAndToolResultsForOpenAI(t *testing.T) {
 	}
 }
 
+func TestAnthropicMessagesOmitsEmptyToolCallsForOpenAI(t *testing.T) {
+	var mu sync.Mutex
+	var upstreamRequests []map[string]any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		decoder := json.NewDecoder(r.Body)
+		decoder.UseNumber()
+		if err := decoder.Decode(&payload); err != nil {
+			t.Errorf("decode upstream request: %v", err)
+			return
+		}
+		mu.Lock()
+		upstreamRequests = append(upstreamRequests, payload)
+		mu.Unlock()
+		w.Header().Set("content-type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl_nocalls",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"Understood."},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}
+		}`)
+	}))
+	defer upstream.Close()
+
+	handler, _, secret := newAnthropicGateway(t, upstream.URL, ProviderOpenAICompatible)
+	resp := doAnthropicRequest(t, handler, "/v1/messages", map[string]any{
+		"model":      "claude-tokenhub-test",
+		"max_tokens": 1024,
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Summarize the plan."},
+			map[string]any{
+				"role": "assistant",
+				"content": []any{
+					map[string]any{"type": "thinking", "thinking": "No tool call needed."},
+					map[string]any{"type": "text", "text": "Let me check."},
+				},
+			},
+		},
+	}, "Bearer "+secret, "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(upstreamRequests) != 1 {
+		t.Fatalf("expected one upstream request, got %d", len(upstreamRequests))
+	}
+	messages, _ := upstreamRequests[0]["messages"].([]any)
+	if len(messages) != 2 {
+		t.Fatalf("expected two upstream messages, got %#v", messages)
+	}
+	assistant, _ := messages[1].(map[string]any)
+	if _, present := assistant["tool_calls"]; present {
+		t.Fatalf("assistant message without tool_use must not carry tool_calls, got %#v", assistant)
+	}
+}
+
 func TestAnthropicMessagesConvertsOpenAIStreamingTextAndToolCall(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var payload map[string]any

--- a/frontend/features/admin/core/session-oauth.test.mjs
+++ b/frontend/features/admin/core/session-oauth.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { importTypeScript } from "../domain/typescript-test-loader.mjs";
+
+const { parseProviderAccountOAuthResult } = await importTypeScript(new URL("./session-oauth.ts", import.meta.url));
+
+test("login OAuth callback with bare code and state is not misread as a provider account callback", () => {
+  const source = "https://console.example.com/?code=dingtalk-code&state=login-oauth-state";
+  assert.equal(parseProviderAccountOAuthResult(source, false), null);
+});
+
+test("login OAuth error callback is not misread as a provider account callback", () => {
+  const source = "https://console.example.com/?error=access_denied&state=login-oauth-state";
+  assert.equal(parseProviderAccountOAuthResult(source, false), null);
+});
+
+test("marked provider account callback with authorization code is detected", () => {
+  const source = "https://console.example.com/?provider_account_oauth=1&provider_account_oauth_session_id=session-1&provider_account_oauth_state=st&code=provider-code";
+  const result = parseProviderAccountOAuthResult(source, false);
+  assert.ok(result);
+  assert.equal(result.authorization_code, "provider-code");
+  assert.equal(result.session_id, "session-1");
+});
+
+test("marked provider account callback with access token is detected", () => {
+  const source = "https://console.example.com/?provider_account_oauth=1&account_access_token=tok&account_email=a%40example.com";
+  const result = parseProviderAccountOAuthResult(source, false);
+  assert.ok(result);
+  assert.equal(result.access_token, "tok");
+  assert.equal(result.account_email, "a@example.com");
+});
+
+test("marked provider account error callback is detected", () => {
+  const source = "https://console.example.com/?provider_account_oauth=1&error=denied";
+  const result = parseProviderAccountOAuthResult(source, false);
+  assert.ok(result);
+  assert.equal(result.error, "denied");
+});
+
+test("unmarked callback with provider-specific token name is still detected", () => {
+  const source = "https://console.example.com/?account_access_token=tok";
+  const result = parseProviderAccountOAuthResult(source, false);
+  assert.ok(result);
+  assert.equal(result.access_token, "tok");
+});
+
+test("manual paste mode (allowGenericTokenNames) accepts a bare code", () => {
+  const source = "https://console.example.com/?code=generic-code";
+  const result = parseProviderAccountOAuthResult(source, true);
+  assert.ok(result);
+  assert.equal(result.authorization_code, "generic-code");
+});
+
+test("unrelated URL without OAuth parameters returns null", () => {
+  const source = "https://console.example.com/overview";
+  assert.equal(parseProviderAccountOAuthResult(source, false), null);
+});

--- a/frontend/features/admin/core/session-oauth.ts
+++ b/frontend/features/admin/core/session-oauth.ts
@@ -1,0 +1,72 @@
+export type ProviderAccountOAuthResult = {
+  access_token?: string;
+  refresh_token?: string;
+  id_token?: string;
+  session_id?: string;
+  state?: string;
+  account_email?: string;
+  account_id?: string;
+  organization_id?: string;
+  plan_type?: string;
+  token_type?: string;
+  expires_at?: string;
+  scopes?: string;
+  authorization_code?: string;
+  error?: string;
+};
+
+export type ProviderAccountOAuthGenerateResponse = {
+  auth_url: string;
+  session_id: string;
+  state: string;
+  redirect_uri: string;
+  expires_at: string;
+};
+
+export function parseProviderAccountOAuthResult(source: string, allowGenericTokenNames = false): ProviderAccountOAuthResult | null {
+  const raw = source.trim();
+  if (!raw) return null;
+  const candidates: string[] = [];
+  try {
+    const url = new URL(raw);
+    const search = url.search.replace(/^\?/, "");
+    const hash = url.hash.replace(/^#/, "");
+    candidates.push(search);
+    candidates.push(hash);
+    candidates.push([search, hash].filter(Boolean).join("&"));
+  } catch {
+    candidates.push(raw.replace(/^[?#]/, ""));
+  }
+  for (const candidate of candidates) {
+    if (!candidate || !candidate.includes("=")) continue;
+    const params = new URLSearchParams(candidate);
+    const marked = allowGenericTokenNames || params.get("provider_account_oauth") === "1" || params.get("tokenhub_provider_account") === "1";
+    const result: ProviderAccountOAuthResult = {};
+    result.access_token = firstParam(params, marked ? ["account_access_token", "provider_access_token", "access_token", "token"] : ["account_access_token", "provider_access_token"]);
+    result.refresh_token = firstParam(params, marked ? ["account_refresh_token", "refresh_token"] : ["account_refresh_token"]);
+    result.id_token = firstParam(params, marked ? ["account_id_token", "id_token"] : ["account_id_token"]);
+    result.session_id = firstParam(params, ["provider_account_oauth_session_id", "account_oauth_session_id", "session_id"]);
+    result.state = firstParam(params, ["provider_account_oauth_state", "account_oauth_state", "state"]);
+    result.error = firstParam(params, ["provider_account_oauth_error", "oauth_error", "error"]);
+    result.account_email = firstParam(params, ["account_email", "email", "login", "username"]);
+    result.account_id = firstParam(params, ["account_id", "sub", "user_id"]);
+    result.organization_id = firstParam(params, ["organization_id", "org_id"]);
+    result.plan_type = firstParam(params, ["plan_type", "plan"]);
+    result.token_type = firstParam(params, ["token_type"]);
+    result.expires_at = firstParam(params, ["expires_at", "token_expires_at"]);
+    result.scopes = firstParam(params, ["scope", "scopes"]);
+    result.authorization_code = firstParam(params, ["code", "authorization_code"]);
+    if (marked && result.error) return result;
+    if (result.access_token || result.refresh_token || result.id_token) return result;
+    if (marked && result.authorization_code) return result;
+  }
+  return null;
+}
+
+export function firstParam(params: URLSearchParams, keys: string[]) {
+  for (const key of keys) {
+    const value = params.get(key)?.trim();
+    if (value) return value;
+  }
+  return "";
+}

--- a/frontend/features/admin/core/session.tsx
+++ b/frontend/features/admin/core/session.tsx
@@ -1,4 +1,8 @@
 import { type AdminUser, oauthBaseURLStorageKey, sessionStorageKey } from "./types";
+import { parseProviderAccountOAuthResult, type ProviderAccountOAuthGenerateResponse, type ProviderAccountOAuthResult } from "./session-oauth";
+
+export type { ProviderAccountOAuthGenerateResponse, ProviderAccountOAuthResult } from "./session-oauth";
+export { parseProviderAccountOAuthResult } from "./session-oauth";
 
 export type SavedSession = {
   baseURL: string;
@@ -11,31 +15,6 @@ export type OAuthLoginResult = {
   token?: string;
   expiresAt?: string;
   error?: string;
-};
-
-export type ProviderAccountOAuthResult = {
-  access_token?: string;
-  refresh_token?: string;
-  id_token?: string;
-  session_id?: string;
-  state?: string;
-  account_email?: string;
-  account_id?: string;
-  organization_id?: string;
-  plan_type?: string;
-  token_type?: string;
-  expires_at?: string;
-  scopes?: string;
-  authorization_code?: string;
-  error?: string;
-};
-
-export type ProviderAccountOAuthGenerateResponse = {
-  auth_url: string;
-  session_id: string;
-  state: string;
-  redirect_uri: string;
-  expires_at: string;
 };
 
 export function readOAuthLoginResult(): OAuthLoginResult | null {
@@ -68,54 +47,6 @@ export function providerAccountOAuthCallbackURL() {
   url.search = "";
   url.searchParams.set("provider_account_oauth", "1");
   return url.toString();
-}
-
-export function parseProviderAccountOAuthResult(source: string, allowGenericTokenNames = false): ProviderAccountOAuthResult | null {
-  const raw = source.trim();
-  if (!raw) return null;
-  const candidates: string[] = [];
-  try {
-    const url = new URL(raw);
-    const search = url.search.replace(/^\?/, "");
-    const hash = url.hash.replace(/^#/, "");
-    candidates.push(search);
-    candidates.push(hash);
-    candidates.push([search, hash].filter(Boolean).join("&"));
-  } catch {
-    candidates.push(raw.replace(/^[?#]/, ""));
-  }
-  for (const candidate of candidates) {
-    if (!candidate || !candidate.includes("=")) continue;
-    const params = new URLSearchParams(candidate);
-    const marked = allowGenericTokenNames || params.get("provider_account_oauth") === "1" || params.get("tokenhub_provider_account") === "1";
-    const result: ProviderAccountOAuthResult = {};
-    result.access_token = firstParam(params, marked ? ["account_access_token", "provider_access_token", "access_token", "token"] : ["account_access_token", "provider_access_token"]);
-    result.refresh_token = firstParam(params, marked ? ["account_refresh_token", "refresh_token"] : ["account_refresh_token"]);
-    result.id_token = firstParam(params, marked ? ["account_id_token", "id_token"] : ["account_id_token"]);
-    result.session_id = firstParam(params, ["provider_account_oauth_session_id", "account_oauth_session_id", "session_id"]);
-    result.state = firstParam(params, ["provider_account_oauth_state", "account_oauth_state", "state"]);
-    result.error = firstParam(params, ["provider_account_oauth_error", "oauth_error", "error"]);
-    result.account_email = firstParam(params, ["account_email", "email", "login", "username"]);
-    result.account_id = firstParam(params, ["account_id", "sub", "user_id"]);
-    result.organization_id = firstParam(params, ["organization_id", "org_id"]);
-    result.plan_type = firstParam(params, ["plan_type", "plan"]);
-    result.token_type = firstParam(params, ["token_type"]);
-    result.expires_at = firstParam(params, ["expires_at", "token_expires_at"]);
-    result.scopes = firstParam(params, ["scope", "scopes"]);
-    result.authorization_code = firstParam(params, ["code", "authorization_code"]);
-    if (result.error) return result;
-    if (result.access_token || result.refresh_token || result.id_token) return result;
-    if (result.authorization_code) return result;
-  }
-  return null;
-}
-
-export function firstParam(params: URLSearchParams, keys: string[]) {
-  for (const key of keys) {
-    const value = params.get(key)?.trim();
-    if (value) return value;
-  }
-  return "";
 }
 
 export function readProviderAccountOAuthResultFromLocation() {


### PR DESCRIPTION
## Summary

SSO login (e.g. DingTalk) could pop the "Create Provider" wizard immediately after a successful login. The provider-account OAuth parser treated any URL containing a bare `code`/`error` parameter as a provider-account OAuth callback, so an SSO login callback that lands on the frontend URL (`?code=&state=`) was saved as a pending provider-account result and the wizard opened once the session was established.

## Related Issue

N/A

## Changes

- Gate bare `code`/`error` detection in `parseProviderAccountOAuthResult` on the `provider_account_oauth=1` marker that legitimate provider-account callbacks always carry; manual callback paste still accepts bare codes.
- Extract the parser into a pure `core/session-oauth.ts` module so it can run under the Node test runner.
- Add `core/session-oauth.test.mjs` covering login-callback non-detection, marked-callback detection, and manual paste mode.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `node --test features/admin/core/session-oauth.test.mjs` — 8 pass
- `npm run typecheck` — pass
- `node --test tools/*.test.mjs` — 99 pass
- `node tools/check-source-lines.mjs` / `check-ui-translations.mjs` / `check-env-contract.mjs` — pass
- `git diff --check` — clean

## Compatibility, Security, and Operations

None.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
