### PR TITLE
fix(frontend): support key copy over HTTP

### DIFF
--- a/frontend/features/admin/domain/clipboard.test.mjs
+++ b/frontend/features/admin/domain/clipboard.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { importTypeScript } from "./typescript-test-loader.mjs";
+
+const { copyText } = await importTypeScript(new URL("./clipboard.ts", import.meta.url));
+
+function fakeDocument({ commandResult = true, commandError } = {}) {
+  const calls = [];
+  const activeElement = { focus: () => calls.push("restore-focus") };
+  const textarea = {
+    style: {},
+    value: "",
+    focus: () => calls.push("focus"),
+    remove: () => calls.push("remove"),
+    select: () => calls.push("select"),
+    setAttribute: (name, value) => calls.push(["attribute", name, value]),
+    setSelectionRange: (start, end) => calls.push(["selection", start, end]),
+  };
+  const document = {
+    activeElement,
+    body: { appendChild: (element) => calls.push(["append", element]) },
+    createElement: (tagName) => {
+      calls.push(["create", tagName]);
+      return textarea;
+    },
+    execCommand: (command) => {
+      calls.push(["command", command]);
+      if (commandError) throw commandError;
+      return commandResult;
+    },
+  };
+  return { calls, document, textarea };
+}
+
+test("uses the Clipboard API when it is available", async () => {
+  const writes = [];
+  const legacy = fakeDocument();
+
+  assert.equal(await copyText("th-key", {
+    clipboard: { writeText: async (value) => writes.push(value) },
+    document: legacy.document,
+  }), true);
+  assert.deepEqual(writes, ["th-key"]);
+  assert.deepEqual(legacy.calls, []);
+});
+
+test("falls back to document.execCommand when Clipboard API is unavailable over HTTP", async () => {
+  const legacy = fakeDocument();
+
+  assert.equal(await copyText("th-http-key", { document: legacy.document }), true);
+  assert.equal(legacy.textarea.value, "th-http-key");
+  assert.ok(legacy.calls.some((call) => Array.isArray(call) && call[0] === "command" && call[1] === "copy"));
+  assert.ok(legacy.calls.includes("remove"));
+  assert.ok(legacy.calls.includes("restore-focus"));
+});
+
+test("uses the fallback when Clipboard API access is rejected", async () => {
+  const legacy = fakeDocument();
+
+  assert.equal(await copyText("th-fallback-key", {
+    clipboard: { writeText: async () => { throw new Error("denied"); } },
+    document: legacy.document,
+  }), true);
+  assert.ok(legacy.calls.some((call) => Array.isArray(call) && call[0] === "command"));
+});
+
+test("reports failure and removes the temporary textarea when both methods fail", async () => {
+  const legacy = fakeDocument({ commandError: new Error("blocked") });
+
+  assert.equal(await copyText("th-failed-key", { document: legacy.document }), false);
+  assert.ok(legacy.calls.includes("remove"));
+});

--- a/frontend/features/admin/domain/clipboard.ts
+++ b/frontend/features/admin/domain/clipboard.ts
@@ -1,0 +1,60 @@
+type ClipboardWriter = {
+  writeText: (value: string) => Promise<void>;
+};
+
+export type ClipboardEnvironment = {
+  clipboard?: ClipboardWriter;
+  document?: Document;
+};
+
+function browserClipboardEnvironment(): ClipboardEnvironment {
+  let clipboard: ClipboardWriter | undefined;
+  try {
+    clipboard = typeof navigator === "undefined" ? undefined : navigator.clipboard;
+  } catch {
+    clipboard = undefined;
+  }
+  return {
+    clipboard,
+    document: typeof document === "undefined" ? undefined : document,
+  };
+}
+
+function copyWithDocument(value: string, targetDocument?: Document): boolean {
+  if (!targetDocument?.body || typeof targetDocument.execCommand !== "function") return false;
+
+  const textarea = targetDocument.createElement("textarea");
+  const activeElement = targetDocument.activeElement as HTMLElement | null;
+  textarea.value = value;
+  textarea.setAttribute("readonly", "");
+  textarea.setAttribute("aria-hidden", "true");
+  textarea.style.position = "fixed";
+  textarea.style.inset = "0 auto auto 0";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+  targetDocument.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  textarea.setSelectionRange(0, value.length);
+
+  try {
+    return targetDocument.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+    activeElement?.focus();
+  }
+}
+
+export async function copyText(value: string, environment = browserClipboardEnvironment()): Promise<boolean> {
+  if (environment.clipboard?.writeText) {
+    try {
+      await environment.clipboard.writeText(value);
+      return true;
+    } catch {
+      // The legacy command remains available in insecure contexts and older browsers.
+    }
+  }
+  return copyWithDocument(value, environment.document);
+}

--- a/frontend/features/admin/shared/ui.tsx
+++ b/frontend/features/admin/shared/ui.tsx
@@ -2,6 +2,7 @@ import { Check, Copy, KeyRound } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { type AdminUser, type AppData, type FieldConfig, type Model } from "../core/types";
 import { modelCategory, modelCategoryLabel } from "../domain/catalog";
