### PR TITLE
feat(audit): paginate request logs in SQL

### DIFF
--- a/backend/internal/server/admin_operations_http.go
+++ b/backend/internal/server/admin_operations_http.go
@@ -696,18 +696,6 @@ func (s *Server) handleAdminGenerateBilling(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusOK, result)
 }
 
-func (s *Server) handleAdminRequestLogs(w http.ResponseWriter, r *http.Request) {
-	user, ok := s.requireAdmin(w, r, "audit", r.Method)
-	if !ok {
-		return
-	}
-	if r.Method != http.MethodGet {
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]any{"data": s.requestLogsWithUsageForUser(user)})
-}
-
 func (s *Server) handleAdminRequestDetail(w http.ResponseWriter, r *http.Request) {
 	user, ok := s.requireAdmin(w, r, "audit", r.Method)
 	if !ok {

--- a/backend/internal/server/admin_request_logs.go
+++ b/backend/internal/server/admin_request_logs.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultRequestLogPageSize = 20
+	maxRequestLogPageSize     = 100
+)
+
+func (s *Server) handleAdminRequestLogs(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAdmin(w, r, "audit", r.Method)
+	if !ok {
+		return
+	}
+	if r.Method != http.MethodGet {
+		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
+		return
+	}
+	query, err := s.requestLogQueryForUser(user, r)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	page, err := s.store.QueryRequestLogs(query)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	if !s.canViewGlobalOperations(user) {
+		for index := range page.Data {
+			page.Data[index].ProviderCostUSD = 0
+		}
+	}
+	writeJSON(w, http.StatusOK, page)
+}
+
+func (s *Server) requestLogQueryForUser(user AdminUser, r *http.Request) (RequestLogQuery, error) {
+	page, err := positiveRequestLogQueryInt(r.URL.Query().Get("page"), 1)
+	if err != nil {
+		return RequestLogQuery{}, err
+	}
+	pageSize, err := positiveRequestLogQueryInt(r.URL.Query().Get("page_size"), defaultRequestLogPageSize)
+	if err != nil {
+		return RequestLogQuery{}, err
+	}
+	if pageSize > maxRequestLogPageSize {
+		pageSize = maxRequestLogPageSize
+	}
+	if page-1 > int(^uint(0)>>1)/pageSize {
+		return RequestLogQuery{}, NewHTTPError(http.StatusBadRequest, "invalid_request", "page offset is too large")
+	}
+	query := RequestLogQuery{
+		Page:     page,
+		PageSize: pageSize,
+		Status:   strings.ToLower(strings.TrimSpace(r.URL.Query().Get("status"))),
+		Keyword:  strings.TrimSpace(r.URL.Query().Get("q")),
+		Global:   s.canViewGlobalOperations(user),
+	}
+	if query.Status == "" {
+		query.Status = "all"
+	}
+	if query.Status != "all" && query.Status != "ok" && query.Status != "error" {
+		return RequestLogQuery{}, NewHTTPError(http.StatusBadRequest, "invalid_request", "status must be all, ok, or error")
+	}
+	if query.Global {
+		return query, nil
+	}
+	if normalizeAdminRole(user.Role) == "team_leader" {
+		query.ProjectIDs = trueMapKeys(s.visibleProjectIDSet(user))
+	}
+	query.APIKeyIDs = trueMapKeys(s.visibleAPIKeyIDSet(user))
+	return query, nil
+}
+
+func positiveRequestLogQueryInt(value string, fallback int) (int, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback, nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed < 1 {
+		return 0, NewHTTPError(http.StatusBadRequest, "invalid_request", "page and page_size must be positive integers")
+	}
+	return parsed, nil
+}
+
+func trueMapKeys(values map[string]bool) []string {
+	keys := make([]string, 0, len(values))
+	for key, include := range values {
+		if include {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}

--- a/backend/internal/server/admin_request_logs_test.go
+++ b/backend/internal/server/admin_request_logs_test.go
@@ -1,0 +1,384 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestAdminRequestLogsDefaultsToTwentyItems(t *testing.T) {
+	store := NewMemoryStore()
+	createdAt := time.Date(2026, time.August, 5, 10, 0, 0, 0, time.UTC)
+	for index := 1; index <= 25; index++ {
+		statusCode := http.StatusOK
+		if index%5 == 0 {
+			statusCode = http.StatusBadGateway
+		}
+		if err := store.db.Create(&RequestLog{
+			ID:         fmt.Sprintf("log_%02d", index),
+			RequestID:  fmt.Sprintf("req_%02d", index),
+			ProjectID:  "project_audit_page",
+			APIKeyID:   "key_audit_page",
+			ModelName:  "gpt-audit",
+			StatusCode: statusCode,
+			LatencyMS:  int64(100 + index),
+			CreatedAt:  createdAt,
+		}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.db.Create(&UsageRecord{
+		ID:          "usage_audit_page",
+		RequestID:   "req_25",
+		ProjectID:   "project_audit_page",
+		APIKeyID:    "key_audit_page",
+		TotalTokens: 42,
+		CostUSD:     0.0042,
+		CreatedAt:   createdAt,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	response := doJSON(t, New(store).Handler(), http.MethodGet, "/api/admin/audit/requests", nil, "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected request logs 200, got %d: %s", response.Code, response.Body)
+	}
+	var payload struct {
+		Data       []RequestLog         `json:"data"`
+		Pagination RequestLogPagination `json:"pagination"`
+		Summary    RequestLogSummary    `json:"summary"`
+	}
+	if err := json.Unmarshal([]byte(response.Body), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Data) != 20 {
+		t.Fatalf("expected default page size 20, got %d", len(payload.Data))
+	}
+	if payload.Pagination.Page != 1 || payload.Pagination.PageSize != 20 || payload.Pagination.Total != 25 || payload.Pagination.TotalPages != 2 {
+		t.Fatalf("unexpected pagination: %+v", payload.Pagination)
+	}
+	if payload.Summary.All != 25 || payload.Summary.OK != 20 || payload.Summary.Error != 5 || payload.Summary.AverageLatencyMS != 113 {
+		t.Fatalf("unexpected summary: %+v", payload.Summary)
+	}
+	if payload.Data[0].ID != "log_25" || payload.Data[19].ID != "log_06" {
+		t.Fatalf("expected stable created_at/id order, got first=%s last=%s", payload.Data[0].ID, payload.Data[19].ID)
+	}
+	if payload.Data[0].UsageRecordCount != 1 || payload.Data[0].TotalTokens != 42 || payload.Data[0].EstimatedCostUSD != 0.0042 {
+		t.Fatalf("expected current-page usage enrichment, got %+v", payload.Data[0])
+	}
+	secondResponse := doJSON(t, New(store).Handler(), http.MethodGet, "/api/admin/audit/requests?page=2", nil, "")
+	var secondPage RequestLogPage
+	if err := json.Unmarshal([]byte(secondResponse.Body), &secondPage); err != nil {
+		t.Fatal(err)
+	}
+	if len(secondPage.Data) != 5 || secondPage.Data[0].ID != "log_05" || secondPage.Data[4].ID != "log_01" {
+		t.Fatalf("expected stable non-overlapping second page, got %+v", secondPage.Data)
+	}
+}
+
+func TestAdminRequestLogsFiltersStatusBeforePagination(t *testing.T) {
+	store := NewMemoryStore()
+	createdAt := time.Date(2026, time.August, 5, 11, 0, 0, 0, time.UTC)
+	for index := 1; index <= 31; index++ {
+		statusCode := http.StatusOK
+		if index > 25 {
+			statusCode = http.StatusBadGateway
+		}
+		if err := store.db.Create(&RequestLog{
+			ID:         fmt.Sprintf("status_log_%02d", index),
+			RequestID:  fmt.Sprintf("status_req_%02d", index),
+			ProjectID:  "project_status_page",
+			APIKeyID:   "key_status_page",
+			ModelName:  "gpt-status",
+			StatusCode: statusCode,
+			LatencyMS:  int64(index),
+			CreatedAt:  createdAt,
+		}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	response := doJSON(t, New(store).Handler(), http.MethodGet, "/api/admin/audit/requests?status=error&page=1&page_size=5", nil, "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected filtered request logs 200, got %d: %s", response.Code, response.Body)
+	}
+	var payload struct {
+		Data       []RequestLog         `json:"data"`
+		Pagination RequestLogPagination `json:"pagination"`
+		Summary    RequestLogSummary    `json:"summary"`
+	}
+	if err := json.Unmarshal([]byte(response.Body), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Data) != 5 {
+		t.Fatalf("expected five error logs on the first page, got %d", len(payload.Data))
+	}
+	for _, log := range payload.Data {
+		if log.StatusCode < http.StatusBadRequest {
+			t.Fatalf("status filter returned successful request: %+v", log)
+		}
+	}
+	if payload.Pagination.Total != 6 || payload.Pagination.TotalPages != 2 {
+		t.Fatalf("status filter must run before pagination: %+v", payload.Pagination)
+	}
+	if payload.Summary.All != 31 || payload.Summary.OK != 25 || payload.Summary.Error != 6 {
+		t.Fatalf("summary should retain status-tab counts: %+v", payload.Summary)
+	}
+}
+
+func TestAdminRequestLogsSearchesExistingAuditFields(t *testing.T) {
+	store := NewMemoryStore()
+	project := store.CreateProject(Project{ID: "project_search", Name: "Alpha Finance"})
+	provider := store.AddProvider(Provider{ID: "provider_search", Name: "Jade Channel", Type: "openai_compatible"})
+	createdAt := time.Date(2026, time.August, 5, 12, 0, 0, 0, time.UTC)
+	if err := store.db.Create(&RequestLog{
+		ID:                 "log_search_match",
+		RequestID:          "req-needle-id",
+		ProjectID:          project.ID,
+		APIKeyID:           "key-needle-id",
+		ModelName:          "gpt-needle-model",
+		ProviderID:         provider.ID,
+		ProviderResourceID: "resource-needle-id",
+		ProviderModel:      "upstream-needle-model",
+		StatusCode:         http.StatusTooManyRequests,
+		ErrorCode:          "rate-limit-needle",
+		CreatedAt:          createdAt,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.Create(&RequestLog{
+		ID:         "log_search_noise",
+		RequestID:  "req-unrelated",
+		ProjectID:  "project_unrelated",
+		APIKeyID:   "key_unrelated",
+		ModelName:  "gpt-unrelated",
+		StatusCode: http.StatusOK,
+		CreatedAt:  createdAt.Add(-time.Minute),
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	app := New(store).Handler()
+	keywords := []string{
+		"REQ-NEEDLE-ID",
+		"Alpha Finance",
+		"jade channel",
+		"key-needle-id",
+		"gpt-needle-model",
+		"provider_search",
+		"resource-needle-id",
+		"upstream-needle-model",
+		"rate-limit-needle",
+		"429",
+	}
+	for _, keyword := range keywords {
+		t.Run(keyword, func(t *testing.T) {
+			response := doJSON(t, app, http.MethodGet, "/api/admin/audit/requests?q="+url.QueryEscape(keyword), nil, "")
+			if response.Code != http.StatusOK {
+				t.Fatalf("expected search 200, got %d: %s", response.Code, response.Body)
+			}
+			var payload struct {
+				Data       []RequestLog         `json:"data"`
+				Pagination RequestLogPagination `json:"pagination"`
+				Summary    RequestLogSummary    `json:"summary"`
+			}
+			if err := json.Unmarshal([]byte(response.Body), &payload); err != nil {
+				t.Fatal(err)
+			}
+			if len(payload.Data) != 1 || payload.Data[0].ID != "log_search_match" {
+				t.Fatalf("keyword %q returned unexpected data: %+v", keyword, payload.Data)
+			}
+			if payload.Pagination.Total != 1 || payload.Summary.All != 1 || payload.Summary.Error != 1 {
+				t.Fatalf("keyword %q returned unexpected metadata: pagination=%+v summary=%+v", keyword, payload.Pagination, payload.Summary)
+			}
+		})
+	}
+	for _, literal := range []string{"%", "!"} {
+		wildcard := doJSON(t, app, http.MethodGet, "/api/admin/audit/requests?q="+url.QueryEscape(literal), nil, "")
+		var wildcardPayload RequestLogPage
+		if err := json.Unmarshal([]byte(wildcard.Body), &wildcardPayload); err != nil {
+			t.Fatal(err)
+		}
+		if len(wildcardPayload.Data) != 0 || wildcardPayload.Summary.All != 0 {
+			t.Fatalf("LIKE wildcard %q must be searched literally: %+v", literal, wildcardPayload)
+		}
+	}
+}
+
+func TestAdminRequestLogsValidatesAndCapsPagination(t *testing.T) {
+	app := New(NewMemoryStore()).Handler()
+	for _, path := range []string{
+		"/api/admin/audit/requests?page=0",
+		"/api/admin/audit/requests?page_size=-1",
+		"/api/admin/audit/requests?page=9223372036854775807&page_size=100",
+		"/api/admin/audit/requests?status=pending",
+	} {
+		response := doJSON(t, app, http.MethodGet, path, nil, "")
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("expected %s to return 400, got %d: %s", path, response.Code, response.Body)
+		}
+	}
+	response := doJSON(t, app, http.MethodGet, "/api/admin/audit/requests?page_size=1000", nil, "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected capped page size 200, got %d: %s", response.Code, response.Body)
+	}
+	var payload RequestLogPage
+	if err := json.Unmarshal([]byte(response.Body), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Pagination.PageSize != maxRequestLogPageSize {
+		t.Fatalf("page size = %d, want cap %d", payload.Pagination.PageSize, maxRequestLogPageSize)
+	}
+}
+
+func TestRequestLogPaginationIndexesCoverVisibleScopes(t *testing.T) {
+	store := NewMemoryStore()
+	tests := []struct {
+		name    string
+		columns []string
+	}{
+		{name: "idx_request_logs_created_at", columns: []string{"created_at"}},
+		{name: "idx_request_logs_project_created", columns: []string{"project_id", "created_at"}},
+		{name: "idx_request_logs_api_key_created", columns: []string{"api_key_id", "created_at"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var owner struct {
+				TableName string
+			}
+			if err := store.db.Raw(
+				"SELECT tbl_name AS table_name FROM sqlite_master WHERE type = 'index' AND name = ?",
+				test.name,
+			).Scan(&owner).Error; err != nil {
+				t.Fatal(err)
+			}
+			if owner.TableName != "request_logs" {
+				t.Fatalf("index %s belongs to %q, want request_logs", test.name, owner.TableName)
+			}
+			var rows []struct {
+				Seq  int
+				Name string
+			}
+			if err := store.db.Raw("PRAGMA index_info('" + test.name + "')").Scan(&rows).Error; err != nil {
+				t.Fatal(err)
+			}
+			if len(rows) != len(test.columns) {
+				t.Fatalf("index %s columns = %+v, want %+v", test.name, rows, test.columns)
+			}
+			for index, column := range test.columns {
+				if rows[index].Name != column {
+					t.Fatalf("index %s column %d = %s, want %s", test.name, index, rows[index].Name, column)
+				}
+			}
+		})
+	}
+}
+
+func TestUserRequestLogScopeRunsBeforePagination(t *testing.T) {
+	store := NewMemoryStore()
+	user, err := store.CreateAdminUser(AdminUser{
+		Username: "request-scope-user",
+		Email:    "request-scope-user@tokenhub.local",
+		Role:     "user",
+		Status:   StatusActive,
+	}, "user123456")
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherUser, err := store.CreateAdminUser(AdminUser{
+		Username: "request-scope-other",
+		Email:    "request-scope-other@tokenhub.local",
+		Role:     "user",
+		Status:   StatusActive,
+	}, "other123456")
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := store.CreateProject(Project{Name: "Shared Request Scope", OwnerUserID: otherUser.ID})
+	store.CreateResource("project-members", AdminResource{
+		Name:   "Request Scope Viewer",
+		Status: StatusActive,
+		Fields: map[string]any{
+			"project_id": project.ID,
+			"user_id":    user.ID,
+			"role":       "viewer",
+		},
+	})
+	ownKey, _, err := store.CreateAPIKey(project.ID, APIKey{
+		Name:     "request-scope-own-key",
+		Status:   StatusActive,
+		Metadata: map[string]string{"created_by": user.ID},
+	}, "thk_request_scope_own")
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherKey, _, err := store.CreateAPIKey(project.ID, APIKey{
+		Name:     "request-scope-other-key",
+		Status:   StatusActive,
+		Metadata: map[string]string{"created_by": otherUser.ID},
+	}, "thk_request_scope_other")
+	if err != nil {
+		t.Fatal(err)
+	}
+	createdAt := time.Date(2026, time.August, 5, 13, 0, 0, 0, time.UTC)
+	if err := store.db.Create(&RequestLog{
+		ID: "log_scope_own", RequestID: "req_scope_own", ProjectID: project.ID, APIKeyID: ownKey.ID,
+		StatusCode: http.StatusOK, CreatedAt: createdAt,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	for index := 1; index <= 25; index++ {
+		if err := store.db.Create(&RequestLog{
+			ID:         fmt.Sprintf("log_scope_other_%02d", index),
+			RequestID:  fmt.Sprintf("req_scope_other_%02d", index),
+			ProjectID:  project.ID,
+			APIKeyID:   otherKey.ID,
+			StatusCode: http.StatusOK,
+			CreatedAt:  createdAt.Add(time.Duration(index) * time.Second),
+		}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, record := range []UsageRecord{
+		{ID: "usage_scope_own", RequestID: "req_scope_own", ProjectID: project.ID, APIKeyID: ownKey.ID, TotalTokens: 42, CostUSD: 0.0042, CreatedAt: createdAt},
+		{ID: "usage_scope_hidden_collision", RequestID: "req_scope_own", ProjectID: project.ID, APIKeyID: otherKey.ID, TotalTokens: 999, CostUSD: 9.99, CreatedAt: createdAt},
+	} {
+		if err := store.db.Create(&record).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	app := New(store).Handler()
+	login := doJSON(t, app, http.MethodPost, "/api/admin/auth/login", map[string]any{
+		"identity": user.Email,
+		"password": "user123456",
+	}, "")
+	var credentials struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal([]byte(login.Body), &credentials); err != nil {
+		t.Fatal(err)
+	}
+	response := doJSON(t, app, http.MethodGet, "/api/admin/audit/requests", nil, credentials.Token)
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected scoped request logs 200, got %d: %s", response.Code, response.Body)
+	}
+	var payload struct {
+		Data       []RequestLog         `json:"data"`
+		Pagination RequestLogPagination `json:"pagination"`
+		Summary    RequestLogSummary    `json:"summary"`
+	}
+	if err := json.Unmarshal([]byte(response.Body), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Data) != 1 || payload.Data[0].RequestID != "req_scope_own" {
+		t.Fatalf("user scope leaked another key's log from the same project: %+v", payload.Data)
+	}
+	if payload.Data[0].TotalTokens != 42 || payload.Data[0].EstimatedCostUSD != 0.0042 || payload.Data[0].UsageRecordCount != 1 {
+		t.Fatalf("user scope leaked colliding hidden usage into the visible log: %+v", payload.Data[0])
+	}
+	if payload.Pagination.Total != 1 || payload.Summary.All != 1 {
+		t.Fatalf("hidden logs must not participate in metadata: pagination=%+v summary=%+v", payload.Pagination, payload.Summary)
+	}
+}

--- a/backend/internal/server/request_log_usage.go
+++ b/backend/internal/server/request_log_usage.go
@@ -1,17 +1,5 @@
 package server
 
-func (s *Server) requestLogsWithUsageForUser(user AdminUser) []RequestLog {
-	logs := s.filterRequestLogsForUser(user, s.store.ListRequestLogs())
-	records := s.filterUsageRecordsForUser(user, s.store.ListUsageRecords())
-	result := enrichRequestLogsWithUsage(logs, records)
-	if !s.canViewGlobalOperations(user) {
-		for index := range result {
-			result[index].ProviderCostUSD = 0
-		}
-	}
-	return result
-}
-
 func enrichRequestLogsWithUsage(logs []RequestLog, records []UsageRecord) []RequestLog {
 	byRequestID := make(map[string]*RequestLog, len(logs))
 	result := make([]RequestLog, len(logs))
@@ -24,21 +12,25 @@ func enrichRequestLogsWithUsage(logs []RequestLog, records []UsageRecord) []Requ
 		if log == nil {
 			continue
 		}
-		log.InputTokens += record.InputTokens
-		log.CachedInputTokens += record.CachedInputTokens
-		log.CacheWriteTokens += record.CacheWriteTokens
-		log.InputAudioTokens += record.InputAudioTokens
-		log.OutputTokens += record.OutputTokens
-		log.ReasoningTokens += record.ReasoningTokens
-		log.OutputAudioTokens += record.OutputAudioTokens
-		log.AcceptedPredictionTokens += record.AcceptedPredictionTokens
-		log.RejectedPredictionTokens += record.RejectedPredictionTokens
-		log.TotalTokens += record.TotalTokens
-		log.EstimatedCostUSD += record.CostUSD
-		log.ProviderCostUSD += record.ProviderCostUSD
-		log.UsageRecordCount++
+		enrichRequestLogWithUsageRecord(log, record)
 	}
 	return result
+}
+
+func enrichRequestLogWithUsageRecord(log *RequestLog, record UsageRecord) {
+	log.InputTokens += record.InputTokens
+	log.CachedInputTokens += record.CachedInputTokens
+	log.CacheWriteTokens += record.CacheWriteTokens
+	log.InputAudioTokens += record.InputAudioTokens
+	log.OutputTokens += record.OutputTokens
+	log.ReasoningTokens += record.ReasoningTokens
+	log.OutputAudioTokens += record.OutputAudioTokens
+	log.AcceptedPredictionTokens += record.AcceptedPredictionTokens
+	log.RejectedPredictionTokens += record.RejectedPredictionTokens
+	log.TotalTokens += record.TotalTokens
+	log.EstimatedCostUSD += record.CostUSD
+	log.ProviderCostUSD += record.ProviderCostUSD
+	log.UsageRecordCount++
 }
 
 func (s *Server) redactProviderCostsForUser(user AdminUser, detail map[string]any) {

--- a/backend/internal/server/store.go
+++ b/backend/internal/server/store.go
@@ -176,6 +176,7 @@ type Store interface {
 	ListUsageRecords() []UsageRecord
 	GenerateBillingPeriod(period string) (map[string]any, error)
 	ListRequestLogs() []RequestLog
+	QueryRequestLogs(query RequestLogQuery) (RequestLogPage, error)
 	ListProviderObservations(since time.Time) []ProviderObservation
 	RecordProviderObservation(observation ProviderObservation)
 	GetProviderResourceObservation(resourceID string) (ProviderResourceObservation, bool)

--- a/backend/internal/server/store_request_logs.go
+++ b/backend/internal/server/store_request_logs.go
@@ -1,0 +1,203 @@
+package server
+
+import (
+	"math"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+type RequestLogQuery struct {
+	Page       int
+	PageSize   int
+	Status     string
+	Keyword    string
+	Global     bool
+	ProjectIDs []string
+	APIKeyIDs  []string
+}
+
+type RequestLogPagination struct {
+	Page       int   `json:"page"`
+	PageSize   int   `json:"page_size"`
+	Total      int64 `json:"total"`
+	TotalPages int   `json:"total_pages"`
+}
+
+type RequestLogSummary struct {
+	All              int64 `json:"all"`
+	OK               int64 `json:"ok"`
+	Error            int64 `json:"error"`
+	AverageLatencyMS int64 `json:"average_latency_ms"`
+}
+
+type RequestLogPage struct {
+	Data       []RequestLog         `json:"data"`
+	Pagination RequestLogPagination `json:"pagination"`
+	Summary    RequestLogSummary    `json:"summary"`
+}
+
+func (s *GormStore) QueryRequestLogs(query RequestLogQuery) (RequestLogPage, error) {
+	summaryQuery := requestLogBaseQuery(s.db, query)
+	var summaryRow struct {
+		AllCount       int64
+		OKCount        int64
+		ErrorCount     int64
+		AverageLatency float64
+	}
+	if err := summaryQuery.Select(
+		"COUNT(*) AS all_count, " +
+			"COALESCE(SUM(CASE WHEN status_code < 400 THEN 1 ELSE 0 END), 0) AS ok_count, " +
+			"COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count, " +
+			"COALESCE(AVG(latency_ms), 0) AS average_latency",
+	).Scan(&summaryRow).Error; err != nil {
+		return RequestLogPage{}, err
+	}
+
+	total := summaryRow.AllCount
+	if query.Status != "" && query.Status != "all" {
+		countQuery := applyRequestLogStatus(requestLogBaseQuery(s.db, query), query.Status)
+		if err := countQuery.Count(&total).Error; err != nil {
+			return RequestLogPage{}, err
+		}
+	}
+	logs := make([]RequestLog, 0, query.PageSize)
+	offset := (query.Page - 1) * query.PageSize
+	pageQuery := applyRequestLogStatus(requestLogBaseQuery(s.db, query), query.Status)
+	if err := pageQuery.Order("created_at DESC, id DESC").Limit(query.PageSize).Offset(offset).Find(&logs).Error; err != nil {
+		return RequestLogPage{}, err
+	}
+	if err := s.enrichRequestLogPageWithUsage(logs); err != nil {
+		return RequestLogPage{}, err
+	}
+
+	totalPages := 0
+	if total > 0 {
+		totalPages = int((total + int64(query.PageSize) - 1) / int64(query.PageSize))
+	}
+	return RequestLogPage{
+		Data: logs,
+		Pagination: RequestLogPagination{
+			Page:       query.Page,
+			PageSize:   query.PageSize,
+			Total:      total,
+			TotalPages: totalPages,
+		},
+		Summary: RequestLogSummary{
+			All:              summaryRow.AllCount,
+			OK:               summaryRow.OKCount,
+			Error:            summaryRow.ErrorCount,
+			AverageLatencyMS: int64(math.Round(summaryRow.AverageLatency)),
+		},
+	}, nil
+}
+
+func requestLogBaseQuery(db *gorm.DB, query RequestLogQuery) *gorm.DB {
+	return applyRequestLogKeyword(applyRequestLogScope(db.Model(&RequestLog{}), query), query.Keyword)
+}
+
+func applyRequestLogKeyword(db *gorm.DB, keyword string) *gorm.DB {
+	keyword = strings.TrimSpace(keyword)
+	if keyword == "" {
+		return db
+	}
+	pattern := "%" + escapeLikePattern(strings.ToLower(keyword)) + "%"
+	columns := []string{
+		"request_id",
+		"project_id",
+		"api_key_id",
+		"model_name",
+		"provider_id",
+		"provider_resource_id",
+		"provider_model",
+		"error_code",
+	}
+	conditions := make([]string, 0, len(columns)+3)
+	args := make([]any, 0, len(columns)+3)
+	for _, column := range columns {
+		conditions = append(conditions, "LOWER(COALESCE("+column+", '')) LIKE ? ESCAPE '!'")
+		args = append(args, pattern)
+	}
+	conditions = append(conditions,
+		"LOWER(CAST(status_code AS TEXT)) LIKE ? ESCAPE '!'",
+		"EXISTS (SELECT 1 FROM projects WHERE projects.id = request_logs.project_id AND LOWER(COALESCE(projects.name, '')) LIKE ? ESCAPE '!')",
+		"EXISTS (SELECT 1 FROM providers WHERE providers.id = request_logs.provider_id AND LOWER(COALESCE(providers.name, '')) LIKE ? ESCAPE '!')",
+	)
+	args = append(args, pattern, pattern, pattern)
+	return db.Where("("+strings.Join(conditions, " OR ")+")", args...)
+}
+
+func escapeLikePattern(value string) string {
+	return strings.NewReplacer(
+		"!", "!!",
+		"%", "!%",
+		"_", "!_",
+	).Replace(value)
+}
+
+func applyRequestLogStatus(db *gorm.DB, status string) *gorm.DB {
+	switch status {
+	case "ok":
+		return db.Where("status_code < 400")
+	case "error":
+		return db.Where("status_code >= 400")
+	default:
+		return db
+	}
+}
+
+func applyRequestLogScope(db *gorm.DB, query RequestLogQuery) *gorm.DB {
+	if query.Global {
+		return db
+	}
+	switch {
+	case len(query.ProjectIDs) > 0 && len(query.APIKeyIDs) > 0:
+		return db.Where("(project_id IN ? OR api_key_id IN ?)", query.ProjectIDs, query.APIKeyIDs)
+	case len(query.ProjectIDs) > 0:
+		return db.Where("project_id IN ?", query.ProjectIDs)
+	case len(query.APIKeyIDs) > 0:
+		return db.Where("api_key_id IN ?", query.APIKeyIDs)
+	default:
+		return db.Where("1 = 0")
+	}
+}
+
+func (s *GormStore) enrichRequestLogPageWithUsage(logs []RequestLog) error {
+	requestIDs := make([]string, 0, len(logs))
+	logsByScope := make(map[requestLogUsageScope]*RequestLog, len(logs))
+	for index := range logs {
+		log := &logs[index]
+		if log.RequestID != "" {
+			requestIDs = append(requestIDs, log.RequestID)
+			logsByScope[requestLogUsageScope{
+				RequestID: log.RequestID,
+				ProjectID: log.ProjectID,
+				APIKeyID:  log.APIKeyID,
+			}] = log
+		}
+	}
+	if len(requestIDs) == 0 {
+		return nil
+	}
+	var records []UsageRecord
+	if err := s.db.Where("request_id IN ?", requestIDs).Find(&records).Error; err != nil {
+		return err
+	}
+	for _, record := range records {
+		log := logsByScope[requestLogUsageScope{
+			RequestID: record.RequestID,
+			ProjectID: record.ProjectID,
+			APIKeyID:  record.APIKeyID,
+		}]
+		if log != nil {
+			enrichRequestLogWithUsageRecord(log, record)
+		}
+	}
+	return nil
+}
+
+type requestLogUsageScope struct {
+	RequestID string
+	ProjectID string
+	APIKeyID  string
+}

--- a/backend/internal/server/types.go
+++ b/backend/internal/server/types.go
@@ -452,8 +452,8 @@ type UsageRecord struct {
 type RequestLog struct {
 	ID                       string    `json:"id" gorm:"primaryKey"`
 	RequestID                string    `json:"request_id" gorm:"index"`
-	ProjectID                string    `json:"project_id" gorm:"index"`
-	APIKeyID                 string    `json:"api_key_id" gorm:"index"`
+	ProjectID                string    `json:"project_id" gorm:"index;index:idx_request_logs_project_created,priority:1"`
+	APIKeyID                 string    `json:"api_key_id" gorm:"index;index:idx_request_logs_api_key_created,priority:1"`
 	ModelName                string    `json:"model" gorm:"index"`
 	ProviderID               string    `json:"provider_id,omitempty" gorm:"index"`
 	ProviderResourceID       string    `json:"provider_resource_id,omitempty" gorm:"index"`
@@ -470,7 +470,7 @@ type RequestLog struct {
 	LatencyMS                int64     `json:"latency_ms"`
 	ClientIP                 string    `json:"client_ip,omitempty"`
 	UserAgent                string    `json:"user_agent,omitempty"`
-	CreatedAt                time.Time `json:"created_at"`
+	CreatedAt                time.Time `json:"created_at" gorm:"index:idx_request_logs_created_at;index:idx_request_logs_project_created,priority:2;index:idx_request_logs_api_key_created,priority:2"`
 	InputTokens              int64     `json:"input_tokens,omitempty" gorm:"-"`
 	CachedInputTokens        int64     `json:"cached_input_tokens,omitempty" gorm:"-"`
 	CacheWriteTokens         int64     `json:"cache_write_input_tokens,omitempty" gorm:"-"`

--- a/frontend/features/admin/core/data-loading.tsx
+++ b/frontend/features/admin/core/data-loading.tsx
@@ -118,7 +118,6 @@ export function loadPlanForView(user: AdminUser, view: ViewKey): LoadPlan {
     case "audit":
       plan.overview = true;
       plan.keys = can("api-keys");
-      plan.logs = true;
       plan.auditEvents = canViewAdminAudit(user);
       break;
     case "providers":

--- a/frontend/features/admin/core/types.tsx
+++ b/frontend/features/admin/core/types.tsx
@@ -685,6 +685,26 @@ export type RequestLog = {
   usage_record_count?: number;
 };
 
+export type RequestLogPagination = {
+  page: number;
+  page_size: number;
+  total: number;
+  total_pages: number;
+};
+
+export type RequestLogSummary = {
+  all: number;
+  ok: number;
+  error: number;
+  average_latency_ms: number;
+};
+
+export type RequestLogPage = {
+  data: RequestLog[];
+  pagination: RequestLogPagination;
+  summary: RequestLogSummary;
+};
+
 export type UsageRecord = {
   id: string;
   request_id: string;

--- a/frontend/features/admin/domain/audit-request-page.test.mjs
+++ b/frontend/features/admin/domain/audit-request-page.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { importTypeScript } from "./typescript-test-loader.mjs";
+
+const { auditRequestPagePath } = await importTypeScript(new URL("./audit-request-page.ts", import.meta.url));
+
+test("audit request page path carries server-side filters and pagination", () => {
+  assert.equal(
+    auditRequestPagePath({
+      page: 3,
+      pageSize: 50,
+      status: "error",
+      query: "Alpha Finance / 429",
+    }),
+    "/api/admin/audit/requests?page=3&page_size=50&status=error&q=Alpha+Finance+%2F+429",
+  );
+});
+
+test("audit request page path normalizes empty search terms", () => {
+  assert.equal(
+    auditRequestPagePath({
+      page: 1,
+      pageSize: 20,
+      status: "all",
+      query: "   ",
+    }),
+    "/api/admin/audit/requests?page=1&page_size=20&status=all&q=",
+  );
+});

--- a/frontend/features/admin/domain/audit-request-page.ts
+++ b/frontend/features/admin/domain/audit-request-page.ts
@@ -1,0 +1,17 @@
+export type AuditRequestStatus = "all" | "ok" | "error";
+
+export type AuditRequestPageParameters = {
+  page: number;
+  pageSize: number;
+  status: AuditRequestStatus;
+  query: string;
+};
+
+export function auditRequestPagePath(parameters: AuditRequestPageParameters) {
+  const query = new URLSearchParams();
+  query.set("page", String(parameters.page));
+  query.set("page_size", String(parameters.pageSize));
+  query.set("status", parameters.status);
+  query.set("q", parameters.query.trim());
+  return `/api/admin/audit/requests?${query.toString()}`;
+}

--- a/frontend/features/admin/shell/admin-console.tsx
+++ b/frontend/features/admin/shell/admin-console.tsx
@@ -7,6 +7,7 @@ import { allNavGroupTitles, canAccessView, defaultViewForRole, rememberRecentVie
 import { clearOAuthLoginResult, clearPendingOAuthBaseURL, clearProviderAccountOAuthResultFromLocation, clearSavedSession, forwardOAuthAuthorizationResponse, hasPendingProviderAccountOAuthResult, isOAuthAuthorizationResponse, readOAuthLoginResult, readPendingOAuthBaseURL, readProviderAccountOAuthResultFromLocation, readSavedSession, savePendingProviderAccountOAuthResult, saveSession } from "../core/session";
 import { type AdminResource, type AdminUser, type AlertDelivery, type AlertEvent, type APIKey, type AppData, type ApprovalRequest, type AuditEvent, authExpiredEventName, type BillingConnector, type BillingRecord, type BillingSyncRun, type ConfirmState, languageStorageKey, type LoginIdentityProvider, type ModalState, type Model, type ModelRoute, type ModelRoutePolicy, notificationChannelTypes, type Project, type Provider, type ProviderCatalogEntry, type ProviderModel, type ProviderMonitoringSnapshot, type ProviderResource, type ReconciliationRule, type ReconciliationRun, type ReportExportHistoryItem, type RequestLog, type ResourceAction, type ResourceConfig, type SettingsTabKey, type SQLiteBackup, type ToolbarAction, type UsageBreakdown, type UsagePoint, type ViewKey, viewRoutes } from "../core/types";
 import { emptyData, emptySummary, filterByModelCategory, filterRows } from "../domain/catalog";
+import { auditRequestPagePath } from "../domain/audit-request-page";
 import { modelRouteDefaults, rowTitle } from "../domain/entities";
 import { uniqueUIID, viewFromPath } from "../domain/formatting";
 import { reportDatasetLabel } from "../domain/labels";
@@ -313,7 +314,7 @@ export function AdminConsole({ defaultBaseURL }: { defaultBaseURL: string }) {
       queue(plan.providerModels, "provider-models", "/api/admin/provider-models");
       queue(plan.keys, "api-keys", "/api/admin/api-keys");
       queue(plan.routes, "routes", "/api/admin/routing-rules");
-      queue(plan.logs, "audit", "/api/admin/audit/requests");
+      queue(plan.logs, "audit", auditRequestPagePath({ page: 1, pageSize: 20, status: "all", query: "" }));
       queue(plan.auditEvents, "audit-events", "/api/admin/audit/events");
       queue(plan.alerts, "alerts", "/api/admin/alerts");
       queue(plan.alertDeliveries, "alert-deliveries", "/api/admin/alert-deliveries");

--- a/frontend/features/admin/shell/navigation-ui.tsx
+++ b/frontend/features/admin/shell/navigation-ui.tsx
@@ -307,7 +307,7 @@ export function pageHeaderChips(view: ViewKey, data: AppData, user: AdminUser) {
       ];
     case "audit":
       return [
-        { label: "请求日志", value: formatNumber(data.logs.length) },
+        { label: "请求日志", value: formatNumber(data.summary.request_count || data.logs.length) },
         { label: "错误请求", value: formatNumber(data.summary.errors) },
       ];
     default:

--- a/frontend/features/admin/shell/navigation-ui.tsx
+++ b/frontend/features/admin/shell/navigation-ui.tsx
@@ -307,7 +307,7 @@ export function pageHeaderChips(view: ViewKey, data: AppData, user: AdminUser) {
       ];
     case "audit":
       return [
-        { label: "请求日志", value: formatNumber(data.summary.request_count || data.logs.length) },
+        { label: "请求日志", value: formatNumber(data.summary.request_count) },
         { label: "错误请求", value: formatNumber(data.summary.errors) },
       ];
     default:

--- a/frontend/features/admin/views/audit.tsx
+++ b/frontend/features/admin/views/audit.tsx
@@ -1,19 +1,37 @@
 import { Activity, AlertCircle, Check, Copy, Gauge, Search, ShieldCheck } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { canViewAdminAudit } from "../core/navigation";
-import { type AdminUser, type ApiContext, type AppData, type RequestDetail, type RequestPayloadLog } from "../core/types";
+import { type AdminUser, type ApiContext, type AppData, type RequestDetail, type RequestLogPage, type RequestLogPagination, type RequestLogSummary, type RequestPayloadLog } from "../core/types";
+import { auditRequestPagePath, type AuditRequestStatus } from "../domain/audit-request-page";
 import { apiKeyAuditLabel, projectName, providerAttemptLabel, providerAuditLabel, providerResourceAuditLabel } from "../domain/entities";
 import { compactNumber, formatMoney, formatNumber, formatTime } from "../domain/formatting";
 import { actionLabel, enumValueLabel, resourceTypeLabel } from "../domain/labels";
 import { countWithUnit, routeAttemptCountText, tx } from "../i18n/runtime";
 import { adminFetch, isAuthExpiredError } from "../resources/payloads";
 import { DataSection, SimpleTable, StatusPill } from "../shared/ui";
-import { PaginationControls, usePagination } from "./settings-table";
+import { PaginationControls, type PaginationState } from "./settings-table";
 
 export function AuditView({ api, data, user }: { api: ApiContext; data: AppData; user: AdminUser }) {
   const [activeAuditTab, setActiveAuditTab] = useState<"requests" | "admin">("requests");
   const [query, setQuery] = useState("");
-  const [statusFilter, setStatusFilter] = useState<"all" | "ok" | "error">("all");
+  const [statusFilter, setStatusFilter] = useState<AuditRequestStatus>("all");
+  const [requestLogs, setRequestLogs] = useState(data.logs);
+  const [requestPage, setRequestPage] = useState(1);
+  const [requestPageSize, setRequestPageSize] = useState(20);
+  const [requestPagination, setRequestPagination] = useState<RequestLogPagination>({
+    page: 1,
+    page_size: 20,
+    total: data.summary.request_count || data.logs.length,
+    total_pages: Math.ceil((data.summary.request_count || data.logs.length) / 20),
+  });
+  const [requestSummary, setRequestSummary] = useState<RequestLogSummary>({
+    all: data.summary.request_count || data.logs.length,
+    ok: Math.max(0, (data.summary.request_count || data.logs.length) - data.summary.errors),
+    error: data.summary.errors,
+    average_latency_ms: 0,
+  });
+  const [requestListLoading, setRequestListLoading] = useState(false);
+  const [requestListError, setRequestListError] = useState("");
   const [selectedRequestID, setSelectedRequestID] = useState("");
   const [detail, setDetail] = useState<RequestDetail | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
@@ -26,48 +44,74 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
     }
   }, [activeAuditTab, showAdminAudit]);
 
-  const filteredLogs = useMemo(() => {
-    const keyword = query.trim().toLowerCase();
-    return data.logs.filter((log) => {
-      if (statusFilter === "ok" && log.status_code >= 400) return false;
-      if (statusFilter === "error" && log.status_code < 400) return false;
-      if (!keyword) return true;
-      return [
-        log.request_id,
-        log.project_id,
-        projectName(data, log.project_id),
-        log.api_key_id,
-        log.model,
-        log.provider_id,
-        providerAuditLabel(data, log),
-        log.provider_resource_id,
-        log.provider_model,
-        log.error_code,
-        String(log.status_code),
-      ]
-        .filter(Boolean)
-        .some((value) => String(value).toLowerCase().includes(keyword));
-    });
-  }, [data, query, statusFilter]);
+  useEffect(() => {
+    if (activeAuditTab !== "requests") return;
+    const controller = new AbortController();
+    const delay = query.trim() ? 250 : 0;
+    const timeout = window.setTimeout(() => {
+      setRequestListLoading(true);
+      setRequestListError("");
+      adminFetch(api, auditRequestPagePath({
+        page: requestPage,
+        pageSize: requestPageSize,
+        status: statusFilter,
+        query,
+      }), { signal: controller.signal })
+        .then(async (resp) => {
+          if (!resp.ok) throw new Error(`request logs ${resp.status}`);
+          return (await resp.json()) as RequestLogPage;
+        })
+        .then((payload) => {
+          setRequestLogs(payload.data ?? []);
+          setRequestPagination(payload.pagination);
+          setRequestSummary(payload.summary);
+          const lastPage = Math.max(1, payload.pagination.total_pages);
+          if (requestPage > lastPage) setRequestPage(lastPage);
+        })
+        .catch((err) => {
+          if (controller.signal.aborted || isAuthExpiredError(err)) return;
+          setRequestListError(tx("连接失败"));
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) setRequestListLoading(false);
+        });
+    }, delay);
+    return () => {
+      window.clearTimeout(timeout);
+      controller.abort();
+    };
+  }, [activeAuditTab, api, query, requestPage, requestPageSize, statusFilter]);
 
-  const requestLogPagination = usePagination(filteredLogs.length, `request-logs:${statusFilter}:${query.trim()}`);
-  const visibleLogs = useMemo(
-    () => filteredLogs.slice(requestLogPagination.startIndex, requestLogPagination.endIndex),
-    [filteredLogs, requestLogPagination.startIndex, requestLogPagination.endIndex],
-  );
+  const requestLogPagination = useMemo<PaginationState>(() => {
+    const pageCount = Math.max(1, requestPagination.total_pages);
+    const page = Math.min(requestPage, pageCount);
+    const startIndex = requestPagination.total === 0 ? 0 : (page - 1) * requestPageSize;
+    return {
+      page,
+      pageSize: requestPageSize,
+      pageCount,
+      startIndex,
+      endIndex: Math.min(startIndex + requestLogs.length, requestPagination.total),
+      setPage: (nextPage) => setRequestPage(Math.min(Math.max(nextPage, 1), pageCount)),
+      setPageSize: (nextPageSize) => {
+        setRequestPageSize(nextPageSize);
+        setRequestPage(1);
+      },
+    };
+  }, [requestLogs.length, requestPage, requestPageSize, requestPagination.total, requestPagination.total_pages]);
 
   useEffect(() => {
     if (activeAuditTab !== "requests") return;
-    if (filteredLogs.length === 0) {
+    if (requestLogs.length === 0) {
       setSelectedRequestID("");
       setDetail(null);
       return;
     }
-    const selectedVisible = visibleLogs.some((log) => log.request_id === selectedRequestID);
+    const selectedVisible = requestLogs.some((log) => log.request_id === selectedRequestID);
     if (!selectedRequestID || !selectedVisible) {
-      setSelectedRequestID((visibleLogs[0] ?? filteredLogs[0]).request_id);
+      setSelectedRequestID(requestLogs[0].request_id);
     }
-  }, [activeAuditTab, filteredLogs, selectedRequestID, visibleLogs]);
+  }, [activeAuditTab, requestLogs, selectedRequestID]);
 
   useEffect(() => {
     if (activeAuditTab !== "requests") return;
@@ -106,19 +150,19 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
   }, [activeAuditTab, api, selectedRequestID]);
 
   const requestStats = useMemo(() => {
-    const total = data.logs.length;
-    const failures = data.logs.filter((log) => log.status_code >= 400).length;
-    const averageLatency = total
-      ? Math.round(data.logs.reduce((sum, log) => sum + (log.latency_ms || 0), 0) / total)
-      : 0;
-    const successRate = total ? Math.round(((total - failures) / total) * 100) : 0;
-    return { total, failures, averageLatency, successRate };
-  }, [data.logs]);
+    const successRate = requestSummary.all ? Math.round((requestSummary.ok / requestSummary.all) * 100) : 0;
+    return {
+      total: requestSummary.all,
+      failures: requestSummary.error,
+      averageLatency: requestSummary.average_latency_ms,
+      successRate,
+    };
+  }, [requestSummary]);
 
   const filters = [
-    { key: "all", label: `${tx("全部")} ${data.logs.length}` },
-    { key: "ok", label: `${tx("成功")} ${data.logs.length - requestStats.failures}` },
-    { key: "error", label: `${tx("失败")} ${requestStats.failures}` },
+    { key: "all", label: `${tx("全部")} ${requestSummary.all}` },
+    { key: "ok", label: `${tx("成功")} ${requestSummary.ok}` },
+    { key: "error", label: `${tx("失败")} ${requestSummary.error}` },
   ] as const;
 
   return (
@@ -133,7 +177,7 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
         >
           <Activity size={15} />
           <span>{tx("大模型请求历史")}</span>
-          <strong>{formatNumber(data.logs.length)}</strong>
+          <strong>{formatNumber(requestSummary.all)}</strong>
         </button>
         {showAdminAudit ? (
           <button
@@ -158,7 +202,10 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
                 <Search size={15} />
                 <input
                   value={query}
-                  onChange={(event) => setQuery(event.target.value)}
+                  onChange={(event) => {
+                    setQuery(event.target.value);
+                    setRequestPage(1);
+                  }}
                   placeholder={tx("搜索请求 ID、模型、Provider、状态码")}
                 />
               </label>
@@ -168,7 +215,10 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
                     key={filter.key}
                     type="button"
                     className={statusFilter === filter.key ? "active" : ""}
-                    onClick={() => setStatusFilter(filter.key)}
+                    onClick={() => {
+                      setStatusFilter(filter.key);
+                      setRequestPage(1);
+                    }}
                   >
                     {filter.label}
                   </button>
@@ -184,16 +234,20 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
             </div>
 
             <div className="request-history-layout">
-              <div className="request-list-panel">
+              <div className="request-list-panel" aria-busy={requestListLoading}>
                 <div className="request-list-head">
                   <span>{tx("请求列表")}</span>
-                  <strong>{countWithUnit(filteredLogs.length, "条", "record", "件")}</strong>
+                  <strong>{countWithUnit(requestPagination.total, "条", "record", "件")}</strong>
                 </div>
-                {filteredLogs.length === 0 ? (
+                {requestListError && requestLogs.length === 0 ? (
+                  <div className="compact-empty">{requestListError}</div>
+                ) : requestListLoading && requestLogs.length === 0 ? (
+                  <div className="compact-empty">{tx("加载中")}...</div>
+                ) : requestLogs.length === 0 ? (
                   <div className="compact-empty">{tx("没有匹配的请求记录")}</div>
                 ) : (
                   <div className="request-list" role="list">
-                    {visibleLogs.map((log) => (
+                    {requestLogs.map((log) => (
                       <button
                         key={log.request_id}
                         type="button"
@@ -218,7 +272,7 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
                     ))}
                   </div>
                 )}
-                <PaginationControls pagination={requestLogPagination} totalItems={filteredLogs.length} />
+                <PaginationControls pagination={requestLogPagination} totalItems={requestPagination.total} />
               </div>
 
               <RequestDetailPanel

--- a/frontend/features/admin/views/audit.tsx
+++ b/frontend/features/admin/views/audit.tsx
@@ -15,21 +15,11 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
   const [activeAuditTab, setActiveAuditTab] = useState<"requests" | "admin">("requests");
   const [query, setQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<AuditRequestStatus>("all");
-  const [requestLogs, setRequestLogs] = useState(data.logs);
+  const [requestLogs, setRequestLogs] = useState<RequestLogPage["data"]>([]);
   const [requestPage, setRequestPage] = useState(1);
   const [requestPageSize, setRequestPageSize] = useState(20);
-  const [requestPagination, setRequestPagination] = useState<RequestLogPagination>({
-    page: 1,
-    page_size: 20,
-    total: data.summary.request_count || data.logs.length,
-    total_pages: Math.ceil((data.summary.request_count || data.logs.length) / 20),
-  });
-  const [requestSummary, setRequestSummary] = useState<RequestLogSummary>({
-    all: data.summary.request_count || data.logs.length,
-    ok: Math.max(0, (data.summary.request_count || data.logs.length) - data.summary.errors),
-    error: data.summary.errors,
-    average_latency_ms: 0,
-  });
+  const [requestPagination, setRequestPagination] = useState<RequestLogPagination>(() => emptyRequestLogPagination(1, 20));
+  const [requestSummary, setRequestSummary] = useState<RequestLogSummary>(() => emptyRequestLogSummary());
   const [requestListLoading, setRequestListLoading] = useState(false);
   const [requestListError, setRequestListError] = useState("");
   const [selectedRequestID, setSelectedRequestID] = useState("");
@@ -48,9 +38,12 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
     if (activeAuditTab !== "requests") return;
     const controller = new AbortController();
     const delay = query.trim() ? 250 : 0;
+    setRequestListLoading(true);
+    setRequestListError("");
+    setRequestLogs([]);
+    setRequestPagination(emptyRequestLogPagination(requestPage, requestPageSize));
+    setRequestSummary(emptyRequestLogSummary());
     const timeout = window.setTimeout(() => {
-      setRequestListLoading(true);
-      setRequestListError("");
       adminFetch(api, auditRequestPagePath({
         page: requestPage,
         pageSize: requestPageSize,
@@ -239,7 +232,7 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
                   <span>{tx("请求列表")}</span>
                   <strong>{countWithUnit(requestPagination.total, "条", "record", "件")}</strong>
                 </div>
-                {requestListError && requestLogs.length === 0 ? (
+                {requestListError ? (
                   <div className="compact-empty">{requestListError}</div>
                 ) : requestListLoading && requestLogs.length === 0 ? (
                   <div className="compact-empty">{tx("加载中")}...</div>
@@ -305,6 +298,24 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
       )}
     </div>
   );
+}
+
+function emptyRequestLogPagination(page: number, pageSize: number): RequestLogPagination {
+  return {
+    page,
+    page_size: pageSize,
+    total: 0,
+    total_pages: 0,
+  };
+}
+
+function emptyRequestLogSummary(): RequestLogSummary {
+  return {
+    all: 0,
+    ok: 0,
+    error: 0,
+    average_latency_ms: 0,
+  };
 }
 
 export function RequestDetailPanel({

--- a/frontend/features/admin/views/gateway-view.tsx
+++ b/frontend/features/admin/views/gateway-view.tsx
@@ -342,7 +342,7 @@ export function gatewayDocBundle({
   const userCount = data.users.length || data.summary.user_count || 0;
   const providerCount = data.providers.length;
   const routeCount = data.routes.length;
-  const requestLogCount = data.logs.length;
+  const requestLogCount = data.summary.request_count || data.logs.length;
   const visibleModelCount = callableModels.length;
   const chatCurl = `curl -X POST "${baseURL}/chat/completions" \\
   -H "${authHeader}" \\

--- a/frontend/features/admin/views/gateway-view.tsx
+++ b/frontend/features/admin/views/gateway-view.tsx
@@ -342,7 +342,7 @@ export function gatewayDocBundle({
   const userCount = data.users.length || data.summary.user_count || 0;
   const providerCount = data.providers.length;
   const routeCount = data.routes.length;
-  const requestLogCount = data.summary.request_count || data.logs.length;
+  const requestLogCount = data.logs.length;
   const visibleModelCount = callableModels.length;
   const chatCurl = `curl -X POST "${baseURL}/chat/completions" \\
   -H "${authHeader}" \\

--- a/frontend/features/admin/views/overview.tsx
+++ b/frontend/features/admin/views/overview.tsx
@@ -467,7 +467,7 @@ export function OverviewRoleWorkbench({
   const activeRoutes = data.summary.active_route_count || data.routes.filter((route) => route.status === "active").length;
   const apiKeys = data.summary.api_key_count || data.keys.length;
   const callableModels = playgroundModels(data).length || data.models.filter((model) => model.status === "active").length;
-  const requestCount = data.summary.request_count || data.logs.length;
+  const requestCount = data.summary.request_count;
   const setupScore = overviewSetupScore(role, {
     projects: projects.length,
     activeProviders: activeProviders.length,
@@ -1142,8 +1142,8 @@ export type UsageDashboardRankRow = UsageBreakdownRow & {
 };
 
 export function roleUsageMonitorStats(data: AppData) {
-  const requests = data.summary.request_count || data.logs.length;
-  const failedRequests = data.summary.errors || data.logs.filter(requestLogFailed).length;
+  const requests = data.summary.request_count;
+  const failedRequests = data.summary.errors;
   const successRequests = Math.max(0, requests - failedRequests);
   const latencyLogs = data.logs.filter((log) => log.latency_ms > 0);
   const avgLatencyMS = latencyLogs.length


### PR DESCRIPTION
## Summary

Move admin request-audit visibility, search, status filtering, summary statistics, and pagination into SQLite/GORM queries so the console no longer downloads the full request log history.

## Related Issue

Closes #127

## Changes

- Add a paginated request-log query with a default page size of 20, a maximum of 100, stable `created_at DESC, id DESC` ordering, scoped summary counts, and existing audit search semantics.
- Preserve least-privilege visibility before pagination and constrain usage enrichment to the visible request/project/API Key tuple.
- Add `request_logs` indexes for creation time, project plus creation time, and API Key plus creation time.
- Update the audit console to refetch on search, status, page, and page-size changes while other views receive only a bounded recent-log window.
- Keep request detail, CSV export, usage summaries, and OpenAI-compatible `/v1` behavior unchanged.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...`
- `go vet ./...`
- `npm ci` (completed; npm reported three existing high-severity audit advisories)
- `npm run typecheck`
- `npm run build`
- `node --test features/admin/domain/*.test.mjs`
- `node --test tools/*.test.mjs`
- `node tools/check-doc-translations.mjs --base origin/main --head HEAD`
- `node tools/check-ui-translations.mjs`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- `git diff --check origin/main...HEAD`
- SDK provider smoke tests were not run because this change is limited to the admin audit API and console and those tests require configured provider environments.

## Compatibility, Security, and Operations

The admin `GET /api/admin/audit/requests` response now intentionally returns a paginated envelope and defaults to 20 records; callers can request up to 100. The OpenAI-compatible `/v1` contract is unchanged. Authorization is applied in SQL before counts and pagination, and usage enrichment requires an exact request/project/API Key match. AutoMigrate creates the new indexes without a data rewrite. No environment or deployment changes are required. Rollback can revert the application commit; retained indexes are harmless.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
