### PR TITLE
ci: automate localized contributor lists

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: "17 3 * * *"
   workflow_dispatch:
 
 permissions:
   contents: write
 
 concurrency:
-  group: contributors-${{ github.ref }}
+  group: contributors-${{ github.repository }}
   cancel-in-progress: true
 
 jobs:
@@ -22,6 +24,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: main
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -45,4 +49,4 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add README.md README.zh-CN.md README.ja.md
           git commit -m "docs(contributors): refresh contributor lists"
-          git push origin "HEAD:${GITHUB_REF_NAME}"
+          git push origin HEAD:main

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,48 @@
+name: Contributors
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: contributors-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: Refresh README contributor lists
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Generate contributor lists
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node tools/update-contributors.mjs
+
+      - name: Commit contributor changes
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- README.md README.zh-CN.md README.ja.md; then
+            echo "Contributor lists are already current."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md README.zh-CN.md README.ja.md
+          git commit -m "docs(contributors): refresh contributor lists"
+          git push origin "HEAD:${GITHUB_REF_NAME}"

--- a/README.ja.md
+++ b/README.ja.md
@@ -154,11 +154,94 @@ cp deploy/.env.example deploy/.env
 
 TokenHub は、実際のエンタープライズ利用からのフィードバック、ゲートウェイ連携、ドキュメント、テスト、継続的なメンテナンスによって育っています。プロジェクトをより信頼できるものにしてくれるすべての方に感謝します。
 
-<p align="center">
-  <a href="https://github.com/astaxie/TokenHub/graphs/contributors">
-    <img src="https://contrib.rocks/image?repo=astaxie/TokenHub" alt="TokenHub contributors" />
-  </a>
-</p>
+<!-- readme: contributors -start -->
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/astaxie">
+        <img src="https://avatars.githubusercontent.com/u/233907?v=4" width="80px" alt="astaxie" />
+        <br /><sub><b>astaxie</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/legendtkl">
+        <img src="https://avatars.githubusercontent.com/u/2370761?v=4" width="80px" alt="legendtkl" />
+        <br /><sub><b>legendtkl</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/cngump">
+        <img src="https://avatars.githubusercontent.com/u/108251?v=4" width="80px" alt="cngump" />
+        <br /><sub><b>cngump</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/Mr0bean">
+        <img src="https://avatars.githubusercontent.com/u/19573968?v=4" width="80px" alt="Mr0bean" />
+        <br /><sub><b>Mr0bean</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/deepjerry-ai">
+        <img src="https://avatars.githubusercontent.com/u/262369278?v=4" width="80px" alt="deepjerry-ai" />
+        <br /><sub><b>deepjerry-ai</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/coldbrewtea">
+        <img src="https://avatars.githubusercontent.com/u/6879314?v=4" width="80px" alt="coldbrewtea" />
+        <br /><sub><b>coldbrewtea</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/wangle201210">
+        <img src="https://avatars.githubusercontent.com/u/19949348?v=4" width="80px" alt="wangle201210" />
+        <br /><sub><b>wangle201210</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/samz406">
+        <img src="https://avatars.githubusercontent.com/u/3055810?v=4" width="80px" alt="samz406" />
+        <br /><sub><b>samz406</b></sub>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/CLukeLi">
+        <img src="https://avatars.githubusercontent.com/u/252523101?v=4" width="80px" alt="CLukeLi" />
+        <br /><sub><b>CLukeLi</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/ocass-chen">
+        <img src="https://avatars.githubusercontent.com/u/172055494?v=4" width="80px" alt="ocass-chen" />
+        <br /><sub><b>ocass-chen</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/AnxForever">
+        <img src="https://avatars.githubusercontent.com/u/130662349?v=4" width="80px" alt="AnxForever" />
+        <br /><sub><b>AnxForever</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/yujiewanwan">
+        <img src="https://avatars.githubusercontent.com/u/268286250?v=4" width="80px" alt="yujiewanwan" />
+        <br /><sub><b>yujiewanwan</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/lxm">
+        <img src="https://avatars.githubusercontent.com/u/1918195?v=4" width="80px" alt="lxm" />
+        <br /><sub><b>lxm</b></sub>
+      </a>
+    </td>
+  </tr>
+</table>
+
+<!-- readme: contributors -end -->
 
 <p align="center">
   <a href="https://github.com/astaxie/TokenHub/graphs/contributors">すべてのコントリビューターを見る</a>

