### PR TITLE
fix(providers): normalize anthropic endpoint versions

### DIFF
--- a/backend/internal/server/admin_provider_catalog_test.go
+++ b/backend/internal/server/admin_provider_catalog_test.go
@@ -464,6 +464,41 @@ func TestAdminCustomProviderCatalogLoadsUpstreamModels(t *testing.T) {
 	}
 }
 
+func TestAdminAnthropicProviderCatalogLoadsVersionedUpstreamModels(t *testing.T) {
+	app := newTestServer()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/anthropic/v1/models" {
+			t.Fatalf("unexpected upstream path %s", r.URL.Path)
+		}
+		if got := r.Header.Get("x-api-key"); got != "upstream-secret" {
+			t.Fatalf("unexpected upstream API key %q", got)
+		}
+		if got := r.Header.Get("anthropic-version"); got != "2023-06-01" {
+			t.Fatalf("unexpected Anthropic version %q", got)
+		}
+		if got := r.Header.Get("authorization"); got != "" {
+			t.Fatalf("unexpected OpenAI authorization header %q", got)
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"data": []map[string]any{{"id": "MiniMax-M2.7", "type": "model"}},
+		})
+	}))
+	defer upstream.Close()
+
+	resp := doJSON(t, app, http.MethodPost, "/api/admin/provider-catalog/custom", map[string]any{
+		"name":     "MiniMax",
+		"type":     ProviderAnthropic,
+		"base_url": upstream.URL + "/anthropic/v1",
+		"api_key":  "upstream-secret",
+	}, "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected Anthropic provider catalog, got %d: %s", resp.Code, resp.Body)
+	}
+	if !strings.Contains(resp.Body, `"MiniMax-M2.7"`) {
+		t.Fatalf("expected upstream Anthropic model, got %s", resp.Body)
+	}
+}
+
 func TestProviderCatalogUsesStandardModelCategories(t *testing.T) {
 	entries := []ProviderCatalogEntry{
 		{

--- a/backend/internal/server/anthropic_endpoint.go
+++ b/backend/internal/server/anthropic_endpoint.go
@@ -1,0 +1,12 @@
+package server
+
+import "strings"
+
+func anthropicEndpointURL(baseURL string, endpoint string) string {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	endpoint = "/" + strings.TrimLeft(strings.TrimSpace(endpoint), "/")
+	if strings.HasSuffix(strings.ToLower(baseURL), "/v1") && strings.HasPrefix(strings.ToLower(endpoint), "/v1/") {
+		endpoint = endpoint[len("/v1"):]
+	}
+	return baseURL + endpoint
+}

--- a/backend/internal/server/anthropic_messages.go
+++ b/backend/internal/server/anthropic_messages.go
@@ -800,7 +800,7 @@ func (s *Server) doNativeAnthropicRequest(
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+endpoint, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicEndpointURL(baseURL, endpoint), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/server/anthropic_messages_test.go
+++ b/backend/internal/server/anthropic_messages_test.go
@@ -358,7 +358,7 @@ func TestAnthropicMessagesPreservesNativeProtocolAndHeaders(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	handler, _, secret := newAnthropicGateway(t, upstream.URL, ProviderAnthropic)
+	handler, _, secret := newAnthropicGateway(t, upstream.URL+"/v1", ProviderAnthropic)
 	resp := doAnthropicRequest(t, handler, "/v1/messages", map[string]any{
 		"model":      "claude-tokenhub-test",
 		"max_tokens": 1024,

--- a/backend/internal/server/provider_catalog.go
+++ b/backend/internal/server/provider_catalog.go
@@ -513,7 +513,12 @@ func CustomProviderCatalogFromUpstream(ctx context.Context, client *http.Client,
 	if baseURL == "" {
 		return ProviderCatalogEntry{}, NewHTTPError(http.StatusBadRequest, "provider_base_url_required", "Base URL is required to load upstream models")
 	}
-	endpoint, err := url.Parse(strings.TrimRight(baseURL, "/") + "/models")
+	providerType := strings.ToLower(strings.TrimSpace(req.Type))
+	modelsURL := strings.TrimRight(baseURL, "/") + "/models"
+	if providerType == ProviderAnthropic {
+		modelsURL = anthropicEndpointURL(baseURL, "/v1/models")
+	}
+	endpoint, err := url.Parse(modelsURL)
 	if err != nil || endpoint.Scheme == "" || endpoint.Host == "" {
 		return ProviderCatalogEntry{}, NewHTTPError(http.StatusBadRequest, "provider_base_url_invalid", "Base URL is invalid")
 	}
@@ -524,7 +529,17 @@ func CustomProviderCatalogFromUpstream(ctx context.Context, client *http.Client,
 	if err != nil {
 		return ProviderCatalogEntry{}, NewHTTPError(http.StatusBadGateway, "provider_models_request_failed", "Failed to create upstream models request")
 	}
-	if apiKey := strings.TrimSpace(req.APIKey); apiKey != "" {
+	apiKey := strings.TrimSpace(req.APIKey)
+	if providerType == ProviderAnthropic {
+		if apiKey != "" {
+			httpReq.Header.Set("x-api-key", apiKey)
+		}
+		version := strings.TrimSpace(req.Options["anthropic_version"])
+		if version == "" {
+			version = "2023-06-01"
+		}
+		httpReq.Header.Set("anthropic-version", version)
+	} else if apiKey != "" {
 		httpReq.Header.Set("authorization", "Bearer "+apiKey)
 	}
 	resp, err := client.Do(httpReq)
@@ -654,12 +669,13 @@ func sortCatalogEntries(entries []ProviderCatalogEntry) {
 
 func inferProviderType(id string, baseURL string) string {
 	normalized := strings.ToLower(id)
+	normalizedBaseURL := strings.ToLower(strings.TrimRight(strings.TrimSpace(baseURL), "/"))
 	switch {
 	case normalized == "openai":
 		return ProviderOpenAI
 	case strings.Contains(normalized, "azure"):
 		return ProviderAzureOpenAI
-	case strings.Contains(normalized, "anthropic"):
+	case strings.Contains(normalized, "anthropic") || strings.Contains(normalizedBaseURL, "/anthropic/") || strings.HasSuffix(normalizedBaseURL, "/anthropic"):
 		return ProviderAnthropic
 	case normalized == "google" || strings.Contains(normalized, "gemini"):
 		return ProviderGemini

--- a/backend/internal/server/provider_catalog_test.go
+++ b/backend/internal/server/provider_catalog_test.go
@@ -31,6 +31,16 @@ func TestNormalizeProviderCatalogModelUsesExplicitCanonicalName(t *testing.T) {
 	}
 }
 
+func TestNormalizeProviderCatalogEntryInfersAnthropicProtocolFromBaseURL(t *testing.T) {
+	entry := normalizeProviderCatalogEntry("minimax-cn", map[string]any{
+		"name": "MiniMax China",
+		"api":  "https://api.minimaxi.com/anthropic/v1",
+	})
+	if entry.Type != ProviderAnthropic {
+		t.Fatalf("expected Anthropic provider type, got %q", entry.Type)
+	}
+}
+
 func TestBuiltinDeepSeekCatalogDescribesNativeV4Capabilities(t *testing.T) {
 	var deepSeek ProviderCatalogEntry
 	for _, entry := range builtinProviderCatalog(true) {

--- a/backend/internal/server/providers.go
+++ b/backend/internal/server/providers.go
@@ -507,7 +507,7 @@ func (a AnthropicAdapter) doRaw(ctx context.Context, provider Provider, endpoint
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(provider.BaseURL, "/")+endpoint, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicEndpointURL(provider.BaseURL, endpoint), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/server/providers_test.go
+++ b/backend/internal/server/providers_test.go
@@ -6,6 +6,21 @@ import (
 	"testing"
 )
 
+func TestAnthropicEndpointURLNormalizesVersionPrefix(t *testing.T) {
+	tests := []struct{ baseURL, endpoint, want string }{
+		{"https://api.anthropic.com", "/v1/messages", "https://api.anthropic.com/v1/messages"},
+		{"https://api.anthropic.com/v1", "/v1/messages", "https://api.anthropic.com/v1/messages"},
+		{"https://api.minimaxi.com/anthropic", "/v1/models", "https://api.minimaxi.com/anthropic/v1/models"},
+		{"https://api.minimaxi.com/anthropic/v1/", "/v1/models", "https://api.minimaxi.com/anthropic/v1/models"},
+	}
+
+	for _, tt := range tests {
+		if got := anthropicEndpointURL(tt.baseURL, tt.endpoint); got != tt.want {
+			t.Errorf("anthropicEndpointURL(%q, %q) = %q, want %q", tt.baseURL, tt.endpoint, got, tt.want)
+		}
+	}
+}
+
 func TestUsageFromMapExtractsCachedInputTokens(t *testing.T) {
 	tests := []struct {
 		name string

--- a/backend/internal/server/reasoning_effort_test.go
+++ b/backend/internal/server/reasoning_effort_test.go
@@ -344,7 +344,7 @@ func TestAnthropicAdapterTranslatesReasoningEffort(t *testing.T) {
 
 	effort := "medium"
 	adapter := AnthropicAdapter{}
-	provider := Provider{BaseURL: upstream.URL}
+	provider := Provider{BaseURL: upstream.URL + "/v1"}
 	_, _, err := adapter.Chat(context.Background(), provider, "claude-sonnet-5", ChatCompletionRequest{
 		Model:           "reasoning-model",
 		Messages:        []ChatMessage{{Role: "user", Content: "reason"}},


### PR DESCRIPTION
## Summary

Normalize Anthropic provider endpoints so versioned and unversioned Base URLs produce exactly one `/v1` segment. This fixes chat requests for Anthropic-compatible providers whose Base URL already ends in `/v1`, while preserving model discovery for providers whose Base URL omits it.

## Related Issue

Closes #156.

## Changes

- Add a shared Anthropic endpoint builder that removes only an overlapping `/v1` segment.
- Use Anthropic paths and authentication headers for custom catalog loading and connection tests.
- Recognize catalog providers with an `/anthropic` URL path as Anthropic-compatible.
- Cover versioned root and nested Base URLs in adapter, native protocol, catalog, and model discovery tests.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `cd backend && go test ./...`
- `cd backend && go vet ./...`
- `node tools/check-doc-translations.mjs --base upstream/main --head HEAD`
- `node tools/check-ui-translations.mjs`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- `git diff --check`
- `node --test tools/*.test.mjs` has two existing Node 22 TypeScript import failures; the same failures reproduce on `upstream/main`.

## Compatibility, Security, and Operations

Existing Anthropic Provider Base URLs with or without a trailing `/v1` remain supported. OpenAI-compatible endpoint construction is unchanged. No database migration, environment variable, deployment, or credential handling changes are required.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable. No environment variables changed.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable. This fixes existing documented behavior without changing the user contract.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable. No model catalog data changed.
- [x] `git diff --check` passes.