### PR TITLE
fix(models): preserve custom prices on startup

### DIFF
--- a/backend/internal/server/http_test.go
+++ b/backend/internal/server/http_test.go
@@ -633,6 +633,7 @@ models:
 
 	store := NewMemoryStore()
 	store.AddModel(Model{Name: "factory-chat", Family: "customized", Modality: "chat", ContextWindow: 1000, Status: StatusDisabled})
+	store.AddModel(Model{Name: "factory-embedding", Family: "customized", Modality: "embedding", EmbeddingPriceUSDPer1M: 9, Status: StatusDisabled})
 	store.AddModel(Model{Name: "custom-only", Family: "custom", Modality: "chat", Status: StatusActive})
 	app := NewWithConfig(store, Config{AdminToken: "dev_admin_token", ModelCatalogFile: catalogPath}).Handler()
 

--- a/backend/internal/server/seed.go
+++ b/backend/internal/server/seed.go
@@ -196,7 +196,17 @@ func seedDefaultModelCatalog(store Store, catalogFile string) error {
 	if err != nil {
 		return err
 	}
+	existingByName := make(map[string]Model)
+	for _, model := range store.ListModels() {
+		existingByName[model.Name] = model
+	}
 	for _, model := range models {
+		if existing, ok := existingByName[model.Name]; ok {
+			model.InputPriceUSDPer1M = existing.InputPriceUSDPer1M
+			model.CacheReadPriceUSDPer1M = existing.CacheReadPriceUSDPer1M
+			model.OutputPriceUSDPer1M = existing.OutputPriceUSDPer1M
+			model.EmbeddingPriceUSDPer1M = existing.EmbeddingPriceUSDPer1M
+		}
 		store.AddModel(model)
 	}
 	return nil

--- a/backend/internal/server/seed_test.go
+++ b/backend/internal/server/seed_test.go
@@ -48,3 +48,92 @@ func TestRunStartupBootstrapReloadsCatalogOnEveryStart(t *testing.T) {
 		t.Fatalf("catalog edit was not applied on restart: category=%q", got)
 	}
 }
+
+func TestRunStartupBootstrapPreservesExistingModelPrices(t *testing.T) {
+	store := NewMemoryStore()
+	catalogPath := filepath.Join(t.TempDir(), "model-catalog.yaml")
+	config := Config{
+		BootstrapAdminPassword: "startup-price-test-password",
+		ModelCatalogFile:       catalogPath,
+	}
+	writeCatalog := func(content string) {
+		t.Helper()
+		if err := os.WriteFile(catalogPath, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	modelsByName := func() map[string]Model {
+		t.Helper()
+		models := map[string]Model{}
+		for _, model := range store.ListModels() {
+			models[model.Name] = model
+		}
+		return models
+	}
+
+	writeCatalog(`
+version: 1
+models:
+  - name: startup-priced-model
+    category: first
+    family: startup
+    modality: chat
+    context_window: 1000
+    input_price_usd_per_1m: 1
+    cache_read_price_usd_per_1m: 0.1
+    output_price_usd_per_1m: 2
+    embedding_price_usd_per_1m: 0.2
+`)
+	if err := RunStartupBootstrap(context.Background(), store, config); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UpdateModel("startup-priced-model", Model{
+		InputPriceUSDPer1M:     7,
+		CacheReadPriceUSDPer1M: 0,
+		OutputPriceUSDPer1M:    9,
+		EmbeddingPriceUSDPer1M: 0.9,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	writeCatalog(`
+version: 1
+models:
+  - name: startup-priced-model
+    category: second
+    family: startup
+    modality: chat
+    context_window: 2000
+    input_price_usd_per_1m: 10
+    cache_read_price_usd_per_1m: 1
+    output_price_usd_per_1m: 20
+    embedding_price_usd_per_1m: 2
+  - name: startup-new-model
+    category: second
+    family: startup
+    modality: chat
+    context_window: 3000
+    input_price_usd_per_1m: 11
+    cache_read_price_usd_per_1m: 1.1
+    output_price_usd_per_1m: 22
+    embedding_price_usd_per_1m: 2.2
+`)
+	if err := RunStartupBootstrap(context.Background(), store, config); err != nil {
+		t.Fatal(err)
+	}
+
+	models := modelsByName()
+	priced := models["startup-priced-model"]
+	if priced.InputPriceUSDPer1M != 7 || priced.CacheReadPriceUSDPer1M != 0 ||
+		priced.OutputPriceUSDPer1M != 9 || priced.EmbeddingPriceUSDPer1M != 0.9 {
+		t.Fatalf("startup replaced custom prices: %+v", priced)
+	}
+	if priced.Category != "second" || priced.ContextWindow != 2000 {
+		t.Fatalf("startup did not refresh non-price catalog fields: %+v", priced)
+	}
+	newModel := models["startup-new-model"]
+	if newModel.InputPriceUSDPer1M != 11 || newModel.CacheReadPriceUSDPer1M != 1.1 ||
+		newModel.OutputPriceUSDPer1M != 22 || newModel.EmbeddingPriceUSDPer1M != 2.2 {
+		t.Fatalf("new catalog model did not use catalog prices: %+v", newModel)
+	}
+}


### PR DESCRIPTION
## Summary

Startup model catalog synchronization overwrote administrator-configured model prices with catalog defaults on every backend restart. This PR preserves existing prices during startup while continuing to refresh the rest of each model's catalog metadata.

## Related Issue

N/A.

## Changes

- Index existing models by name before startup catalog synchronization.
- Preserve input, cached-input, output, and embedding prices for existing models, including explicit zero values.
- Continue applying updated non-price catalog fields and catalog prices for newly added models.
- Keep the explicit "Sync Model Reference Catalog" action unchanged so administrators can still restore catalog defaults.
- Add regression coverage for restart preservation and explicit catalog restoration.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...`
- `go vet ./...`
- `node --test tools/*.test.mjs` (103 passed)
- `node tools/check-doc-translations.mjs`
- `node tools/check-ui-translations.mjs`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- `git diff --check upstream/main...HEAD`
- Deployed on the v0.5.0 upgrade branch and manually verified that custom prices survive a backend restart.

## Compatibility, Security, and Operations

No API, database schema, environment variable, security, or deployment changes. Existing model prices now remain stable across restarts; administrators can still restore catalog prices explicitly through the existing model catalog synchronization action.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
