### PR TITLE
refactor(server): register simple routes by method

### DIFF
--- a/backend/internal/server/admin_auth_http.go
+++ b/backend/internal/server/admin_auth_http.go
@@ -17,10 +17,6 @@ import (
 )
 
 func (s *Server) handleAdminLogin(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	var req struct {
 		Identity string `json:"identity"`
 		Password string `json:"password"`
@@ -46,10 +42,6 @@ func (s *Server) handleAdminLogin(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleAdminResetPassword(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	var req struct {
 		Token    string `json:"token"`
 		Password string `json:"password"`
@@ -75,10 +67,6 @@ func (s *Server) handleAdminResetPassword(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) handleAdminLogout(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	token := bearerToken(r)
 	if token != "" && token != strings.TrimSpace(s.config.AdminToken) {
 		s.store.RevokeAdminSession(token)
@@ -125,10 +113,6 @@ type oauthTokenResponse struct {
 }
 
 func (s *Server) handleAdminAuthIdentityProviders(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	providers := []adminAuthIdentityProvider{}
 	for _, item := range s.activeOAuthIdentityProviders() {
 		providers = append(providers, adminAuthIdentityProvider{
@@ -144,10 +128,6 @@ func (s *Server) handleAdminAuthIdentityProviders(w http.ResponseWriter, r *http
 }
 
 func (s *Server) handleAdminOAuthStart(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	provider, ok := s.findActiveOAuthIdentityProvider(r.URL.Query().Get("id"))
 	if !ok {
 		writeError(w, r, NewHTTPError(404, "identity_provider_not_found", "Identity provider not found"))
@@ -185,10 +165,6 @@ func (s *Server) handleAdminOAuthStart(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleAdminOAuthCallback(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	state, err := s.verifyOAuthState(r.URL.Query().Get("state"))
 	if err != nil {
 		writeError(w, r, NewHTTPError(400, "invalid_oauth_state", "OAuth state is invalid or expired"))

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -147,18 +147,10 @@ func (s *Server) handleAdminProviderAdapters(w http.ResponseWriter, r *http.Requ
 }
 
 func (s *Server) handleLive(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "service": "tokenhub-backend"})
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
 	defer cancel()
 	if err := s.store.Ping(ctx); err != nil {

--- a/backend/internal/server/method_routes.go
+++ b/backend/internal/server/method_routes.go
@@ -1,0 +1,20 @@
+package server
+
+import "net/http"
+
+// registerSingleMethodRoute must only be called once for a path. Multi-method
+// resources need one shared fallback with the complete Allow value.
+func (s *Server) registerSingleMethodRoute(method string, pattern string, handler http.HandlerFunc, methodNotAllowed http.HandlerFunc) {
+	s.mux.HandleFunc(method+" "+pattern, handler)
+	if method == http.MethodGet {
+		s.mux.HandleFunc(http.MethodHead+" "+pattern, methodNotAllowed)
+	}
+	s.mux.HandleFunc(pattern, methodNotAllowed)
+}
+
+func jsonMethodNotAllowed(allowedMethod string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Allow", allowedMethod)
+		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+	}
+}

--- a/backend/internal/server/method_routing_contract_test.go
+++ b/backend/internal/server/method_routing_contract_test.go
@@ -2,10 +2,12 @@ package server
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestMethodRoutingContracts(t *testing.T) {
@@ -23,8 +25,6 @@ func TestMethodRoutingContracts(t *testing.T) {
 		wantCode  string
 		wantAllow string
 	}{
-		{name: "health wrong method", method: http.MethodPost, path: "/livez", wantCode: "method_not_allowed", wantAllow: ""},
-		{name: "admin login wrong method", method: http.MethodGet, path: "/api/admin/auth/login", wantCode: "method_not_allowed", wantAllow: ""},
 		{name: "gateway wrong method", method: http.MethodGet, path: "/v1/chat/completions", wantCode: "method_not_allowed", wantAllow: ""},
 		{name: "models rejects head", method: http.MethodHead, path: "/v1/models", wantCode: "method_not_allowed", wantAllow: ""},
 	}
@@ -35,6 +35,161 @@ func TestMethodRoutingContracts(t *testing.T) {
 			assertAllowHeader(t, response, test.wantAllow)
 		})
 	}
+}
+
+func TestSimpleMethodRoutesReachHandlers(t *testing.T) {
+	app := newTestServer()
+	tests := []struct {
+		method     string
+		path       string
+		wantStatus int
+	}{
+		{method: http.MethodGet, path: "/livez", wantStatus: http.StatusOK},
+		{method: http.MethodGet, path: "/readyz", wantStatus: http.StatusOK},
+		{method: http.MethodGet, path: "/healthz", wantStatus: http.StatusOK},
+		{method: http.MethodGet, path: "/api/admin/auth/identity-providers", wantStatus: http.StatusOK},
+		{method: http.MethodGet, path: "/api/admin/auth/oauth/start", wantStatus: http.StatusNotFound},
+		{method: http.MethodGet, path: "/api/admin/auth/oauth/callback", wantStatus: http.StatusBadRequest},
+		{method: http.MethodPost, path: "/api/admin/auth/login", wantStatus: http.StatusBadRequest},
+		{method: http.MethodPost, path: "/api/admin/auth/logout", wantStatus: http.StatusNoContent},
+		{method: http.MethodPost, path: "/api/admin/auth/reset-password", wantStatus: http.StatusBadRequest},
+	}
+	for _, test := range tests {
+		t.Run(test.method+" "+test.path, func(t *testing.T) {
+			response := methodRoutingRequest(app, test.method, test.path, "")
+			if response.Code != test.wantStatus {
+				t.Fatalf("expected %d, got %d: %s", test.wantStatus, response.Code, response.Body.String())
+			}
+		})
+	}
+}
+
+func TestSimpleMethodRoutesRejectWrongMethodsAsJSON(t *testing.T) {
+	app := newTestServer()
+	tests := []struct {
+		allowed string
+		method  string
+		path    string
+	}{
+		{allowed: http.MethodGet, method: http.MethodPost, path: "/livez"},
+		{allowed: http.MethodGet, method: http.MethodPost, path: "/readyz"},
+		{allowed: http.MethodGet, method: http.MethodPost, path: "/healthz"},
+		{allowed: http.MethodGet, method: http.MethodPost, path: "/api/admin/auth/identity-providers"},
+		{allowed: http.MethodGet, method: http.MethodPost, path: "/api/admin/auth/oauth/start"},
+		{allowed: http.MethodGet, method: http.MethodPost, path: "/api/admin/auth/oauth/callback"},
+		{allowed: http.MethodPost, method: http.MethodGet, path: "/api/admin/auth/login"},
+		{allowed: http.MethodPost, method: http.MethodGet, path: "/api/admin/auth/logout"},
+		{allowed: http.MethodPost, method: http.MethodGet, path: "/api/admin/auth/reset-password"},
+	}
+	for _, test := range tests {
+		t.Run(test.method+" "+test.path, func(t *testing.T) {
+			response := methodRoutingRequest(app, test.method, test.path, "")
+			assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+			assertAllowHeader(t, response, test.allowed)
+		})
+	}
+}
+
+func TestSimpleGETMethodRoutesRejectHEAD(t *testing.T) {
+	server := httptest.NewServer(newTestServer())
+	defer server.Close()
+
+	paths := []string{
+		"/livez",
+		"/readyz",
+		"/healthz",
+		"/api/admin/auth/identity-providers",
+		"/api/admin/auth/oauth/start",
+		"/api/admin/auth/oauth/callback",
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			request, err := http.NewRequest(http.MethodHead, server.URL+path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			response, err := server.Client().Do(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer response.Body.Close()
+
+			if response.StatusCode != http.StatusMethodNotAllowed {
+				t.Fatalf("expected 405, got %d", response.StatusCode)
+			}
+			if got := response.Header.Get("Allow"); got != http.MethodGet {
+				t.Fatalf("Allow = %q, want %q", got, http.MethodGet)
+			}
+			if requestID := response.Header.Get("x-request-id"); requestID == "" {
+				t.Fatal("x-request-id is empty")
+			}
+			body, err := io.ReadAll(response.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(body) != 0 {
+				t.Fatalf("HEAD response body = %q, want empty", body)
+			}
+		})
+	}
+}
+
+func TestSingleMethodRouteLeavesFallbackHeadersToFallback(t *testing.T) {
+	server := &Server{mux: http.NewServeMux()}
+	server.registerSingleMethodRoute(http.MethodGet, "/protected", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}, func(w http.ResponseWriter, r *http.Request) {
+		writeError(w, r, NewHTTPError(http.StatusUnauthorized, "invalid_admin_token", "Invalid admin token"))
+	})
+
+	response := methodRoutingRequest(server.mux, http.MethodPost, "/protected", "")
+	assertJSONError(t, response, http.StatusUnauthorized, "invalid_admin_token")
+	assertAllowHeader(t, response, "")
+}
+
+func TestSimpleMethodRouteLogoutRevokesSession(t *testing.T) {
+	_, app := newMethodRoutingAdminServer(t, "method-routing-old-password")
+	token, _ := loginMethodRoutingAdmin(t, app, "method-routing-old-password")
+
+	response := methodRoutingRequest(app, http.MethodPost, "/api/admin/auth/logout", token)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("logout: expected 204, got %d: %s", response.Code, response.Body.String())
+	}
+
+	response = methodRoutingRequest(app, http.MethodGet, "/api/admin/auth/me", token)
+	assertJSONError(t, response, http.StatusUnauthorized, "invalid_admin_token")
+}
+
+func TestSimpleMethodRouteResetPasswordInvalidatesOldCredentials(t *testing.T) {
+	const (
+		oldPassword = "method-routing-old-password"
+		newPassword = "method-routing-new-password"
+	)
+	store, app := newMethodRoutingAdminServer(t, oldPassword)
+	oldSession, user := loginMethodRoutingAdmin(t, app, oldPassword)
+	resetToken, _, err := store.CreateAdminPasswordResetToken(user.ID, user.ID, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	response := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/auth/reset-password", map[string]any{
+		"token":    resetToken,
+		"password": newPassword,
+	}, "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("reset password: expected 200, got %d: %s", response.Code, response.Body.String())
+	}
+
+	response = methodRoutingRequest(app, http.MethodGet, "/api/admin/auth/me", oldSession)
+	assertJSONError(t, response, http.StatusUnauthorized, "invalid_admin_token")
+
+	response = methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/auth/login", map[string]any{
+		"identity": user.Email,
+		"password": oldPassword,
+	}, "")
+	assertJSONError(t, response, http.StatusUnauthorized, "invalid_credentials")
+
+	loginMethodRoutingAdmin(t, app, newPassword)
 }
 
 func TestMethodRoutingPreservesAdminAuthenticationOrder(t *testing.T) {
@@ -98,6 +253,56 @@ func methodRoutingRequest(handler http.Handler, method string, path string, toke
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
 	return response
+}
+
+func methodRoutingJSONRequest(t *testing.T, handler http.Handler, method string, path string, payload any, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(method, path, strings.NewReader(string(body)))
+	request.Header.Set("content-type", "application/json")
+	if token != "" {
+		request.Header.Set("authorization", "Bearer "+token)
+	}
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	return response
+}
+
+func newMethodRoutingAdminServer(t *testing.T, password string) (*GormStore, http.Handler) {
+	t.Helper()
+	config := ConfigFromEnv()
+	config.AdminToken = "dev_admin_token"
+	config.BootstrapAdminPassword = password
+	store := NewMemoryStoreWithConfig(config)
+	if err := BootstrapBaseDataWithConfig(store, config); err != nil {
+		t.Fatal(err)
+	}
+	return store, NewWithConfig(store, config).Handler()
+}
+
+func loginMethodRoutingAdmin(t *testing.T, handler http.Handler, password string) (string, AdminUser) {
+	t.Helper()
+	response := methodRoutingJSONRequest(t, handler, http.MethodPost, "/api/admin/auth/login", map[string]any{
+		"identity": "admin@tokenhub.local",
+		"password": password,
+	}, "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("login: expected 200, got %d: %s", response.Code, response.Body.String())
+	}
+	var payload struct {
+		Token string    `json:"token"`
+		User  AdminUser `json:"user"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Token == "" || payload.User.ID == "" {
+		t.Fatalf("incomplete login response: %#v", payload)
+	}
+	return payload.Token, payload.User
 }
 
 func assertJSONError(t *testing.T, response *httptest.ResponseRecorder, wantStatus int, wantCode string) {

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -1,12 +1,14 @@
 package server
 
+import "net/http"
+
 // The gateway's URL surface, kept apart from server construction so adding an
 // endpoint and changing how the server is built stay separate edits.
 
 func (s *Server) routes() {
-	s.mux.HandleFunc("/livez", s.handleLive)
-	s.mux.HandleFunc("/readyz", s.handleHealth)
-	s.mux.HandleFunc("/healthz", s.handleHealth)
+	s.registerSingleMethodRoute(http.MethodGet, "/livez", s.handleLive, jsonMethodNotAllowed(http.MethodGet))
+	s.registerSingleMethodRoute(http.MethodGet, "/readyz", s.handleHealth, jsonMethodNotAllowed(http.MethodGet))
+	s.registerSingleMethodRoute(http.MethodGet, "/healthz", s.handleHealth, jsonMethodNotAllowed(http.MethodGet))
 	s.mux.HandleFunc("/metrics", s.handleMetrics)
 	s.registerModelRoutes()
 	// The in-flight gauge covers exactly the endpoints that route to an upstream, so
@@ -25,13 +27,13 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("/v1/image-assets/", s.handleImageAsset)
 	s.mux.HandleFunc("/api/v1/analytics/token-costs", s.handleTokenCostAnalytics)
 
-	s.mux.HandleFunc("/api/admin/auth/login", s.handleAdminLogin)
-	s.mux.HandleFunc("/api/admin/auth/logout", s.handleAdminLogout)
+	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/auth/login", s.handleAdminLogin, jsonMethodNotAllowed(http.MethodPost))
+	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/auth/logout", s.handleAdminLogout, jsonMethodNotAllowed(http.MethodPost))
 	s.mux.HandleFunc("/api/admin/auth/me", s.handleAdminMe)
-	s.mux.HandleFunc("/api/admin/auth/reset-password", s.handleAdminResetPassword)
-	s.mux.HandleFunc("/api/admin/auth/identity-providers", s.handleAdminAuthIdentityProviders)
-	s.mux.HandleFunc("/api/admin/auth/oauth/start", s.handleAdminOAuthStart)
-	s.mux.HandleFunc("/api/admin/auth/oauth/callback", s.handleAdminOAuthCallback)
+	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/auth/reset-password", s.handleAdminResetPassword, jsonMethodNotAllowed(http.MethodPost))
+	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/auth/identity-providers", s.handleAdminAuthIdentityProviders, jsonMethodNotAllowed(http.MethodGet))
+	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/auth/oauth/start", s.handleAdminOAuthStart, jsonMethodNotAllowed(http.MethodGet))
+	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/auth/oauth/callback", s.handleAdminOAuthCallback, jsonMethodNotAllowed(http.MethodGet))
 	s.mux.HandleFunc("/api/admin/overview", s.handleAdminOverview)
 	s.mux.HandleFunc("/api/admin/playground/chat", s.handleAdminPlaygroundChat)
 	s.mux.HandleFunc("/api/admin/playground/chat/stream", s.handleAdminPlaygroundChatStream)


### PR DESCRIPTION
## Summary

Move method checks for the first batch of simple endpoints out of the handlers and into `http.ServeMux` route patterns.

The handlers can now focus on request validation and business logic, while wrong methods still use TokenHub's JSON error format instead of the default plain-text 405 response.

## Related Issue

Related #145 

## Changes

- Added a small helper for single-method routes with a caller-provided 405 fallback.
- Kept explicit HEAD rejection for GET routes to preserve the current behavior.
- Added `Allow` headers to wrong-method responses.
- Migrated these routes:
  - `GET /livez`
  - `GET /readyz`
  - `GET /healthz`
  - `GET /api/admin/auth/identity-providers`
  - `GET /api/admin/auth/oauth/start`
  - `GET /api/admin/auth/oauth/callback`
  - `POST /api/admin/auth/login`
  - `POST /api/admin/auth/logout`
  - `POST /api/admin/auth/reset-password`
- Added route-level coverage for normal requests, wrong methods, HEAD, JSON errors, request IDs, and `Allow`.
- Added full logout and password reset tests to make sure headers and request bodies still reach the handlers correctly.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...`
- `go vet ./...`
- `node --test tools/*.test.mjs`
- `node tools/check-doc-translations.mjs`
- `node tools/check-ui-translations.mjs`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- `git diff --check`

Frontend build and SDK smoke tests were not run because this change only touches backend routing and does not change frontend or gateway behavior.

## Compatibility, Security, and Operations

Wrong methods still return TokenHub's JSON error body with a request ID. They now also include the matching `Allow` header.

GET routes still reject HEAD, and CORS preflight requests are still handled before the mux. There are no database, configuration, deployment, or authentication flow changes.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
