### PR TITLE
fix(server): omit empty tool_calls array when converting Anthropic assistant messages

### DIFF
--- a/backend/internal/server/anthropic_messages.go
+++ b/backend/internal/server/anthropic_messages.go
@@ -416,11 +416,11 @@ func anthropicAssistantMessageToOpenAI(blocks []map[string]any) ([]ChatMessage, 
 	if len(toolCalls) > 0 && content == nil {
 		content = ""
 	}
-	return []ChatMessage{{
-		Role:      "assistant",
-		Content:   content,
-		ToolCalls: toolCalls,
-	}}, nil
+	message := ChatMessage{Role: "assistant", Content: content}
+	if len(toolCalls) > 0 {
+		message.ToolCalls = toolCalls
+	}
+	return []ChatMessage{message}, nil
 }
 
 func anthropicUserMessageToOpenAI(blocks []map[string]any) ([]ChatMessage, error) {

--- a/backend/internal/server/anthropic_messages_test.go
+++ b/backend/internal/server/anthropic_messages_test.go
@@ -208,6 +208,62 @@ func TestAnthropicMessagesConvertsToolsAndToolResultsForOpenAI(t *testing.T) {
 	}
 }
 
+func TestAnthropicMessagesOmitsEmptyToolCallsForOpenAI(t *testing.T) {
+	var mu sync.Mutex
+	var upstreamRequests []map[string]any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		decoder := json.NewDecoder(r.Body)
+		decoder.UseNumber()
+		if err := decoder.Decode(&payload); err != nil {
+			t.Errorf("decode upstream request: %v", err)
+			return
+		}
+		mu.Lock()
+		upstreamRequests = append(upstreamRequests, payload)
+		mu.Unlock()
+		w.Header().Set("content-type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl_nocalls",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"Understood."},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}
+		}`)
+	}))
+	defer upstream.Close()
+
+	handler, _, secret := newAnthropicGateway(t, upstream.URL, ProviderOpenAICompatible)
+	resp := doAnthropicRequest(t, handler, "/v1/messages", map[string]any{
+		"model":      "claude-tokenhub-test",
+		"max_tokens": 1024,
+		"messages": []any{
+			map[string]any{"role": "user", "content": "Summarize the plan."},
+			map[string]any{
+				"role": "assistant",
+				"content": []any{
+					map[string]any{"type": "thinking", "thinking": "No tool call needed."},
+					map[string]any{"type": "text", "text": "Let me check."},
+				},
+			},
+		},
+	}, "Bearer "+secret, "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(upstreamRequests) != 1 {
+		t.Fatalf("expected one upstream request, got %d", len(upstreamRequests))
+	}
+	messages, _ := upstreamRequests[0]["messages"].([]any)
+	if len(messages) != 2 {
+		t.Fatalf("expected two upstream messages, got %#v", messages)
+	}
+	assistant, _ := messages[1].(map[string]any)
+	if _, present := assistant["tool_calls"]; present {
+		t.Fatalf("assistant message without tool_use must not carry tool_calls, got %#v", assistant)
+	}
+}
+
 func TestAnthropicMessagesConvertsOpenAIStreamingTextAndToolCall(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var payload map[string]any


### PR DESCRIPTION
## Summary

将 Anthropic assistant 消息转换为 OpenAI 格式时，即使 `tool_calls` 为空也会写出空数组。修复为仅当 `toolCalls` 非空时才设置该字段，空时保持为空，使 `omitempty` 正确地从 JSON 输出中省略该字段。

## Related Issue

N/A

## Changes

- 仅当 `toolCalls` 非空时设置 `ToolCalls`，空时保持为 nil，由 `omitempty` 省略该字段。
- 新增 `TestAnthropicMessagesOmitsEmptyToolCallsForOpenAI` 回归测试。

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- 本机 Go 工具链版本过低（缺 `cmp`、`iter`、`slices` 等标准库包），无法编译并运行 backend 测试，依赖 CI 验证。
- 提交 `ba20aa0` 为本仓库 fork 上既有提交，本次仅将其拆分为独立 PR。

## Compatibility, Security, and Operations

None.

## Checklist

- [x] 行为变更已新增或更新测试，或已说明无需测试的原因。
- [x] 未包含任何凭据、本地 `.env` 文件、数据库、备份或运行时日志。
- [x] 环境变量变更已同步到示例、Compose、`start.sh` 与部署文档（如适用）。
- [x] 共享的用户可见行为已在英文、简体中文和日文中保持一致（如适用）。
- [x] `data/model-catalog.yaml` 保持受跟踪，目录变更已复核（如适用）。
- [x] `git diff --check` 通过。