--- a/README.md
+++ b/README.md
@@ -154,11 +154,94 @@ The native installer verifies Release checksums, installs a systemd service, and
 
 TokenHub grows through product feedback, gateway integrations, documentation, tests, and the steady care of people who run it in real enterprise environments.
 
-<p align="center">
-  <a href="https://github.com/astaxie/TokenHub/graphs/contributors">
-    <img src="https://contrib.rocks/image?repo=astaxie/TokenHub" alt="TokenHub contributors" />
-  </a>
-</p>
+<!-- readme: contributors -start -->
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/astaxie">
+        <img src="https://avatars.githubusercontent.com/u/233907?v=4" width="80px" alt="astaxie" />
+        <br /><sub><b>astaxie</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/legendtkl">
+        <img src="https://avatars.githubusercontent.com/u/2370761?v=4" width="80px" alt="legendtkl" />
+        <br /><sub><b>legendtkl</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/cngump">
+        <img src="https://avatars.githubusercontent.com/u/108251?v=4" width="80px" alt="cngump" />
+        <br /><sub><b>cngump</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/Mr0bean">
+        <img src="https://avatars.githubusercontent.com/u/19573968?v=4" width="80px" alt="Mr0bean" />
+        <br /><sub><b>Mr0bean</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/deepjerry-ai">
+        <img src="https://avatars.githubusercontent.com/u/262369278?v=4" width="80px" alt="deepjerry-ai" />
+        <br /><sub><b>deepjerry-ai</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/coldbrewtea">
+        <img src="https://avatars.githubusercontent.com/u/6879314?v=4" width="80px" alt="coldbrewtea" />
+        <br /><sub><b>coldbrewtea</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/wangle201210">
+        <img src="https://avatars.githubusercontent.com/u/19949348?v=4" width="80px" alt="wangle201210" />
+        <br /><sub><b>wangle201210</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/samz406">
+        <img src="https://avatars.githubusercontent.com/u/3055810?v=4" width="80px" alt="samz406" />
+        <br /><sub><b>samz406</b></sub>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/CLukeLi">
+        <img src="https://avatars.githubusercontent.com/u/252523101?v=4" width="80px" alt="CLukeLi" />
+        <br /><sub><b>CLukeLi</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/ocass-chen">
+        <img src="https://avatars.githubusercontent.com/u/172055494?v=4" width="80px" alt="ocass-chen" />
+        <br /><sub><b>ocass-chen</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/AnxForever">
+        <img src="https://avatars.githubusercontent.com/u/130662349?v=4" width="80px" alt="AnxForever" />
+        <br /><sub><b>AnxForever</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/yujiewanwan">
+        <img src="https://avatars.githubusercontent.com/u/268286250?v=4" width="80px" alt="yujiewanwan" />
+        <br /><sub><b>yujiewanwan</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/lxm">
+        <img src="https://avatars.githubusercontent.com/u/1918195?v=4" width="80px" alt="lxm" />
+        <br /><sub><b>lxm</b></sub>
+      </a>
+    </td>
+  </tr>
+</table>
+
+<!-- readme: contributors -end -->
 
 <p align="center">
   <a href="https://github.com/astaxie/TokenHub/graphs/contributors">View all contributors</a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,11 +154,94 @@ cp deploy/.env.example deploy/.env
 
 TokenHub 的演进离不开真实企业场景里的使用反馈、网关集成、文档完善、测试补充和持续维护。感谢每一位让项目变得更可靠的人。
 
