### PR TITLE
feat(admin): make JSON request body limits runtime-tunable

### DIFF
--- a/backend/internal/server/anthropic_messages.go
+++ b/backend/internal/server/anthropic_messages.go
@@ -91,7 +91,7 @@ func (s *Server) handleAnthropicCountTokens(w http.ResponseWriter, r *http.Reque
 
 func (s *Server) decodeAnthropicMessagesRequest(w http.ResponseWriter, r *http.Request, requireMaxTokens bool) (anthropicMessagesRequest, error) {
 	var raw map[string]any
-	if err := s.decodeJSONLimit(w, r, &raw, s.config.MaxMultimodalRequestBytes); err != nil {
+	if err := s.decodeJSONLimit(w, r, &raw, s.effectiveMultimodalRequestLimit()); err != nil {
 		return anthropicMessagesRequest{}, err
 	}
 	model, _ := raw["model"].(string)

--- a/backend/internal/server/body_limit_runtime_test.go
+++ b/backend/internal/server/body_limit_runtime_test.go
@@ -1,0 +1,161 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReadEffectiveBodyLimits(t *testing.T) {
+	cases := []struct {
+		name           string
+		envJSON        int64
+		envMultimodal  int64
+		dbJSON         any
+		dbMultimodal   any
+		wantJSON       int64
+		wantMultimodal int64
+	}{
+		{
+			name:    "no override falls back to env defaults",
+			envJSON: 1 << 10, envMultimodal: 4 << 10,
+			wantJSON: 1 << 10, wantMultimodal: 4 << 10,
+		},
+		{
+			name:    "override honored",
+			envJSON: 1 << 10, envMultimodal: 4 << 10,
+			dbJSON: int64(2 << 10), dbMultimodal: int64(8 << 10),
+			wantJSON: 2 << 10, wantMultimodal: 8 << 10,
+		},
+		{
+			name:    "override over ceiling clamps",
+			envJSON: 1 << 10, envMultimodal: 4 << 10,
+			dbJSON: int64(1024 << 30), dbMultimodal: int64(1024 << 30),
+			wantJSON: maxConfigurableRequestBytes, wantMultimodal: maxConfigurableRequestBytes,
+		},
+		{
+			name:    "zero override falls back to env",
+			envJSON: 1 << 10, envMultimodal: 4 << 10,
+			dbJSON: int64(0), dbMultimodal: int64(0),
+			wantJSON: 1 << 10, wantMultimodal: 4 << 10,
+		},
+		{
+			name:    "garbage override falls back to env",
+			envJSON: 1 << 10, envMultimodal: 4 << 10,
+			dbJSON: "lots", dbMultimodal: "nope",
+			wantJSON: 1 << 10, wantMultimodal: 4 << 10,
+		},
+		{
+			name:    "partial override only changes one tier",
+			envJSON: 1 << 10, envMultimodal: 4 << 10,
+			dbJSON: int64(2 << 10), dbMultimodal: nil,
+			wantJSON: 2 << 10, wantMultimodal: 4 << 10,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := NewMemoryStore()
+			s := NewWithConfig(store, Config{AdminToken: "dev_admin_token", MaxJSONRequestBytes: tc.envJSON, MaxMultimodalRequestBytes: tc.envMultimodal})
+			fields := map[string]any{}
+			if tc.dbJSON != nil {
+				fields["max_json_request_bytes"] = tc.dbJSON
+			}
+			if tc.dbMultimodal != nil {
+				fields["max_multimodal_request_bytes"] = tc.dbMultimodal
+			}
+			store.CreateResource("settings", AdminResource{ID: "cfg_gateway", Status: StatusActive, Fields: fields})
+			got := s.readEffectiveBodyLimits()
+			if got.jsonLimit != tc.wantJSON || got.multimodalLimit != tc.wantMultimodal {
+				t.Fatalf("readEffectiveBodyLimits() = (json=%d, multimodal=%d), want (json=%d, multimodal=%d)",
+					got.jsonLimit, got.multimodalLimit, tc.wantJSON, tc.wantMultimodal)
+			}
+		})
+	}
+}
+
+func TestReadEffectiveBodyLimitsPrefersCfgGateway(t *testing.T) {
+	store := NewMemoryStore()
+	s := NewWithConfig(store, Config{AdminToken: "dev_admin_token", MaxJSONRequestBytes: 1 << 10, MaxMultimodalRequestBytes: 4 << 10})
+	store.CreateResource("settings", AdminResource{ID: "cfg_legacy", Status: StatusActive, Fields: map[string]any{"max_json_request_bytes": int64(1 << 10)}})
+	store.CreateResource("settings", AdminResource{ID: "cfg_gateway", Status: StatusActive, Fields: map[string]any{"max_json_request_bytes": int64(8 << 10)}})
+	got := s.readEffectiveBodyLimits()
+	if got.jsonLimit != 8<<10 {
+		t.Fatalf("expected cfg_gateway value 8KiB, got %d", got.jsonLimit)
+	}
+}
+
+func decodeJSONAt(t *testing.T, s *Server, limit int64, n int) error {
+	t.Helper()
+	body := `"` + strings.Repeat("a", n-2) + `"`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	var target any
+	return s.decodeJSONLimit(rec, req, &target, limit)
+}
+
+func TestDecodeJSONHonorsRuntimeJSONOverride(t *testing.T) {
+	// Env default 1KiB: a 2KiB body is over the limit and is rejected with 413.
+	store := NewMemoryStore()
+	s := NewWithConfig(store, Config{AdminToken: "dev_admin_token", MaxJSONRequestBytes: 1 << 10, MaxMultimodalRequestBytes: 4 << 10})
+	if err := decodeJSONAt(t, s, s.effectiveJSONRequestLimit(), 2<<10); !isPayloadTooLarge(err) {
+		t.Fatalf("expected 413 at env default, got %v", err)
+	}
+
+	// Raise the limit at runtime via cfg_gateway; the same 2KiB body is now accepted,
+	// and a body over the raised limit is still rejected.
+	store2 := NewMemoryStore()
+	s2 := NewWithConfig(store2, Config{AdminToken: "dev_admin_token", MaxJSONRequestBytes: 1 << 10, MaxMultimodalRequestBytes: 4 << 10})
+	store2.CreateResource("settings", AdminResource{ID: "cfg_gateway", Status: StatusActive, Fields: map[string]any{"max_json_request_bytes": int64(4 << 10)}})
+	if err := decodeJSONAt(t, s2, s2.effectiveJSONRequestLimit(), 2<<10); err != nil {
+		t.Fatalf("expected acceptance under raised runtime limit, got %v", err)
+	}
+	if err := decodeJSONAt(t, s2, s2.effectiveJSONRequestLimit(), 5<<10); !isPayloadTooLarge(err) {
+		t.Fatalf("expected 413 over raised runtime limit, got %v", err)
+	}
+}
+
+func TestDecodeJSONMultimodalOverrideSeparateFromJSON(t *testing.T) {
+	store := NewMemoryStore()
+	s := NewWithConfig(store, Config{AdminToken: "dev_admin_token", MaxJSONRequestBytes: 1 << 10, MaxMultimodalRequestBytes: 2 << 10})
+	// Raise only the multimodal tier; the JSON tier stays at the 1KiB env default.
+	store.CreateResource("settings", AdminResource{ID: "cfg_gateway", Status: StatusActive, Fields: map[string]any{"max_multimodal_request_bytes": int64(8 << 10)}})
+	// 4KiB body: over the 1KiB JSON limit but under the 8KiB multimodal override.
+	if err := decodeJSONAt(t, s, s.effectiveMultimodalRequestLimit(), 4<<10); err != nil {
+		t.Fatalf("expected acceptance under raised multimodal limit, got %v", err)
+	}
+	if err := decodeJSONAt(t, s, s.effectiveJSONRequestLimit(), 4<<10); !isPayloadTooLarge(err) {
+		t.Fatalf("expected 413 at unchanged 1KiB JSON limit, got %v", err)
+	}
+}
+
+// TestBodyLimitCacheReadsSettingsOnceUntilTTLExpiry verifies the 10-second
+// cache: within the TTL, repeated effective-limit calls serve the cached
+// snapshot (a settings change is NOT re-read), and after the TTL expires the
+// next call re-reads settings and picks up the change.
+func TestBodyLimitCacheReadsSettingsOnceUntilTTLExpiry(t *testing.T) {
+	store := NewMemoryStore()
+	s := NewWithConfig(store, Config{AdminToken: "dev_admin_token", MaxJSONRequestBytes: 1 << 20, MaxMultimodalRequestBytes: 4 << 20})
+	store.CreateResource("settings", AdminResource{ID: "cfg_gateway", Status: StatusActive, Fields: map[string]any{"max_json_request_bytes": int64(8 << 20)}})
+
+	// First call reads settings and caches the snapshot with refreshedAt set.
+	if got := s.currentBodyLimits().jsonLimit; got != 8<<20 {
+		t.Fatalf("first read: jsonLimit=%d, want 8MiB", got)
+	}
+
+	// Change the override; within TTL the cache must serve the stale value
+	// (no re-read), proving the snapshot is fresh and not re-queried per call.
+	store.UpdateResource("settings", "cfg_gateway", AdminResource{Fields: map[string]any{"max_json_request_bytes": int64(16 << 20)}})
+	if got := s.currentBodyLimits().jsonLimit; got != 8<<20 {
+		t.Fatalf("within TTL: jsonLimit=%d, want stale 8MiB (no re-read)", got)
+	}
+
+	// Back-date the snapshot's refreshedAt to simulate TTL expiry.
+	s.bodyLimits.snapshot.Store(&bodyLimitSnapshot{jsonLimit: 8 << 20, multimodalLimit: 4 << 20, refreshedAt: time.Now().Add(-bodyLimitTTL - time.Second)})
+
+	// After expiry, the next call re-reads settings and picks up the new override.
+	if got := s.currentBodyLimits().jsonLimit; got != 16<<20 {
+		t.Fatalf("after TTL expiry: jsonLimit=%d, want 16MiB (re-read)", got)
+	}
+}

--- a/backend/internal/server/gateway_http.go
+++ b/backend/internal/server/gateway_http.go
@@ -23,7 +23,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req ChatCompletionRequest
-	if err := s.decodeJSONLimit(w, r, &req, s.config.MaxMultimodalRequestBytes); err != nil {
+	if err := s.decodeJSONLimit(w, r, &req, s.effectiveMultimodalRequestLimit()); err != nil {
 		writeError(w, r, err)
 		return
 	}
@@ -148,7 +148,7 @@ func (s *Server) handleResponses(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req ResponsesRequest
-	if err := s.decodeJSONLimit(w, r, &req, s.config.MaxMultimodalRequestBytes); err != nil {
+	if err := s.decodeJSONLimit(w, r, &req, s.effectiveMultimodalRequestLimit()); err != nil {
 		writeError(w, r, err)
 		return
 	}
@@ -254,7 +254,7 @@ func (s *Server) handleResponsesCompact(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	var request map[string]json.RawMessage
-	if err := s.decodeJSONLimit(w, r, &request, s.config.MaxMultimodalRequestBytes); err != nil {
+	if err := s.decodeJSONLimit(w, r, &request, s.effectiveMultimodalRequestLimit()); err != nil {
 		writeError(w, r, err)
 		return
 	}
@@ -500,7 +500,7 @@ func (s *Server) handleAdminPlaygroundChat(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	var playgroundReq playgroundChatRequest
-	if err := s.decodeJSONLimit(w, r, &playgroundReq, s.config.MaxMultimodalRequestBytes); err != nil {
+	if err := s.decodeJSONLimit(w, r, &playgroundReq, s.effectiveMultimodalRequestLimit()); err != nil {
 		writeError(w, r, err)
 		return
 	}

--- a/backend/internal/server/gemini_native_http.go
+++ b/backend/internal/server/gemini_native_http.go
@@ -117,7 +117,7 @@ func (s *Server) handleGeminiCountTokens(w http.ResponseWriter, r *http.Request,
 		return
 	}
 	var payload map[string]any
-	if err := s.decodeJSONLimit(w, r, &payload, s.config.MaxMultimodalRequestBytes); err != nil {
+	if err := s.decodeJSONLimit(w, r, &payload, s.effectiveMultimodalRequestLimit()); err != nil {
 		writeError(w, r, err)
 		return
 	}
@@ -135,7 +135,7 @@ func (s *Server) handleGeminiGenerate(w http.ResponseWriter, r *http.Request, mo
 		return
 	}
 	var payload map[string]any
-	if err := s.decodeJSONLimit(w, r, &payload, s.config.MaxMultimodalRequestBytes); err != nil {
+	if err := s.decodeJSONLimit(w, r, &payload, s.effectiveMultimodalRequestLimit()); err != nil {
 		writeError(w, r, err)
 		return
 	}

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -45,6 +45,7 @@ type Server struct {
 	responseInstanceID  string
 	versions            *versionService
 	guardrailEngine     *guardrails.Engine
+	bodyLimits          bodyLimitCache
 }
 
 func New(store Store) *Server {

--- a/backend/internal/server/http_transport.go
+++ b/backend/internal/server/http_transport.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
+	"time"
 )
 
 func (s *Server) recordAdminAudit(r *http.Request, user AdminUser, action string, resourceType string, resourceID string, before any, after any) {
@@ -75,16 +77,19 @@ func bearerToken(r *http.Request) string {
 // treats an absent body as acceptable.
 var errEmptyRequestBody = NewHTTPError(http.StatusBadRequest, "invalid_request", "request body is required")
 
-// decodeJSON decodes the request body into target using the global JSON body limit.
+// decodeJSON decodes the request body into target using the effective JSON body
+// limit. The limit is the env-configured default unless an admin raises it from
+// the System Settings page (cfg_gateway.max_json_request_bytes); see
+// effectiveJSONRequestLimit.
 func (s *Server) decodeJSON(w http.ResponseWriter, r *http.Request, target any) error {
-	return s.decodeJSONLimit(w, r, target, s.config.MaxJSONRequestBytes)
+	return s.decodeJSONLimit(w, r, target, s.effectiveJSONRequestLimit())
 }
 
 // decodeJSONOptional behaves like decodeJSON but treats a completely empty body as
 // success, leaving target at its zero value. Used by endpoints whose JSON body is
 // optional.
 func (s *Server) decodeJSONOptional(w http.ResponseWriter, r *http.Request, target any) error {
-	if err := s.decodeJSONLimit(w, r, target, s.config.MaxJSONRequestBytes); err != nil && !errors.Is(err, errEmptyRequestBody) {
+	if err := s.decodeJSONLimit(w, r, target, s.effectiveJSONRequestLimit()); err != nil && !errors.Is(err, errEmptyRequestBody) {
 		return err
 	}
 	return nil
@@ -140,6 +145,88 @@ func isPayloadTooLarge(err error) bool {
 		return false
 	}
 	return AsHTTPError(err).Status == http.StatusRequestEntityTooLarge
+}
+
+// bodyLimitTTL bounds how long the cached effective body limits stay fresh. Admin
+// edits to cfg_gateway take effect for new requests within this window; it trades
+// up-to-TTL staleness for not querying the store on every request.
+const bodyLimitTTL = 10 * time.Second
+
+type bodyLimitSnapshot struct {
+	jsonLimit       int64
+	multimodalLimit int64
+	refreshedAt     time.Time
+}
+
+// bodyLimitCache holds the effective JSON/multimodal request body limits with an
+// atomic snapshot so the hot path reads without a lock; refreshes are occasional
+// idempotent stores.
+type bodyLimitCache struct {
+	snapshot atomic.Pointer[bodyLimitSnapshot]
+}
+
+// effectiveJSONRequestLimit returns the byte cap enforced on regular JSON request
+// bodies. It prefers a cfg_gateway.max_json_request_bytes override (clamped to the
+// ceiling) so an admin can raise the limit from the console without a restart;
+// otherwise it falls back to the env-configured default.
+func (s *Server) effectiveJSONRequestLimit() int64 {
+	return s.currentBodyLimits().jsonLimit
+}
+
+// effectiveMultimodalRequestLimit is the higher cap for bodies that carry images or
+// other multimodal content (vision, Codex computer-use). It prefers
+// cfg_gateway.max_multimodal_request_bytes and otherwise falls back to the env
+// default.
+func (s *Server) effectiveMultimodalRequestLimit() int64 {
+	return s.currentBodyLimits().multimodalLimit
+}
+
+func (s *Server) currentBodyLimits() bodyLimitSnapshot {
+	if snap := s.bodyLimits.snapshot.Load(); snap != nil && time.Since(snap.refreshedAt) < bodyLimitTTL {
+		return *snap
+	}
+	snap := s.readEffectiveBodyLimits()
+	snap.refreshedAt = time.Now()
+	s.bodyLimits.snapshot.Store(&snap)
+	return snap
+}
+
+// readEffectiveBodyLimits reads the cfg_gateway overrides and clamps them to the
+// ceiling (maxConfigurableRequestBytes). A missing, malformed, or non-positive
+// value falls back to the env-configured default rather than rejecting every
+// request. It mirrors apiKeyGenerationConfig: cfg_gateway is preferred, the first
+// active settings record is a fallback.
+func (s *Server) readEffectiveBodyLimits() bodyLimitSnapshot {
+	snap := bodyLimitSnapshot{
+		jsonLimit:       s.config.MaxJSONRequestBytes,
+		multimodalLimit: s.config.MaxMultimodalRequestBytes,
+	}
+	var fields map[string]any
+	for _, item := range s.store.ListResources("settings") {
+		if item.Status != StatusActive {
+			continue
+		}
+		if item.ID == "cfg_gateway" {
+			fields = item.Fields
+			break
+		}
+		if fields == nil {
+			fields = item.Fields
+		}
+	}
+	if v := int64Field(fields, "max_json_request_bytes"); v > 0 {
+		if v > maxConfigurableRequestBytes {
+			v = maxConfigurableRequestBytes
+		}
+		snap.jsonLimit = v
+	}
+	if v := int64Field(fields, "max_multimodal_request_bytes"); v > 0 {
+		if v > maxConfigurableRequestBytes {
+			v = maxConfigurableRequestBytes
+		}
+		snap.multimodalLimit = v
+	}
+	return snap
 }
 
 func writeJSON(w http.ResponseWriter, status int, value any) {

--- a/backend/internal/server/playground_stream.go
+++ b/backend/internal/server/playground_stream.go
@@ -247,7 +247,7 @@ func (s *Server) handleAdminPlaygroundChatStream(w http.ResponseWriter, r *http.
 		return
 	}
 	var playgroundReq playgroundChatRequest
-	if err := s.decodeJSONLimit(w, r, &playgroundReq, s.config.MaxMultimodalRequestBytes); err != nil {
+	if err := s.decodeJSONLimit(w, r, &playgroundReq, s.effectiveMultimodalRequestLimit()); err != nil {
 		writeError(w, r, err)
 		return
 	}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -404,6 +404,8 @@ Options: `--rebuild`, `--reset` to drop the local database, `--backend-port N`, 
 | `TOKENHUB_DB_CONN_MAX_LIFETIME_MINUTES` | `30` | Maximum connection lifetime in minutes (PostgreSQL only) |
 | `TOKENHUB_API` | empty | Target Admin API for the `tokenhub-migrate` CLI. Read only by that CLI, never by the running server; overridden by `--to` |
 
+> **Runtime override:** An administrator can raise either body limit at runtime from the System Settings page (`max_json_request_bytes` / `max_multimodal_request_bytes` in the `cfg_gateway` settings resource) without a restart. The override takes precedence over the env default; both are clamped to the 512 MiB ceiling. Changes take effect for new requests within approximately 10 seconds (cache TTL). Keep your reverse proxy's body size limit (e.g. nginx `client_max_body_size`) aligned with the effective limit after an override.
+
 ## Frontend Environment Variables
 
 | Variable | Default | Description |

--- a/docs/ja/deployment.md
+++ b/docs/ja/deployment.md
@@ -401,6 +401,8 @@ docker compose --env-file deploy/.env -f deploy/docker-compose.yml down -v
 | `TOKENHUB_RESPONSE_MAX_QUEUED_JOBS` | `1000` | 1 つのデプロイが受け付ける待機中および実行中のバックグラウンド Responses ジョブ上限 |
 | `TOKENHUB_API` | 空 | `tokenhub-migrate` CLI が対象とする Admin API の URL。この CLI のみが読み取り、バックエンドサーバーは読み取りません。`--to` で上書きされます |
 
+> **ランタイムオーバーライド:** 管理者はシステム設定ページから実行時にいずれかのボディ上限を引き上げられます（`cfg_gateway` 設定リソースの `max_json_request_bytes` / `max_multimodal_request_bytes`）。再起動不要。このオーバーライドは env デフォルトより優先され、両方とも 512 MiB の上限にクランプされます。変更は新しいリクエストに対して約 10 秒以内（キャッシュ TTL）で反映されます。オーバーライド後はリバースプロキシのボディサイズ上限（例: nginx `client_max_body_size`）を有効な上限に合わせてください。
+
 ## フロントエンド環境変数
 
 | 変数 | デフォルト | 説明 |

--- a/docs/zh-CN/deployment.md
+++ b/docs/zh-CN/deployment.md
@@ -401,6 +401,8 @@ docker compose --env-file deploy/.env -f deploy/docker-compose.yml down -v
 | `TOKENHUB_RESPONSE_MAX_QUEUED_JOBS` | `1000` | 单个部署接受的排队中与运行中后台 Responses 任务总上限 |
 | `TOKENHUB_API` | 空 | `tokenhub-migrate` CLI 的目标 Admin API 地址。仅由该 CLI 读取，后端服务不会读取；可被 `--to` 覆盖 |
 
+> **运行时覆盖：** 管理员可在系统设置页运行时调高任一限额（`cfg_gateway` 设置资源的 `max_json_request_bytes` / `max_multimodal_request_bytes`），无需重启。该覆盖优先于 env 默认值；两者均钳制到 512 MiB 天花板。更改对新请求在约 10 秒内（缓存 TTL）生效。覆盖后请保持反向代理的请求体限额（如 nginx `client_max_body_size`）与生效限额对齐。
+
 ## 前端环境变量
 
 | 变量 | 默认值 | 说明 |

--- a/frontend/features/admin/i18n/en.tsx
+++ b/frontend/features/admin/i18n/en.tsx
@@ -1139,7 +1139,7 @@ export const enTranslations: Record<string, string> = {
     "API Key 前缀": "API Key Prefix",
     "API Key 随机长度": "API Key Random Length",
     "新建和轮换 Key 时使用；建议以 _ 结尾，例如 sk_。": "Used when creating and rotating Keys; ending with _ is recommended, for example sk_.",
-    "前缀后面的随机字符数，系统会限制在 24-128 之间。": "Number of random characters after the prefix. The system limits it to 24-128.",
+    "前缀后面的随机字符数，系统会限制在 24-128 之间。": "Number of random characters after the prefix. The system limits it to 24-128.", "JSON 请求体上限": "JSON Request Body Limit", "多模态请求体上限": "Multimodal Request Body Limit", "常规 JSON 请求体最大字节数；留空回退 env 配置的 TOKENHUB_MAX_JSON_REQUEST_BYTES（默认 8 MiB）；上限 512 MiB。": "Maximum bytes for a regular JSON request body. Leave empty to fall back to the env-configured TOKENHUB_MAX_JSON_REQUEST_BYTES (default 8 MiB); ceiling 512 MiB.", "含图像等多模态内容的请求体最大字节数；留空回退 env 配置的 TOKENHUB_MAX_MULTIMODAL_REQUEST_BYTES（默认 32 MiB）；上限 512 MiB。": "Maximum bytes for a request body carrying images or multimodal content. Leave empty to fall back to the env-configured TOKENHUB_MAX_MULTIMODAL_REQUEST_BYTES (default 32 MiB); ceiling 512 MiB.",
     "用户名字段": "Username Claim",
     "邮箱字段": "Email Claim",
     "团队字段": "Team Claim",

--- a/frontend/features/admin/i18n/ja.tsx
+++ b/frontend/features/admin/i18n/ja.tsx
@@ -1139,7 +1139,7 @@ export const jaTranslations: Record<string, string> = {
     "API Key 前缀": "API Key プレフィックス",
     "API Key 随机长度": "API Key ランダム長",
     "新建和轮换 Key 时使用；建议以 _ 结尾，例如 sk_。": "Key の作成とローテーション時に使用します。sk_ のように _ で終えることを推奨します。",
-    "前缀后面的随机字符数，系统会限制在 24-128 之间。": "プレフィックス後のランダム文字数です。システムは 24-128 に制限します。",
+    "前缀后面的随机字符数，系统会限制在 24-128 之间。": "プレフィックス後のランダム文字数です。システムは 24-128 に制限します。", "JSON 请求体上限": "JSON リクエストボディ上限", "多模态请求体上限": "マルチモーダルリクエストボディ上限", "常规 JSON 请求体最大字节数；留空回退 env 配置的 TOKENHUB_MAX_JSON_REQUEST_BYTES（默认 8 MiB）；上限 512 MiB。": "通常の JSON リクエストボディの最大バイト数。空欄なら env 設定の TOKENHUB_MAX_JSON_REQUEST_BYTES（デフォルト 8 MiB）にフォールバック、上限 512 MiB。", "含图像等多模态内容的请求体最大字节数；留空回退 env 配置的 TOKENHUB_MAX_MULTIMODAL_REQUEST_BYTES（默认 32 MiB）；上限 512 MiB。": "画像やマルチモーダルを含むリクエストボディの最大バイト数。空欄なら env 設定の TOKENHUB_MAX_MULTIMODAL_REQUEST_BYTES（デフォルト 32 MiB）にフォールバック、上限 512 MiB。",
     "用户名字段": "ユーザー名 Claim",
     "邮箱字段": "メール Claim",
     "团队字段": "チーム Claim",

--- a/frontend/features/admin/resources/settings-config.tsx
+++ b/frontend/features/admin/resources/settings-config.tsx
@@ -80,6 +80,8 @@ export function systemSettingConfig(): ResourceConfig<AdminResource> {
     { key: "audit_retention", label: "审计保留", help: "请求审计日志的默认保留周期，例如 180d。" },
     { key: "api_key_prefix", label: "API Key 前缀", placeholder: "sk_", help: "新建和轮换 Key 时使用；建议以 _ 结尾，例如 sk_。" },
     { key: "api_key_random_length", label: "API Key 随机长度", type: "number", placeholder: "48", help: "前缀后面的随机字符数，系统会限制在 24-128 之间。" },
+    { key: "max_json_request_bytes", label: "JSON 请求体上限", type: "number", placeholder: "8388608", help: "常规 JSON 请求体最大字节数；留空回退 env 配置的 TOKENHUB_MAX_JSON_REQUEST_BYTES（默认 8 MiB）；上限 512 MiB。" },
+    { key: "max_multimodal_request_bytes", label: "多模态请求体上限", type: "number", placeholder: "33554432", help: "含图像等多模态内容的请求体最大字节数；留空回退 env 配置的 TOKENHUB_MAX_MULTIMODAL_REQUEST_BYTES（默认 32 MiB）；上限 512 MiB。" },
   ]);
   return {
     ...base,


### PR DESCRIPTION
## Summary

`decodeJSON`'s request body limits were made env-configurable by #144 (merged): `TOKENHUB_MAX_JSON_REQUEST_BYTES` / `TOKENHUB_MAX_MULTIMODAL_REQUEST_BYTES`, 413 `payload_too_large`, `http.MaxBytesReader` streaming, separate regular and multimodal tiers, 512 MiB ceiling. Changing them still required a restart, so when a workload (Codex computer-use image recognition, long-context vision) hit the default mid-flight, an operator could not raise the cap without draining the gateway.

This PR is a follow-up that adds a **runtime-adjustable** layer on top of #144, without touching its decode contract: an admin can raise either limit from the System Settings page and it takes effect for new requests within ~10 s, no restart. It is not a replacement — #144's env path, 413, streaming, two tiers, and ceiling all stand; this only adds an in-memory override sourced from the `cfg_gateway` system setting.

(I saw #144 land while the earlier version of this PR was waiting on review feedback; this is a rebuild onto current main that builds on #144 rather than duplicating it.)

## Related Issue

Supplements #144 (which closed #125).

## Changes

- New effective-limit layer in `http_transport.go`:
  - `effectiveJSONRequestLimit()` / `effectiveMultimodalRequestLimit()` return the effective cap.
  - `bodyLimitCache` (atomic.Pointer snapshot, `bodyLimitTTL = 10s`); `currentBodyLimits()` serves the cache and refreshes via `readEffectiveBodyLimits()` on expiry — the hot path does not query the store per request.
  - `readEffectiveBodyLimits()` defaults to `s.config.Max*RequestBytes` (the env values from #144), then reads `cfg_gateway.max_json_request_bytes` / `max_multimodal_request_bytes` (reusing the existing `int64Field` helper). A set, positive value overrides the env default; a missing / malformed / non-positive value falls back to the env default; both are clamped to `maxConfigurableRequestBytes` (512 MiB).
  - It mirrors `apiKeyGenerationConfig`: `cfg_gateway` is preferred, the first active settings record is a fallback.
- `decodeJSON` / `decodeJSONOptional` use `effectiveJSONRequestLimit()`; the eight multimodal call sites (`gateway_http`, `anthropic_messages`, `gemini_native_http`, `playground_stream`) use `effectiveMultimodalRequestLimit()`.
- `http.go`: `Server` gains a `bodyLimits bodyLimitCache` field.
- `seed.go`: deliberately **not** seeded with the two fields, so a fresh deployment preserves an operator-customized env value until an admin sets an override.
- Frontend: two new fields on the System Settings page (`settings-config.tsx`), left empty by `defaultFormValues` (placeholder only) so saving the page does not silently write a number that overrides the env default. The two labels and help strings are added to `en.tsx` and `ja.tsx` so non-Chinese locales do not fall back to Chinese.
- Tests: `body_limit_runtime_test.go` covers override honored / clamp-to-ceiling / bad-value fallback / partial override / cfg_gateway preference, plus an end-to-end that a raised runtime limit accepts a previously-over-limit body and still 413s beyond it, and that the multimodal tier is independent of the JSON tier.

#144's `decodeJSONLimit` (413, `http.MaxBytesReader`, single-value check, `errEmptyRequestBody` / `decodeJSONOptional` semantics) is unchanged.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `gofmt -l` on changed Go files — clean.
- `go vet ./...` (CGO_ENABLED=1) — clean.
- `go build ./...` — clean.
- `go test ./internal/server/` — new tests pass; the only failures on this host are pre-existing environment ones (Postgres/multi-instance, sqlite-backup, `version_update` network/`bin/tokenhub`) that fail identically on the clean base commit (`25c481a`) with these changes stashed, plus one analytics-snapshot test that is flaky in the full suite but passes in isolation; none are caused by this change.
- golangci-lint v2.12.2 is run by CI as the authoritative lint check; the cache path was verified with `-race`.
- Frontend: `npm run typecheck` and `npm run build` — clean.
- Repository gates run locally: `node tools/check-ui-translations.mjs` (passed, 0 new literal keys), `node tools/check-env-contract.mjs` (passed, 55 backend variables; no env var introduced), `node --test tools/*.test.mjs` (116 passed / 0 failed), `node tools/check-source-lines.mjs` (passed).
- `git diff --check origin/main HEAD` — passes.

## Compatibility, Security, and Operations

- No public API contract change. Default behavior is unchanged: with no `cfg_gateway` override, the effective limit equals the #144 env default.
- A new runtime-configurable admin setting; takes effect for new requests within the cache TTL (~10 s) without a restart. In multi-instance deployments each replica refreshes independently.
- The configured value is clamped to the 512 MiB ceiling (`maxConfigurableRequestBytes`), so an operator cannot raise it beyond the budget #144 already set.
- No new environment variable, no schema migration (the fields live in the existing `cfg_gateway` settings resource `Fields` map).
- Rollback: revert the commit, or clear the two settings fields (falls back to the env defaults).

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included. (`frontend/next-env.d.ts` is not committed — it is a Next.js build artifact.)
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable. — N/A; no environment variable introduced; the override is a DB-backed system setting, and #144 already synced the env vars.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable. — The two new settings field labels and help strings are added to `en.tsx` and `ja.tsx` (the ZH literals are the source). The UI translation gate passes with 0 new literal keys; the dynamic `tx(field.*)` keys are covered manually per the earlier review feedback.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable. — N/A.
- [x] `git diff --check` passes.
