### PR TITLE
fix(admin): expose language preferences to all users

### DIFF
--- a/frontend/app/styles/redesign/login.css
+++ b/frontend/app/styles/redesign/login.css
@@ -58,11 +58,17 @@ textarea:focus-visible {
   color: var(--ink);
 }
 
-.login-theme-toggle {
+.login-utility-actions {
   position: absolute;
   top: clamp(22px, 3.2vw, 42px);
   right: clamp(22px, 3.2vw, 42px);
   z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.login-theme-toggle {
   width: 42px;
   height: 42px;
   border: 1px solid rgba(162, 176, 198, 0.38);
@@ -73,6 +79,15 @@ textarea:focus-visible {
   background: rgba(255, 255, 255, 0.82);
   color: #536174;
   cursor: pointer;
+  box-shadow: 0 10px 24px rgba(29, 66, 122, 0.08);
+  backdrop-filter: blur(14px);
+}
+
+.login-utility-actions .login-language-select .language-select-trigger {
+  height: 42px;
+  border-color: rgba(127, 148, 182, 0.24);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.76);
   box-shadow: 0 10px 24px rgba(29, 66, 122, 0.08);
   backdrop-filter: blur(14px);
 }
@@ -948,6 +963,13 @@ textarea:focus-visible {
 }
 
 [data-theme="dark"] .login-theme-toggle {
+  border-color: rgba(104, 121, 149, 0.34);
+  background: rgba(20, 26, 38, 0.82);
+  color: #a8b4c6;
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.28);
+}
+
+[data-theme="dark"] .login-language-select .language-select-trigger {
   border-color: rgba(104, 121, 149, 0.34);
   background: rgba(20, 26, 38, 0.82);
   color: #a8b4c6;

--- a/frontend/app/styles/redesign/responsive.css
+++ b/frontend/app/styles/redesign/responsive.css
@@ -34,10 +34,17 @@
     overflow-y: auto;
   }
 
-  .login-theme-toggle {
+  .login-utility-actions {
     top: 24px;
     right: 24px;
+  }
+
+  .login-theme-toggle {
     width: 40px;
+    height: 40px;
+  }
+
+  .login-utility-actions .login-language-select .language-select-trigger {
     height: 40px;
   }
 
@@ -360,6 +367,22 @@
     gap: 6px;
   }
 
+  .topbar-language-select {
+    width: 36px;
+    flex: 0 0 36px;
+  }
+
+  .topbar-language-select .language-select-trigger {
+    width: 100%;
+    justify-content: center;
+    padding: 0;
+  }
+
+  .topbar-language-select .language-select-label,
+  .topbar-language-select .language-select-chevron {
+    display: none;
+  }
+
   .top-version-status .version {
     max-width: 78px;
     padding: 0 8px;
@@ -378,9 +401,25 @@
     overflow: auto;
   }
 
-  .login-theme-toggle {
+  .login-utility-actions {
     top: 18px;
     right: 18px;
+  }
+
+  .login-utility-actions .login-language-select {
+    width: 40px;
+    flex: 0 0 40px;
+  }
+
+  .login-utility-actions .login-language-select .language-select-trigger {
+    width: 100%;
+    justify-content: center;
+    padding: 0;
+  }
+
+  .login-utility-actions .login-language-select .language-select-label,
+  .login-utility-actions .login-language-select .language-select-chevron {
+    display: none;
   }
 
   .login-stage {

--- a/frontend/app/styles/redesign/shell.css
+++ b/frontend/app/styles/redesign/shell.css
@@ -683,6 +683,87 @@
   gap: 10px;
 }
 
+.language-select {
+  position: relative;
+  display: inline-flex;
+}
+
+.language-select-trigger {
+  min-width: 0;
+  height: 36px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px;
+  background: var(--surface);
+  color: var(--ink-2);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 680;
+}
+
+.language-select-trigger:hover,
+.language-select-trigger:focus-visible,
+.language-select-trigger[aria-expanded="true"] {
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+  color: var(--accent);
+}
+
+.language-select-label {
+  white-space: nowrap;
+}
+
+.language-select-chevron {
+  flex: 0 0 auto;
+  transition: transform 150ms ease;
+}
+
+.language-select-trigger[aria-expanded="true"] .language-select-chevron {
+  transform: rotate(180deg);
+}
+
+.language-select-options {
+  position: fixed;
+  z-index: 1300;
+  width: 176px;
+  padding: 5px;
+  border: 1px solid var(--border-2);
+  border-radius: 11px;
+  display: grid;
+  gap: 2px;
+  background: var(--surface);
+  box-shadow: var(--shadow-lg);
+}
+
+.language-select-option {
+  width: 100%;
+  min-height: 38px;
+  border-radius: 8px;
+  padding: 0 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 680;
+  text-align: left;
+}
+
+.language-select-option:hover,
+.language-select-option:focus-visible {
+  background: var(--surface-2);
+}
+
+.language-select-option.selected {
+  background: var(--accent-weak-2);
+  color: var(--accent);
+}
+
 .top-quick-actions {
   display: inline-flex;
   align-items: center;

--- a/frontend/features/admin/i18n/language-preference.ts
+++ b/frontend/features/admin/i18n/language-preference.ts
@@ -1,0 +1,22 @@
+export type AppLanguage = "zh-CN" | "en" | "ja";
+
+export const languageOptions: Array<{ value: AppLanguage; label: string; nativeLabel: string }> = [
+  { value: "zh-CN", label: "Chinese", nativeLabel: "简体中文" },
+  { value: "en", label: "English", nativeLabel: "English" },
+  { value: "ja", label: "Japanese", nativeLabel: "日本語" },
+];
+
+export function languageFromLocales(locales: readonly string[]): AppLanguage {
+  for (const locale of locales) {
+    const normalized = locale.trim().toLowerCase();
+    if (normalized === "zh" || normalized.startsWith("zh-")) return "zh-CN";
+    if (normalized === "ja" || normalized.startsWith("ja-")) return "ja";
+    if (normalized === "en" || normalized.startsWith("en-")) return "en";
+  }
+  return "en";
+}
+
+export function preferredLanguage(saved: string | null, locales: readonly string[]): AppLanguage {
+  if (saved === "en" || saved === "ja" || saved === "zh-CN") return saved;
+  return languageFromLocales(locales);
+}

--- a/frontend/features/admin/i18n/language-switcher.tsx
+++ b/frontend/features/admin/i18n/language-switcher.tsx
@@ -1,0 +1,165 @@
+import { Check, ChevronDown, Globe2 } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { type AppLanguage, languageOptions, tx } from "./runtime";
+
+export function LanguageSwitcher({
+  language,
+  onChange,
+  className,
+}: {
+  language: AppLanguage;
+  onChange: (language: AppLanguage) => void;
+  className?: string;
+}) {
+  return (
+    <div className={className ? `language-switcher ${className}` : "language-switcher"} role="radiogroup" aria-label={tx("界面语言")}>
+      {languageOptions.map((option) => (
+        <button
+          aria-checked={language === option.value}
+          className={language === option.value ? "active" : ""}
+          key={option.value}
+          onClick={() => onChange(option.value)}
+          role="radio"
+          type="button"
+        >
+          <span>{languageOptionLabel(option, language)}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function LanguageSelect({
+  language,
+  onChange,
+  className,
+}: {
+  language: AppLanguage;
+  onChange: (language: AppLanguage) => void;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState({ left: 0, top: 0 });
+  const [menuTheme, setMenuTheme] = useState<"light" | "dark">("light");
+  const menuID = useId();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const optionsRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const current = languageOptions.find((option) => option.value === language) ?? languageOptions[0];
+
+  useEffect(() => {
+    if (!open) return;
+    const closeMenu = () => setOpen(false);
+    const closeOutside = (event: MouseEvent | FocusEvent) => {
+      const target = event.target as Node;
+      if (!containerRef.current?.contains(target) && !optionsRef.current?.contains(target)) closeMenu();
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      closeMenu();
+      triggerRef.current?.focus();
+    };
+    const focusFrame = window.requestAnimationFrame(() => {
+      optionsRef.current?.querySelector<HTMLButtonElement>('[aria-selected="true"]')?.focus();
+    });
+    window.addEventListener("mousedown", closeOutside);
+    window.addEventListener("focusin", closeOutside);
+    window.addEventListener("keydown", closeOnEscape);
+    window.addEventListener("resize", closeMenu);
+    window.addEventListener("scroll", closeMenu, true);
+    return () => {
+      window.cancelAnimationFrame(focusFrame);
+      window.removeEventListener("mousedown", closeOutside);
+      window.removeEventListener("focusin", closeOutside);
+      window.removeEventListener("keydown", closeOnEscape);
+      window.removeEventListener("resize", closeMenu);
+      window.removeEventListener("scroll", closeMenu, true);
+    };
+  }, [open]);
+
+  function toggleMenu() {
+    if (!open && triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      const menuWidth = 176;
+      const menuHeight = 132;
+      const openBelow = window.innerHeight - rect.bottom >= menuHeight + 12;
+      setPosition({
+        left: Math.min(Math.max(8, rect.right - menuWidth), window.innerWidth - menuWidth - 8),
+        top: openBelow ? rect.bottom + 6 : Math.max(8, rect.top - menuHeight - 6),
+      });
+      setMenuTheme(triggerRef.current.closest('[data-theme="dark"]') ? "dark" : "light");
+    }
+    setOpen((currentOpen) => !currentOpen);
+  }
+
+  function selectLanguage(nextLanguage: AppLanguage) {
+    onChange(nextLanguage);
+    setOpen(false);
+    triggerRef.current?.focus();
+  }
+
+  function moveOptionFocus(event: React.KeyboardEvent<HTMLButtonElement>) {
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
+    event.preventDefault();
+    const options = Array.from(optionsRef.current?.querySelectorAll<HTMLButtonElement>('[role="option"]') ?? []);
+    const currentIndex = options.indexOf(event.currentTarget);
+    if (event.key === "Home") options[0]?.focus();
+    else if (event.key === "End") options.at(-1)?.focus();
+    else if (event.key === "ArrowDown") options[(currentIndex + 1) % options.length]?.focus();
+    else options[(currentIndex - 1 + options.length) % options.length]?.focus();
+  }
+
+  return (
+    <div className={className ? `language-select ${className}` : "language-select"} ref={containerRef}>
+      <button
+        aria-controls={open ? menuID : undefined}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-label={tx("界面语言")}
+        className="language-select-trigger"
+        onClick={toggleMenu}
+        ref={triggerRef}
+        title={tx("界面语言")}
+        type="button"
+      >
+        <Globe2 aria-hidden="true" size={16} />
+        <span className="language-select-label">{current.nativeLabel}</span>
+        <ChevronDown aria-hidden="true" className="language-select-chevron" size={14} />
+      </button>
+      {open && typeof document !== "undefined" ? createPortal(
+        <div
+          className="language-select-options"
+          data-theme={menuTheme}
+          id={menuID}
+          ref={optionsRef}
+          role="listbox"
+          style={position}
+        >
+          {languageOptions.map((option) => {
+            const selected = language === option.value;
+            return (
+              <button
+                aria-selected={selected}
+                className={selected ? "language-select-option selected" : "language-select-option"}
+                key={option.value}
+                onClick={() => selectLanguage(option.value)}
+                onKeyDown={moveOptionFocus}
+                role="option"
+                type="button"
+              >
+                <span>{option.nativeLabel}</span>
+                {selected ? <Check aria-hidden="true" size={15} /> : null}
+              </button>
+            );
+          })}
+        </div>,
+        document.body,
+      ) : null}
+    </div>
+  );
+}
+
+export function languageOptionLabel(option: { label: string; nativeLabel: string }, language: AppLanguage) {
+  return language === "en" ? option.label : option.nativeLabel;
+}

--- a/frontend/features/admin/i18n/language-switcher.tsx
+++ b/frontend/features/admin/i18n/language-switcher.tsx
@@ -129,6 +129,7 @@ export function LanguageSelect({
       </button>
       {open && typeof document !== "undefined" ? createPortal(
         <div
+          aria-label={tx("界面语言")}
           className="language-select-options"
           data-theme={menuTheme}
           id={menuID}

--- a/frontend/features/admin/i18n/runtime.tsx
+++ b/frontend/features/admin/i18n/runtime.tsx
@@ -1,20 +1,15 @@
 import { languageStorageKey } from "../core/types";
+import { type AppLanguage, languageFromLocales, languageOptions, preferredLanguage } from "./language-preference";
 import { translations } from "./translations";
 
-export type AppLanguage = "zh-CN" | "en" | "ja";
-
-export const languageOptions: Array<{ value: AppLanguage; label: string; nativeLabel: string }> = [
-  { value: "zh-CN", label: "Chinese", nativeLabel: "简体中文" },
-  { value: "en", label: "English", nativeLabel: "English" },
-  { value: "ja", label: "Japanese", nativeLabel: "日本語" },
-];
+export { type AppLanguage, languageFromLocales, languageOptions, preferredLanguage };
 
 export let activeLanguage: AppLanguage = "en";
 
 export function readSavedLanguage(): AppLanguage {
   if (typeof window === "undefined") return "en";
   const saved = window.localStorage.getItem(languageStorageKey);
-  return saved === "en" || saved === "ja" || saved === "zh-CN" ? saved : "en";
+  return preferredLanguage(saved, navigator.languages?.length ? navigator.languages : [navigator.language]);
 }
 
 export function setActiveLanguage(language: AppLanguage) {

--- a/frontend/features/admin/shell/admin-console.tsx
+++ b/frontend/features/admin/shell/admin-console.tsx
@@ -731,7 +731,9 @@ export function AdminConsole({ defaultBaseURL }: { defaultBaseURL: string }) {
       <ResetPasswordView
         loading={loading}
         error={error}
+        language={language}
         theme={theme}
+        onLanguageChange={changeLanguage}
         onThemeToggle={toggleTheme}
         token={resetToken}
         onReset={(token, password) => void resetPassword(token, password)}
@@ -747,7 +749,9 @@ export function AdminConsole({ defaultBaseURL }: { defaultBaseURL: string }) {
         baseURL={baseURL}
         identityProviders={loginIdentityProviders}
         oauthReturnURL={oauthReturnURL}
+        language={language}
         theme={theme}
+        onLanguageChange={changeLanguage}
         onThemeToggle={toggleTheme}
         onLogin={(identity, password) => void login(identity, password)}
       />
@@ -775,7 +779,9 @@ export function AdminConsole({ defaultBaseURL }: { defaultBaseURL: string }) {
           activeView={activeView}
           data={data}
           user={currentUser}
+          language={language}
           theme={theme}
+          onLanguageChange={changeLanguage}
           onSelectView={selectView}
           onThemeToggle={toggleTheme}
         />

--- a/frontend/features/admin/shell/auth.tsx
+++ b/frontend/features/admin/shell/auth.tsx
@@ -4,7 +4,8 @@ import { savePendingOAuthBaseURL } from "../core/session";
 import { type LoginIdentityProvider, viewRoutes } from "../core/types";
 import { stringifyValue } from "../domain/entities";
 import { identityProviderIconLabel } from "../domain/labels";
-import { activeLanguage, tx } from "../i18n/runtime";
+import { LanguageSelect } from "../i18n/language-switcher";
+import { activeLanguage, type AppLanguage, tx } from "../i18n/runtime";
 
 export const identityProviderIconOptions = [
   "auto",
@@ -522,13 +523,36 @@ export function loginIdentityProviderIconConfig(key: string): { key: string; ico
   }
 }
 
+function LoginUtilityActions({
+  language,
+  theme,
+  onLanguageChange,
+  onThemeToggle,
+}: {
+  language: AppLanguage;
+  theme: "light" | "dark";
+  onLanguageChange: (language: AppLanguage) => void;
+  onThemeToggle: () => void;
+}) {
+  return (
+    <div className="login-utility-actions">
+      <LanguageSelect className="login-language-select" language={language} onChange={onLanguageChange} />
+      <button className="login-theme-toggle" onClick={onThemeToggle} title={tx("切换主题")} type="button">
+        {theme === "light" ? <Moon size={17} /> : <Sun size={17} />}
+      </button>
+    </div>
+  );
+}
+
 export function LoginView({
   loading,
   error,
   baseURL,
   identityProviders,
   oauthReturnURL,
+  language,
   theme,
+  onLanguageChange,
   onThemeToggle,
   onLogin,
 }: {
@@ -537,7 +561,9 @@ export function LoginView({
   baseURL: string;
   identityProviders: LoginIdentityProvider[];
   oauthReturnURL: string;
+  language: AppLanguage;
   theme: "light" | "dark";
+  onLanguageChange: (language: AppLanguage) => void;
   onThemeToggle: () => void;
   onLogin: (identity: string, password: string) => void;
 }) {
@@ -559,9 +585,12 @@ export function LoginView({
 
   return (
     <main className="login-shell" data-theme={theme}>
-      <button className="login-theme-toggle" onClick={onThemeToggle} title={tx("切换主题")} type="button">
-        {theme === "light" ? <Moon size={17} /> : <Sun size={17} />}
-      </button>
+      <LoginUtilityActions
+        language={language}
+        theme={theme}
+        onLanguageChange={onLanguageChange}
+        onThemeToggle={onThemeToggle}
+      />
       <section className="login-stage">
         <aside className={`login-hero-panel${heroPaused ? " is-paused" : ""}`} aria-label="TokenHub">
           <div className="login-brand-lockup">
@@ -709,14 +738,18 @@ export function LoginView({
 export function ResetPasswordView({
   loading,
   error,
+  language,
   theme,
+  onLanguageChange,
   onThemeToggle,
   token,
   onReset,
 }: {
   loading: boolean;
   error: string;
+  language: AppLanguage;
   theme: "light" | "dark";
+  onLanguageChange: (language: AppLanguage) => void;
   onThemeToggle: () => void;
   token: string;
   onReset: (token: string, password: string) => void;
@@ -734,9 +767,12 @@ export function ResetPasswordView({
 
   return (
     <main className="login-shell" data-theme={theme}>
-      <button className="login-theme-toggle" onClick={onThemeToggle} title={tx("切换主题")} type="button">
-        {theme === "light" ? <Moon size={17} /> : <Sun size={17} />}
-      </button>
+      <LoginUtilityActions
+        language={language}
+        theme={theme}
+        onLanguageChange={onLanguageChange}
+        onThemeToggle={onThemeToggle}
+      />
       <section className="login-stage">
         <form className="login-card" onSubmit={submit}>
           <div className="login-card-head">

--- a/frontend/features/admin/shell/navigation-ui.tsx
+++ b/frontend/features/admin/shell/navigation-ui.tsx
@@ -4,7 +4,8 @@ import { appRole, filterNavItemByAccess, isNavItemActive, isNavParentItem, navGr
 import { type AdminUser, type AppData, type NavItem, type ViewKey } from "../core/types";
 import { formatMoney, formatNumber, playgroundModels } from "../domain/formatting";
 import { roleLabel, userInitial } from "../domain/labels";
-import { displayText, tx } from "../i18n/runtime";
+import { LanguageSelect } from "../i18n/language-switcher";
+import { type AppLanguage, displayText, tx } from "../i18n/runtime";
 import { resourceConfigFor } from "../resources/settings-config";
 
 export function Sidebar({
@@ -327,14 +328,18 @@ export function TopNav({
   activeView,
   data,
   user,
+  language,
   theme,
+  onLanguageChange,
   onSelectView,
   onThemeToggle,
 }: {
   activeView: ViewKey;
   data: AppData;
   user: AdminUser;
+  language: AppLanguage;
   theme: "light" | "dark";
+  onLanguageChange: (language: AppLanguage) => void;
   onSelectView: (view: ViewKey) => void;
   onThemeToggle: () => void;
 }) {
@@ -459,6 +464,7 @@ export function TopNav({
           <span>{userInitial(user)}</span>
           <strong>{roleLabel(user.role)}</strong>
         </div>
+        <LanguageSelect className="topbar-language-select" language={language} onChange={onLanguageChange} />
         <button className="top-icon-button" onClick={onThemeToggle} title={tx("切换主题")} type="button">
           {theme === "light" ? <Moon size={17} /> : <Sun size={17} />}
         </button>

--- a/frontend/features/admin/views/settings-table.tsx
+++ b/frontend/features/admin/views/settings-table.tsx
@@ -5,6 +5,7 @@ import { filterRows } from "../domain/catalog";
 import { readPath, rowID, stringifyValue } from "../domain/entities";
 import { formatNumber, formatTime } from "../domain/formatting";
 import { settingsTabLabel } from "../domain/labels";
+import { LanguageSwitcher, languageOptionLabel } from "../i18n/language-switcher";
 import { activeLanguage, type AppLanguage, countWithLabel, displayText, languageOptions, translatedCell, tx } from "../i18n/runtime";
 import { defaultFormValues } from "../resources/payloads";
 import { apiKeyStatusAction, APIKeyDownloadMenu, APIKeyStatusSwitch } from "../resources/project-key-config";
@@ -121,37 +122,6 @@ export function LanguagePreferenceRow({
       </div>
     </div>
   );
-}
-
-export function LanguageSwitcher({
-  language,
-  onChange,
-  className,
-}: {
-  language: AppLanguage;
-  onChange: (language: AppLanguage) => void;
-  className?: string;
-}) {
-  return (
-    <div className={className ? `language-switcher ${className}` : "language-switcher"} role="radiogroup" aria-label={tx("界面语言")}>
-      {languageOptions.map((option) => (
-        <button
-          aria-checked={language === option.value}
-          className={language === option.value ? "active" : ""}
-          key={option.value}
-          onClick={() => onChange(option.value)}
-          role="radio"
-          type="button"
-        >
-          <span>{languageOptionLabel(option, language)}</span>
-        </button>
-      ))}
-    </div>
-  );
-}
-
-export function languageOptionLabel(option: { label: string; nativeLabel: string }, language: AppLanguage) {
-  return language === "en" ? option.label : option.nativeLabel;
 }
 
 export function SystemSettingsPanel({

--- a/tools/admin-language-preference.test.mjs
+++ b/tools/admin-language-preference.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { languageFromLocales, preferredLanguage } from "../frontend/features/admin/i18n/language-preference.ts";
+
+describe("admin language preference", () => {
+  it("detects supported browser languages", () => {
+    assert.equal(languageFromLocales(["zh-CN"]), "zh-CN");
+    assert.equal(languageFromLocales(["zh-Hant-TW"]), "zh-CN");
+    assert.equal(languageFromLocales(["ja-JP"]), "ja");
+    assert.equal(languageFromLocales(["en-GB"]), "en");
+  });
+
+  it("uses the first supported browser language and otherwise falls back to English", () => {
+    assert.equal(languageFromLocales(["fr-FR", "ja-JP", "en-US"]), "ja");
+    assert.equal(languageFromLocales(["fr-FR", "de-DE"]), "en");
+  });
+
+  it("keeps a saved choice ahead of browser detection", () => {
+    assert.equal(preferredLanguage("en", ["zh-CN"]), "en");
+    assert.equal(preferredLanguage("zh-CN", ["en-US"]), "zh-CN");
+    assert.equal(preferredLanguage("unsupported", ["ja-JP"]), "ja");
+  });
+});


### PR DESCRIPTION
## Summary

The admin console currently falls back to English when no preference is saved, while its general language control is only available under system settings. This makes the initial language surprising for Chinese and Japanese browsers and prevents lower-privilege users from changing it.

## Related Issue

Supersedes #131.

## Changes

- Resolve the first-run language from the browser's supported locale list while keeping a saved browser preference authoritative.
- Add a compact language menu beside the theme control on login and password-reset pages.
- Add the same language menu to the global top bar so every signed-in role can change the UI language.
- Render the menu in a portal to avoid shell clipping and support outside-click, Escape, focus, and arrow-key interactions.
- Keep the existing system-settings preference entry and reuse the shared language components.
- Add regression tests for locale detection, fallback, and saved-preference precedence.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `node --test tools/*.test.mjs` (102 tests passed)
- `node tools/check-doc-translations.mjs --base origin/main --head HEAD`
- `node tools/check-ui-translations.mjs --base origin/main --head HEAD`
- `node tools/check-source-lines.mjs`
- `npm run typecheck`
- `npm run build`
- `git diff --check origin/main..HEAD`

## Compatibility, Security, and Operations

No API, persistence, authorization, environment, or deployment changes. The preference remains local to the current browser, and existing saved language values continue to take precedence.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.