-<p align="center">
-  <a href="https://github.com/astaxie/TokenHub/graphs/contributors">
-    <img src="https://contrib.rocks/image?repo=astaxie/TokenHub" alt="TokenHub contributors" />
-  </a>
-</p>
+<!-- readme: contributors -start -->
+
+<table>
+  <tr>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/astaxie">
+        <img src="https://avatars.githubusercontent.com/u/233907?v=4" width="80px" alt="astaxie" />
+        <br /><sub><b>astaxie</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/legendtkl">
+        <img src="https://avatars.githubusercontent.com/u/2370761?v=4" width="80px" alt="legendtkl" />
+        <br /><sub><b>legendtkl</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/cngump">
+        <img src="https://avatars.githubusercontent.com/u/108251?v=4" width="80px" alt="cngump" />
+        <br /><sub><b>cngump</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/Mr0bean">
+        <img src="https://avatars.githubusercontent.com/u/19573968?v=4" width="80px" alt="Mr0bean" />
+        <br /><sub><b>Mr0bean</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/deepjerry-ai">
+        <img src="https://avatars.githubusercontent.com/u/262369278?v=4" width="80px" alt="deepjerry-ai" />
+        <br /><sub><b>deepjerry-ai</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/coldbrewtea">
+        <img src="https://avatars.githubusercontent.com/u/6879314?v=4" width="80px" alt="coldbrewtea" />
+        <br /><sub><b>coldbrewtea</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/wangle201210">
+        <img src="https://avatars.githubusercontent.com/u/19949348?v=4" width="80px" alt="wangle201210" />
+        <br /><sub><b>wangle201210</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/samz406">
+        <img src="https://avatars.githubusercontent.com/u/3055810?v=4" width="80px" alt="samz406" />
+        <br /><sub><b>samz406</b></sub>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/CLukeLi">
+        <img src="https://avatars.githubusercontent.com/u/252523101?v=4" width="80px" alt="CLukeLi" />
+        <br /><sub><b>CLukeLi</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/ocass-chen">
+        <img src="https://avatars.githubusercontent.com/u/172055494?v=4" width="80px" alt="ocass-chen" />
+        <br /><sub><b>ocass-chen</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/AnxForever">
+        <img src="https://avatars.githubusercontent.com/u/130662349?v=4" width="80px" alt="AnxForever" />
+        <br /><sub><b>AnxForever</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/yujiewanwan">
+        <img src="https://avatars.githubusercontent.com/u/268286250?v=4" width="80px" alt="yujiewanwan" />
+        <br /><sub><b>yujiewanwan</b></sub>
+      </a>
+    </td>
+    <td align="center" valign="top" width="12.5%">
+      <a href="https://github.com/lxm">
+        <img src="https://avatars.githubusercontent.com/u/1918195?v=4" width="80px" alt="lxm" />
+        <br /><sub><b>lxm</b></sub>
+      </a>
+    </td>
+  </tr>
+</table>
+
+<!-- readme: contributors -end -->
 
 <p align="center">
   <a href="https://github.com/astaxie/TokenHub/graphs/contributors">查看全部贡献者</a>

