### PR TITLE
fix(admin): expose language preferences to all users

### DIFF
--- a/frontend/app/styles/redesign/login.css
+++ b/frontend/app/styles/redesign/login.css
@@ -449,7 +449,7 @@ textarea:focus-visible {
 
 .login-language-switcher {
   justify-self: start;
-  margin: 0;
+  margin: 14px 0 0;
 }
 
 .field {

--- a/frontend/app/styles/redesign/responsive.css
+++ b/frontend/app/styles/redesign/responsive.css
@@ -360,6 +360,22 @@
     gap: 6px;
   }
 
+  .topbar-language-select {
+    width: 36px;
+    flex: 0 0 36px;
+    justify-content: center;
+    padding: 0;
+    position: relative;
+  }
+
+  .topbar-language-select select {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    max-width: none;
+    opacity: 0;
+  }
+
   .top-version-status .version {
     max-width: 78px;
     padding: 0 8px;

--- a/frontend/app/styles/redesign/shell.css
+++ b/frontend/app/styles/redesign/shell.css
@@ -683,6 +683,37 @@
   gap: 10px;
 }
 
+.language-select {
+  height: 36px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding-left: 10px;
+  background: var(--surface);
+  color: var(--ink-2);
+}
+
+.language-select:focus-within,
+.language-select:hover {
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+  color: var(--accent);
+}
+
+.language-select select {
+  height: 34px;
+  max-width: 104px;
+  border: 0;
+  outline: 0;
+  padding: 0 8px 0 0;
+  background: transparent;
+  color: var(--ink-2);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 680;
+}
+
 .top-quick-actions {
   display: inline-flex;
   align-items: center;

--- a/frontend/features/admin/i18n/language-preference.ts
+++ b/frontend/features/admin/i18n/language-preference.ts
@@ -1,0 +1,22 @@
+export type AppLanguage = "zh-CN" | "en" | "ja";
+
+export const languageOptions: Array<{ value: AppLanguage; label: string; nativeLabel: string }> = [
+  { value: "zh-CN", label: "Chinese", nativeLabel: "简体中文" },
+  { value: "en", label: "English", nativeLabel: "English" },
+  { value: "ja", label: "Japanese", nativeLabel: "日本語" },
+];
+
+export function languageFromLocales(locales: readonly string[]): AppLanguage {
+  for (const locale of locales) {
+    const normalized = locale.trim().toLowerCase();
+    if (normalized === "zh" || normalized.startsWith("zh-")) return "zh-CN";
+    if (normalized === "ja" || normalized.startsWith("ja-")) return "ja";
+    if (normalized === "en" || normalized.startsWith("en-")) return "en";
+  }
+  return "en";
+}
+
+export function preferredLanguage(saved: string | null, locales: readonly string[]): AppLanguage {
+  if (saved === "en" || saved === "ja" || saved === "zh-CN") return saved;
+  return languageFromLocales(locales);
+}

--- a/frontend/features/admin/i18n/language-switcher.tsx
+++ b/frontend/features/admin/i18n/language-switcher.tsx
@@ -1,0 +1,58 @@
+import { Globe2 } from "lucide-react";
+import { type AppLanguage, languageOptions, tx } from "./runtime";
+
+export function LanguageSwitcher({
+  language,
+  onChange,
+  className,
+}: {
+  language: AppLanguage;
+  onChange: (language: AppLanguage) => void;
+  className?: string;
+}) {
+  return (
+    <div className={className ? `language-switcher ${className}` : "language-switcher"} role="radiogroup" aria-label={tx("界面语言")}>
+      {languageOptions.map((option) => (
+        <button
+          aria-checked={language === option.value}
+          className={language === option.value ? "active" : ""}
+          key={option.value}
+          onClick={() => onChange(option.value)}
+          role="radio"
+          type="button"
+        >
+          <span>{languageOptionLabel(option, language)}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function LanguageSelect({
+  language,
+  onChange,
+  className,
+}: {
+  language: AppLanguage;
+  onChange: (language: AppLanguage) => void;
+  className?: string;
+}) {
+  return (
+    <label className={className ? `language-select ${className}` : "language-select"} title={tx("界面语言")}>
+      <Globe2 aria-hidden="true" size={16} />
+      <select
+        aria-label={tx("界面语言")}
+        onChange={(event) => onChange(event.target.value as AppLanguage)}
+        value={language}
+      >
+        {languageOptions.map((option) => (
+          <option key={option.value} value={option.value}>{option.nativeLabel}</option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+export function languageOptionLabel(option: { label: string; nativeLabel: string }, language: AppLanguage) {
+  return language === "en" ? option.label : option.nativeLabel;
+}

--- a/frontend/features/admin/i18n/runtime.tsx
+++ b/frontend/features/admin/i18n/runtime.tsx
@@ -1,20 +1,15 @@
 import { languageStorageKey } from "../core/types";
+import { type AppLanguage, languageFromLocales, languageOptions, preferredLanguage } from "./language-preference";
 import { translations } from "./translations";
 
-export type AppLanguage = "zh-CN" | "en" | "ja";
-
-export const languageOptions: Array<{ value: AppLanguage; label: string; nativeLabel: string }> = [
-  { value: "zh-CN", label: "Chinese", nativeLabel: "简体中文" },
-  { value: "en", label: "English", nativeLabel: "English" },
-  { value: "ja", label: "Japanese", nativeLabel: "日本語" },
-];
+export { type AppLanguage, languageFromLocales, languageOptions, preferredLanguage };
 
 export let activeLanguage: AppLanguage = "en";
 
 export function readSavedLanguage(): AppLanguage {
   if (typeof window === "undefined") return "en";
   const saved = window.localStorage.getItem(languageStorageKey);
-  return saved === "en" || saved === "ja" || saved === "zh-CN" ? saved : "en";
+  return preferredLanguage(saved, navigator.languages?.length ? navigator.languages : [navigator.language]);
 }
 
 export function setActiveLanguage(language: AppLanguage) {

--- a/frontend/features/admin/shell/admin-console.tsx
+++ b/frontend/features/admin/shell/admin-console.tsx
@@ -731,7 +731,9 @@ export function AdminConsole({ defaultBaseURL }: { defaultBaseURL: string }) {
       <ResetPasswordView
         loading={loading}
         error={error}
+        language={language}
         theme={theme}
+        onLanguageChange={changeLanguage}
         onThemeToggle={toggleTheme}
         token={resetToken}
         onReset={(token, password) => void resetPassword(token, password)}
@@ -747,7 +749,9 @@ export function AdminConsole({ defaultBaseURL }: { defaultBaseURL: string }) {
         baseURL={baseURL}
         identityProviders={loginIdentityProviders}
         oauthReturnURL={oauthReturnURL}
+        language={language}
         theme={theme}
+        onLanguageChange={changeLanguage}
         onThemeToggle={toggleTheme}
         onLogin={(identity, password) => void login(identity, password)}
       />
@@ -775,7 +779,9 @@ export function AdminConsole({ defaultBaseURL }: { defaultBaseURL: string }) {
           activeView={activeView}
           data={data}
           user={currentUser}
+          language={language}
           theme={theme}
+          onLanguageChange={changeLanguage}
           onSelectView={selectView}
           onThemeToggle={toggleTheme}
         />

--- a/frontend/features/admin/shell/auth.tsx
+++ b/frontend/features/admin/shell/auth.tsx
@@ -4,7 +4,8 @@ import { savePendingOAuthBaseURL } from "../core/session";
 import { type LoginIdentityProvider, viewRoutes } from "../core/types";
 import { stringifyValue } from "../domain/entities";
 import { identityProviderIconLabel } from "../domain/labels";
-import { activeLanguage, tx } from "../i18n/runtime";
+import { LanguageSwitcher } from "../i18n/language-switcher";
+import { activeLanguage, type AppLanguage, tx } from "../i18n/runtime";
 
 export const identityProviderIconOptions = [
   "auto",
@@ -528,7 +529,9 @@ export function LoginView({
   baseURL,
   identityProviders,
   oauthReturnURL,
+  language,
   theme,
+  onLanguageChange,
   onThemeToggle,
   onLogin,
 }: {
@@ -537,7 +540,9 @@ export function LoginView({
   baseURL: string;
   identityProviders: LoginIdentityProvider[];
   oauthReturnURL: string;
+  language: AppLanguage;
   theme: "light" | "dark";
+  onLanguageChange: (language: AppLanguage) => void;
   onThemeToggle: () => void;
   onLogin: (identity: string, password: string) => void;
 }) {
@@ -628,6 +633,7 @@ export function LoginView({
         <form className="login-card" onSubmit={submit}>
           <div className="login-card-head">
             <h1>{tx("登录控制台")}</h1>
+            <LanguageSwitcher className="login-language-switcher" language={language} onChange={onLanguageChange} />
           </div>
           <label className="field">
             <span>{tx("账号 / 邮箱")}</span>
@@ -709,14 +715,18 @@ export function LoginView({
 export function ResetPasswordView({
   loading,
   error,
+  language,
   theme,
+  onLanguageChange,
   onThemeToggle,
   token,
   onReset,
 }: {
   loading: boolean;
   error: string;
+  language: AppLanguage;
   theme: "light" | "dark";
+  onLanguageChange: (language: AppLanguage) => void;
   onThemeToggle: () => void;
   token: string;
   onReset: (token: string, password: string) => void;
@@ -742,6 +752,7 @@ export function ResetPasswordView({
           <div className="login-card-head">
             <h1>{tx("重置密码")}</h1>
             <p>{tx("请设置新的控制台登录密码。")}</p>
+            <LanguageSwitcher className="login-language-switcher" language={language} onChange={onLanguageChange} />
           </div>
           <label className="field">
             <span>{tx("新密码")}</span>

--- a/frontend/features/admin/shell/navigation-ui.tsx
+++ b/frontend/features/admin/shell/navigation-ui.tsx
@@ -4,7 +4,8 @@ import { appRole, filterNavItemByAccess, isNavItemActive, isNavParentItem, navGr
 import { type AdminUser, type AppData, type NavItem, type ViewKey } from "../core/types";
 import { formatMoney, formatNumber, playgroundModels } from "../domain/formatting";
 import { roleLabel, userInitial } from "../domain/labels";
-import { displayText, tx } from "../i18n/runtime";
+import { LanguageSelect } from "../i18n/language-switcher";
+import { type AppLanguage, displayText, tx } from "../i18n/runtime";
 import { resourceConfigFor } from "../resources/settings-config";
 
 export function Sidebar({
@@ -327,14 +328,18 @@ export function TopNav({
   activeView,
   data,
   user,
+  language,
   theme,
+  onLanguageChange,
   onSelectView,
   onThemeToggle,
 }: {
   activeView: ViewKey;
   data: AppData;
   user: AdminUser;
+  language: AppLanguage;
   theme: "light" | "dark";
+  onLanguageChange: (language: AppLanguage) => void;
   onSelectView: (view: ViewKey) => void;
   onThemeToggle: () => void;
 }) {
@@ -459,6 +464,7 @@ export function TopNav({
           <span>{userInitial(user)}</span>
           <strong>{roleLabel(user.role)}</strong>
         </div>
+        <LanguageSelect className="topbar-language-select" language={language} onChange={onLanguageChange} />
         <button className="top-icon-button" onClick={onThemeToggle} title={tx("切换主题")} type="button">
           {theme === "light" ? <Moon size={17} /> : <Sun size={17} />}
         </button>

--- a/frontend/features/admin/views/settings-table.tsx
+++ b/frontend/features/admin/views/settings-table.tsx
@@ -5,6 +5,7 @@ import { filterRows } from "../domain/catalog";
 import { readPath, rowID, stringifyValue } from "../domain/entities";
 import { formatNumber, formatTime } from "../domain/formatting";
 import { settingsTabLabel } from "../domain/labels";
+import { LanguageSwitcher, languageOptionLabel } from "../i18n/language-switcher";
 import { activeLanguage, type AppLanguage, countWithLabel, displayText, languageOptions, translatedCell, tx } from "../i18n/runtime";
 import { defaultFormValues } from "../resources/payloads";
 import { apiKeyStatusAction, APIKeyDownloadMenu, APIKeyStatusSwitch } from "../resources/project-key-config";
@@ -121,37 +122,6 @@ export function LanguagePreferenceRow({
       </div>
     </div>
   );
-}
-
-export function LanguageSwitcher({
-  language,
-  onChange,
-  className,
-}: {
-  language: AppLanguage;
-  onChange: (language: AppLanguage) => void;
-  className?: string;
-}) {
-  return (
-    <div className={className ? `language-switcher ${className}` : "language-switcher"} role="radiogroup" aria-label={tx("界面语言")}>
-      {languageOptions.map((option) => (
-        <button
-          aria-checked={language === option.value}
-          className={language === option.value ? "active" : ""}
-          key={option.value}
-          onClick={() => onChange(option.value)}
-          role="radio"
-          type="button"
-        >
-          <span>{languageOptionLabel(option, language)}</span>
-        </button>
-      ))}
-    </div>
-  );
-}
-
-export function languageOptionLabel(option: { label: string; nativeLabel: string }, language: AppLanguage) {
-  return language === "en" ? option.label : option.nativeLabel;
 }
 
 export function SystemSettingsPanel({

--- a/tools/admin-language-preference.test.mjs
+++ b/tools/admin-language-preference.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { languageFromLocales, preferredLanguage } from "../frontend/features/admin/i18n/language-preference.ts";
+
+describe("admin language preference", () => {
+  it("detects supported browser languages", () => {
+    assert.equal(languageFromLocales(["zh-CN"]), "zh-CN");
+    assert.equal(languageFromLocales(["zh-Hant-TW"]), "zh-CN");
+    assert.equal(languageFromLocales(["ja-JP"]), "ja");
+    assert.equal(languageFromLocales(["en-GB"]), "en");
+  });
+
+  it("uses the first supported browser language and otherwise falls back to English", () => {
+    assert.equal(languageFromLocales(["fr-FR", "ja-JP", "en-US"]), "ja");
+    assert.equal(languageFromLocales(["fr-FR", "de-DE"]), "en");
+  });
+
+  it("keeps a saved choice ahead of browser detection", () => {
+    assert.equal(preferredLanguage("en", ["zh-CN"]), "en");
+    assert.equal(preferredLanguage("zh-CN", ["en-US"]), "zh-CN");
+    assert.equal(preferredLanguage("unsupported", ["ja-JP"]), "ja");
+  });
+});


### PR DESCRIPTION
## Summary

The admin console currently falls back to English when no preference is saved, and the general language control is only available under system settings. This makes the initial language surprising for Chinese and Japanese browsers and prevents lower-privilege users from changing it.

## Related Issue

N/A

## Changes

- Resolve the first-run language from the browser's supported locale list while keeping a saved browser preference authoritative.
- Add language controls to the login and password-reset views.
- Add a compact language selector to the global top bar so every signed-in role can change the UI language.
- Extract reusable language preference and selector helpers.
- Add regression tests for locale detection, fallback, and saved-preference precedence.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `node --test tools/*.test.mjs` (102 tests passed)
- `node tools/check-doc-translations.mjs --base HEAD^ --head HEAD`
- `node tools/check-ui-translations.mjs --base HEAD^ --head HEAD`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- `npm run typecheck`
- `npm run build`
- Playwright smoke check with `zh-CN` and `ja-JP` browser locales, plus saved-English override and reload persistence.

## Compatibility, Security, and Operations

No API, persistence, authorization, environment, or deployment changes. The preference remains local to the current browser and existing saved language values keep taking precedence.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.