+import { copyText } from "../domain/clipboard";
 import { codexImageCapableResources, findProvider, isCodexSubscriptionImageModel, modelRoutesFor } from "../domain/entities";
 import { compactNumber, routeStrategyLabel } from "../domain/formatting";
 import { enumOptionLabel, enumValueLabel, splitList } from "../domain/labels";
@@ -50,12 +51,7 @@ export function IssuedKeyModal({ value, onClose }: { value: string; onClose: () 
   }, [closeCountdown]);
 
   async function copyKey() {
-    try {
-      await navigator.clipboard?.writeText(value);
-      setCopied(true);
-    } catch {
-      setCopied(false);
-    }
+    setCopied(await copyText(value));
   }
 
   return (

--- a/frontend/features/admin/views/audit.tsx
+++ b/frontend/features/admin/views/audit.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { canViewAdminAudit } from "../core/navigation";
 import { type AdminUser, type ApiContext, type AppData, type RequestDetail, type RequestLogPage, type RequestLogPagination, type RequestLogSummary, type RequestPayloadLog } from "../core/types";
 import { auditRequestPagePath, type AuditRequestStatus } from "../domain/audit-request-page";
+import { copyText } from "../domain/clipboard";
 import { apiKeyAuditLabel, projectName, providerAttemptLabel, providerAuditLabel, providerResourceAuditLabel } from "../domain/entities";
 import { compactNumber, formatMoney, formatNumber, formatTime } from "../domain/formatting";
 import { actionLabel, enumValueLabel, resourceTypeLabel } from "../domain/labels";
@@ -410,9 +411,9 @@ export function RequestDetailPanel({
   const isError = log.status_code >= 400;
 
   async function copyRequestID() {
-    await navigator.clipboard?.writeText(log.request_id).catch(() => undefined);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1200);
+    const success = await copyText(log.request_id);
+    setCopied(success);
+    if (success) window.setTimeout(() => setCopied(false), 1200);
   }
 
   return (

--- a/frontend/features/admin/views/gateway-docs-ui.tsx
+++ b/frontend/features/admin/views/gateway-docs-ui.tsx
@@ -1,5 +1,6 @@
 import { Check, Copy } from "lucide-react";
 import { useState } from "react";
+import { copyText } from "../domain/clipboard";
 import { type AppLanguage, tx } from "../i18n/runtime";
 
 export function gatewayLanguageLabel(language: AppLanguage) {
@@ -17,13 +18,9 @@ export function apiMethodClass(method?: string) {
 export function GatewayCopyCard({ label, value }: { label: string; value: string }) {
   const [copied, setCopied] = useState(false);
   async function copyValue() {
-    try {
-      await navigator.clipboard?.writeText(value);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1400);
-    } catch {
-      setCopied(false);
-    }
+    const success = await copyText(value);
+    setCopied(success);
+    if (success) window.setTimeout(() => setCopied(false), 1400);
   }
   return (
     <article className="gateway-copy-card">
@@ -39,13 +36,9 @@ export function GatewayCopyCard({ label, value }: { label: string; value: string
 export function GatewayCodeBlock({ code }: { code: string }) {
   const [copied, setCopied] = useState(false);
   async function copyCode() {
-    try {
-      await navigator.clipboard?.writeText(code);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1400);
-    } catch {
-      setCopied(false);
-    }
+    const success = await copyText(code);
+    setCopied(success);
+    if (success) window.setTimeout(() => setCopied(false), 1400);
   }
   return (
     <div className="gateway-code-block">

--- a/frontend/features/admin/views/playground.tsx
+++ b/frontend/features/admin/views/playground.tsx
@@ -20,6 +20,7 @@ import {
   type PlaygroundStreamEvent,
 } from "../core/types";
 import { modelCategory, modelCategoryLabel } from "../domain/catalog";
+import { copyText } from "../domain/clipboard";
 import {
   activeRouteCount,
   apiExampleLanguages,
@@ -542,7 +543,7 @@ export function PlaygroundPanel({ api, data, canViewRoutes }: { api: ApiContext;
       <section className="playground-main" aria-label={tx("模型演练对话")}>
         <div className="playground-model-bar">
           <div className="playground-model-title">
-            <button type="button" className="playground-copy-model" title={tx("复制模型名")} onClick={() => navigator.clipboard?.writeText(modelName).catch(() => undefined)}>
+            <button type="button" className="playground-copy-model" title={tx("复制模型名")} onClick={() => void copyText(modelName)}>
               <strong>{modelName || tx("选择模型")}</strong>
               <Copy size={13} />
             </button>
@@ -785,13 +786,9 @@ export function PlaygroundAPIExamples({ baseURL, modelName }: { baseURL: string;
   const examples = useMemo(() => apiExampleScripts(baseURL, modelName), [baseURL, modelName]);
   const current = examples[language];
   async function copyCurrent() {
-    try {
-      await navigator.clipboard?.writeText(current);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1400);
-    } catch {
-      setCopied(false);
-    }
+    const success = await copyText(current);
+    setCopied(success);
+    if (success) window.setTimeout(() => setCopied(false), 1400);
   }
   return (
     <section className="api-example-panel">

--- a/frontend/features/admin/views/provider-account-ui.tsx
+++ b/frontend/features/admin/views/provider-account-ui.tsx
@@ -1,6 +1,7 @@
 import { AlertCircle, Check, Copy, KeyRound, Send } from "lucide-react";
 import { useState } from "react";
 import type { ProviderResource } from "../core/types";
+import { copyText } from "../domain/clipboard";
 import { tx } from "../i18n/runtime";
 
 export type ProviderAccountOAuthAction = "copy" | "open";
@@ -10,10 +11,7 @@ export async function launchProviderAccountAuthorization(action: ProviderAccount
     window.open(authURL, "_blank", "noopener,noreferrer");
     return;
   }
-  if (!navigator.clipboard) throw new Error(tx("复制授权链接失败，请允许浏览器访问剪贴板后重试。"));
-  await navigator.clipboard.writeText(authURL).catch(() => {
-    throw new Error(tx("复制授权链接失败，请允许浏览器访问剪贴板后重试。"));
-  });
+  if (!await copyText(authURL)) throw new Error(tx("复制授权链接失败，请允许浏览器访问剪贴板后重试。"));
 }
 
 export type OpenAIQuotaWindow = {

--- a/frontend/features/admin/views/provider-editor.tsx
+++ b/frontend/features/admin/views/provider-editor.tsx
@@ -3,6 +3,7 @@ import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { clearPendingProviderAccountOAuthSession, consumePendingProviderAccountOAuthResult, hasPendingProviderAccountOAuthResult, parseProviderAccountOAuthResult, providerAccountOAuthCallbackURL, type ProviderAccountOAuthGenerateResponse, type ProviderAccountOAuthResult, readPendingProviderAccountOAuthSession, savePendingProviderAccountOAuthSession } from "../core/session";
 import { type ApiContext, type Model, type ModelRoute, type Provider, type ProviderCatalogEntry, type ProviderCredentialMode, type ProviderModel, type ProviderResource } from "../core/types";
 import { buildCustomProviderCatalogEntry, canonicalModelNameForUI, catalogModelCategoryOptions, modelCategory, modelCategoryForCatalog, modelCategoryLabel, providerEntryCategoryCount, providerEntrySupportsCategory } from "../domain/catalog";
+import { copyText } from "../domain/clipboard";
 import { compactNumber, formatModelPrice, modelCapabilities } from "../domain/formatting";
 import { providerTypeLabel } from "../domain/labels";
 import { clearCustomValidity, countWithUnit, handleRequiredFieldInvalid, providerSaveMessage, tx } from "../i18n/runtime";
@@ -762,10 +763,9 @@ export function ProviderUpsertModal({
   }
 
   async function copyProviderAccountCallbackURL() {
-    try {
-      await navigator.clipboard.writeText(openAIAccountOAuthRedirectURI);
+    if (await copyText(openAIAccountOAuthRedirectURI)) {
       setAccountOAuthStatus(tx("已复制 OpenAI 固定回调地址。"));
-    } catch {
+    } else {
       setAccountOAuthCallback(openAIAccountOAuthRedirectURI);
       setAccountOAuthStatus(openAIAccountOAuthRedirectURI);
     }


### PR DESCRIPTION
## Summary

Fix API key copy actions on HTTP deployments where the modern Clipboard API is unavailable. The previous optional Clipboard API call resolved without copying and still showed a successful "Copied" state.

## Related Issue

Closes https://github.com/astaxie/TokenHub/issues/148

## Changes

- Add a shared clipboard helper that prefers `navigator.clipboard` and falls back to a temporary textarea plus `document.execCommand("copy")` for insecure contexts.
- Report copy success only when a browser copy method actually succeeds.
- Route existing admin-console copy actions through the shared helper so they behave consistently on HTTP deployments.
- Add unit coverage for native Clipboard API success, HTTP fallback, permission rejection fallback, and complete failure cleanup.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `node --test features/admin/domain/*.test.mjs` (13 tests passed, run from `frontend/`)
- `npm run typecheck`
- `npm run build`
- `node --test tools/*.test.mjs` (102 tests passed)
- `node tools/check-doc-translations.mjs` (existence check passed; co-change check skipped locally because no diff endpoints were available)
- `node tools/check-ui-translations.mjs`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- In-app browser QA at `http://10.65.4.186:3100/api-keys`: confirmed `navigator.clipboard` was unavailable, generated a local test key, clicked Copy Key, verified the clipboard exactly matched the generated key, observed the Copied state, and found no console warnings or errors.

## Compatibility, Security, and Operations

No API, persistence, authentication, environment, deployment, or rollout impact. The temporary fallback textarea is removed immediately after each copy attempt, focus is restored, and copied values are not logged. No user-facing copy or documentation changed.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