--- a/tools/update-contributors.mjs
+++ b/tools/update-contributors.mjs
@@ -21,7 +21,8 @@ export function renderContributors(contributors) {
   for (const contributor of contributors) {
     if (
       typeof contributor.login !== "string" ||
-      contributor.login.endsWith("[bot]") ||
+      contributor.login.toLowerCase().endsWith("[bot]") ||
+      contributor.type === "Bot" ||
       typeof contributor.avatar_url !== "string" ||
       typeof contributor.html_url !== "string"
     ) {
@@ -118,20 +119,54 @@ export async function fetchContributors(repository, token, fetchImpl = fetch) {
   }
 }
 
-async function updateReadmes(contributors) {
+export async function updateReadmes(
+  contributors,
+  {
+    paths = README_PATHS,
+    readFileImpl = readFile,
+    writeFileImpl = writeFile,
+    log = console.log,
+  } = {},
+) {
   const rendered = renderContributors(contributors);
-  let changed = 0;
-  for (const path of README_PATHS) {
-    const current = await readFile(path, "utf8");
-    const next = replaceContributorSection(current, rendered);
-    if (next !== current) {
-      await writeFile(path, next);
-      changed += 1;
-    }
-  }
-  console.log(
-    `Updated ${changed} of ${README_PATHS.length} contributor sections.`,
+  const prepared = await Promise.all(
+    paths.map(async (path) => {
+      const current = await readFileImpl(path, "utf8");
+      return {
+        path,
+        current,
+        next: replaceContributorSection(current, rendered),
+      };
+    }),
   );
+  const changed = prepared.filter(({ current, next }) => next !== current);
+  const touched = [];
+
+  try {
+    for (const entry of changed) {
+      touched.push(entry);
+      await writeFileImpl(entry.path, entry.next);
+    }
+  } catch (writeError) {
+    const rollbackErrors = [];
+    for (const entry of touched.reverse()) {
+      try {
+        await writeFileImpl(entry.path, entry.current);
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
+      }
+    }
+    if (rollbackErrors.length > 0) {
+      throw new AggregateError(
+        [writeError, ...rollbackErrors],
+        "README update failed and could not be fully rolled back",
+      );
+    }
+    throw writeError;
+  }
+
+  log(`Updated ${changed.length} of ${paths.length} contributor sections.`);
+  return changed.length;
 }
 
 async function main() {

--- a/tools/update-contributors.mjs
+++ b/tools/update-contributors.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const START_MARKER = "<!-- readme: contributors -start -->";
+const END_MARKER = "<!-- readme: contributors -end -->";
+const README_PATHS = ["README.md", "README.zh-CN.md", "README.ja.md"];
+const COLUMNS_PER_ROW = 8;
+
+function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+export function renderContributors(contributors) {
+  const unique = new Map();
+  for (const contributor of contributors) {
+    if (
+      typeof contributor.login !== "string" ||
+      contributor.login.endsWith("[bot]") ||
+      typeof contributor.avatar_url !== "string" ||
+      typeof contributor.html_url !== "string"
+    ) {
+      continue;
+    }
+    unique.set(contributor.login.toLowerCase(), contributor);
+  }
+
+  const entries = [...unique.values()];
+  if (entries.length === 0) {
+    throw new Error("GitHub returned no displayable contributors");
+  }
+
+  const rows = [];
+  for (let index = 0; index < entries.length; index += COLUMNS_PER_ROW) {
+    const cells = entries
+      .slice(index, index + COLUMNS_PER_ROW)
+      .map((contributor) => {
+        const login = escapeHtml(contributor.login);
+        const profile = escapeHtml(contributor.html_url);
+        const avatar = escapeHtml(contributor.avatar_url);
+        return [
+          '    <td align="center" valign="top" width="12.5%">',
+          `      <a href="${profile}">`,
+          `        <img src="${avatar}" width="80px" alt="${login}" />`,
+          `        <br /><sub><b>${login}</b></sub>`,
+          "      </a>",
+          "    </td>",
+        ].join("\n");
+      });
+    rows.push(["  <tr>", ...cells, "  </tr>"].join("\n"));
+  }
+
+  return ["<table>", ...rows, "</table>"].join("\n");
+}
+
+export function replaceContributorSection(readme, rendered) {
+  const start = readme.indexOf(START_MARKER);
+  const end = readme.indexOf(END_MARKER);
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(
+      `README must contain one ordered ${START_MARKER} / ${END_MARKER} pair`,
+    );
+  }
+  if (
+    readme.indexOf(START_MARKER, start + START_MARKER.length) !== -1 ||
+    readme.indexOf(END_MARKER, end + END_MARKER.length) !== -1
+  ) {
+    throw new Error("README contains duplicate contributor markers");
+  }
+
+  return [
+    readme.slice(0, start),
+    START_MARKER,
+    "\n\n",
+    rendered,
+    "\n\n",
+    END_MARKER,
+    readme.slice(end + END_MARKER.length),
+  ].join("");
+}
+
+export async function fetchContributors(repository, token, fetchImpl = fetch) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error(`Invalid GITHUB_REPOSITORY value: ${repository}`);
+  }
+
+  const contributors = [];
+  for (let page = 1; ; page += 1) {
+    const response = await fetchImpl(
+      `https://api.github.com/repos/${repository}/contributors?per_page=100&page=${page}`,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${token}`,
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `GitHub contributors request failed: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const pageEntries = await response.json();
+    if (!Array.isArray(pageEntries)) {
+      throw new Error("GitHub contributors response was not an array");
+    }
+    contributors.push(...pageEntries);
+    if (pageEntries.length < 100) {
+      return contributors;
+    }
+  }
+}
+
+async function updateReadmes(contributors) {
+  const rendered = renderContributors(contributors);
+  let changed = 0;
+  for (const path of README_PATHS) {
+    const current = await readFile(path, "utf8");
+    const next = replaceContributorSection(current, rendered);
+    if (next !== current) {
+      await writeFile(path, next);
+      changed += 1;
+    }
+  }
+  console.log(
+    `Updated ${changed} of ${README_PATHS.length} contributor sections.`,
+  );
+}
+
+async function main() {
+  const repository = process.env.GITHUB_REPOSITORY;
+  const token = process.env.GITHUB_TOKEN;
+  if (!repository || !token) {
+    throw new Error("GITHUB_REPOSITORY and GITHUB_TOKEN are required");
+  }
+  await updateReadmes(await fetchContributors(repository, token));
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/tools/update-contributors.test.mjs
+++ b/tools/update-contributors.test.mjs
@@ -5,6 +5,7 @@ import {
   fetchContributors,
   renderContributors,
   replaceContributorSection,
+  updateReadmes,
 } from "./update-contributors.mjs";
 
 const contributors = [
@@ -18,6 +19,17 @@ const contributors = [
     avatar_url: "https://avatars.example/bot",
     html_url: "https://github.com/apps/release",
   },
+  {
+    login: "LOUD[BOT]",
+    avatar_url: "https://avatars.example/loud-bot",
+    html_url: "https://github.com/apps/loud",
+  },
+  {
+    login: "automation",
+    avatar_url: "https://avatars.example/automation",
+    html_url: "https://github.com/automation",
+    type: "Bot",
+  },
 ];
 
 describe("contributor rendering", () => {
@@ -27,6 +39,8 @@ describe("contributor rendering", () => {
     assert.match(rendered, /href="https:\/\/github\.com\/alice"/);
     assert.match(rendered, /<b>alice<\/b>/);
     assert.doesNotMatch(rendered, /release\[bot\]/);
+    assert.doesNotMatch(rendered, /LOUD\[BOT\]/);
+    assert.doesNotMatch(rendered, /automation/);
   });
 
   it("escapes contributor-controlled values", () => {
@@ -40,6 +54,71 @@ describe("contributor rendering", () => {
 
     assert.match(rendered, /a&lt;&amp;&quot;/);
     assert.match(rendered, /x=1&amp;y=&quot;2&quot;/);
+  });
+});
+
+describe("README transaction", () => {
+  const markerDocument = (content) =>
+    [
+      "before",
+      "<!-- readme: contributors -start -->",
+      content,
+      "<!-- readme: contributors -end -->",
+      "after",
+    ].join("\n");
+
+  it("validates every README before writing any of them", async () => {
+    const files = new Map([
+      ["README.md", markerDocument("old")],
+      ["README.zh-CN.md", "missing markers"],
+      ["README.ja.md", markerDocument("old")],
+    ]);
+    let writes = 0;
+
+    await assert.rejects(
+      () =>
+        updateReadmes(contributors, {
+          paths: [...files.keys()],
+          readFileImpl: async (path) => files.get(path),
+          writeFileImpl: async () => {
+            writes += 1;
+          },
+          log() {},
+        }),
+      /must contain/,
+    );
+
+    assert.equal(writes, 0);
+    assert.equal(files.get("README.md"), markerDocument("old"));
+  });
+
+  it("rolls back every touched README when a write fails", async () => {
+    const original = new Map([
+      ["README.md", markerDocument("english")],
+      ["README.zh-CN.md", markerDocument("chinese")],
+      ["README.ja.md", markerDocument("japanese")],
+    ]);
+    const files = new Map(original);
+    let failedOnce = false;
+
+    await assert.rejects(
+      () =>
+        updateReadmes(contributors, {
+          paths: [...files.keys()],
+          readFileImpl: async (path) => files.get(path),
+          writeFileImpl: async (path, content) => {
+            if (path === "README.zh-CN.md" && !failedOnce) {
+              failedOnce = true;
+              throw new Error("simulated write failure");
+            }
+            files.set(path, content);
+          },
+          log() {},
+        }),
+      /simulated write failure/,
+    );
+
+    assert.deepEqual(files, original);
   });
 });
 

--- a/tools/update-contributors.test.mjs
+++ b/tools/update-contributors.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  fetchContributors,
+  renderContributors,
+  replaceContributorSection,
+} from "./update-contributors.mjs";
+
+const contributors = [
+  {
+    login: "alice",
+    avatar_url: "https://avatars.example/alice",
+    html_url: "https://github.com/alice",
+  },
+  {
+    login: "release[bot]",
+    avatar_url: "https://avatars.example/bot",
+    html_url: "https://github.com/apps/release",
+  },
+];
+
+describe("contributor rendering", () => {
+  it("renders GitHub users and excludes bots", () => {
+    const rendered = renderContributors(contributors);
+
+    assert.match(rendered, /href="https:\/\/github\.com\/alice"/);
+    assert.match(rendered, /<b>alice<\/b>/);
+    assert.doesNotMatch(rendered, /release\[bot\]/);
+  });
+
+  it("escapes contributor-controlled values", () => {
+    const rendered = renderContributors([
+      {
+        login: 'a<&"',
+        avatar_url: 'https://avatars.example/a?x=1&y="2"',
+        html_url: "https://github.com/a?x=1&y=2",
+      },
+    ]);
+
+    assert.match(rendered, /a&lt;&amp;&quot;/);
+    assert.match(rendered, /x=1&amp;y=&quot;2&quot;/);
+  });
+});
+
+describe("README replacement", () => {
+  it("replaces only the marked contributor section", () => {
+    const readme = [
+      "before",
+      "<!-- readme: contributors -start -->",
+      "old",
+      "<!-- readme: contributors -end -->",
+      "after",
+    ].join("\n");
+
+    assert.equal(
+      replaceContributorSection(readme, "new"),
+      [
+        "before",
+        "<!-- readme: contributors -start -->",
+        "",
+        "new",
+        "",
+        "<!-- readme: contributors -end -->",
+        "after",
+      ].join("\n"),
+    );
+  });
+
+  it("rejects missing or duplicate markers", () => {
+    assert.throws(
+      () => replaceContributorSection("README", "new"),
+      /must contain/,
+    );
+    assert.throws(
+      () =>
+        replaceContributorSection(
+          "<!-- readme: contributors -start -->\n<!-- readme: contributors -start -->\n<!-- readme: contributors -end -->",
+          "new",
+        ),
+      /duplicate/,
+    );
+  });
+});
+
+describe("GitHub contributor pagination", () => {
+  it("requests pages until GitHub returns fewer than 100 entries", async () => {
+    const requests = [];
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      login: `user-${index}`,
+    }));
+    const fetchImpl = async (url, options) => {
+      requests.push({ url, options });
+      return {
+        ok: true,
+        async json() {
+          return requests.length === 1 ? firstPage : [{ login: "last-user" }];
+        },
+      };
+    };
+
+    const result = await fetchContributors(
+      "astaxie/TokenHub",
+      "test-token",
+      fetchImpl,
+    );
+
+    assert.equal(result.length, 101);
+    assert.match(requests[0].url, /page=1$/);
+    assert.match(requests[1].url, /page=2$/);
+    assert.equal(
+      requests[0].options.headers.Authorization,
+      "Bearer test-token",
+    );
+  });
+
+  it("rejects malformed repository names", async () => {
+    await assert.rejects(
+      () => fetchContributors("not-a-repository", "token"),
+      /Invalid/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Automatically maintain the contributor table in all three localized README files after changes land on `main`. The implementation follows the linked contributor-list approach while adapting it to TokenHub's translation co-change requirement.

## Related Issue

N/A.

## Changes

- Add a `Contributors` workflow for pushes to `main`, daily reconciliation, and manual dispatches that always target `main`.
- Add a GitHub API-backed generator that validates all localized README files before writing and rolls back touched files on write failure.
- Replace the external `contrib.rocks` image with generated contributor profile tables and add focused generator tests.
- Exclude bot contributors using both GitHub's `type` field and case-insensitive login suffix detection.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [x] Documentation
- [x] Deployment or configuration

## Verification

- `node --test tools/*.test.mjs` (111 tests passed)
- `node tools/check-doc-translations.mjs --base origin/main --head HEAD`
- `node tools/check-ui-translations.mjs`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/contributors.yml`
- `npx --yes prettier@3.6.2 --check .github/workflows/contributors.yml tools/update-contributors.mjs tools/update-contributors.test.mjs`
- `git diff origin/main...HEAD --check`
- Contributor generation rerun produced no diff.

## Compatibility, Security, and Operations

No API, data model, deployment, or runtime compatibility impact. The workflow runs only for trusted `main` pushes, scheduled reconciliation, or manual dispatches; always checks out and pushes `main`; uses the repository-scoped `GITHUB_TOKEN` with `contents: write`; filters bot accounts; and commits only the three README files. Rollback consists of removing the workflow and generator and restoring the existing external contributor image.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
