### PR TITLE
fix(ui): keep global search above page content

### DIFF
--- a/frontend/app/styles/redesign/shell.css
+++ b/frontend/app/styles/redesign/shell.css
@@ -500,6 +500,8 @@
 .topbar {
   height: 60px;
   flex: 0 0 60px;
+  position: relative;
+  z-index: 10;
   padding: 0 22px;
   border-bottom: 1px solid var(--border);
   justify-content: flex-start;

--- a/tools/ui-layering.test.mjs
+++ b/tools/ui-layering.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const shellStyles = await readFile(new URL("../frontend/app/styles/redesign/shell.css", import.meta.url), "utf8");
+
+function declarationsFor(selector) {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return shellStyles.match(new RegExp(`${escapedSelector}\\s*\\{([^}]*)\\}`))?.[1] ?? "";
+}
+
+test("topbar stacking context keeps global search above page content", () => {
+  const topbar = declarationsFor(".topbar");
+  const searchPanel = declarationsFor(".top-search-panel");
+
+  assert.match(topbar, /position:\s*relative\s*;/);
+  assert.match(topbar, /z-index:\s*\d+\s*;/);
+  assert.match(searchPanel, /position:\s*absolute\s*;/);
+  assert.match(searchPanel, /z-index:\s*\d+\s*;/);
+});


### PR DESCRIPTION
## Summary

Fix the global search results being painted underneath Overview metric cards for regular users. The top bar's backdrop filter created a parent stacking context without an explicit layer, so the search panel's own `z-index` could not place it above later page content.

## Related Issue

Closes #146.

## Changes

- Give the top bar stacking context an explicit position and layer above page content.
- Add a CSS contract test covering the top bar and global search panel layering requirements.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `node --test tools/*.test.mjs` (103 tests passed)
- `node tools/check-doc-translations.mjs`
- `node tools/check-ui-translations.mjs`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- `npm ci`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Browser rendering was not completed because the in-app browser's local URL security policy blocked navigation to the restarted localhost service. The new CSS contract test directly covers the corrected stacking context.

## Compatibility, Security, and Operations

None.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
