### PR TITLE
feat(audit): search request logs by API key name

### DIFF
--- a/backend/internal/server/admin_request_logs_test.go
+++ b/backend/internal/server/admin_request_logs_test.go
@@ -173,6 +173,12 @@ func TestAdminRequestLogsFiltersExactModelAndInclusiveTimeRange(t *testing.T) {
 func TestAdminRequestLogsSearchesExistingAuditFields(t *testing.T) {
 	store := NewMemoryStore()
 	project := store.CreateProject(Project{ID: "project_search", Name: "Alpha Finance"})
+	if _, _, err := store.CreateAPIKey(project.ID, APIKey{
+		ID:   "key-needle-id",
+		Name: "Batch Processing",
+	}, "thk_search_key"); err != nil {
+		t.Fatal(err)
+	}
 	provider := store.AddProvider(Provider{ID: "provider_search", Name: "Jade Channel", Type: "openai_compatible"})
 	createdAt := time.Date(2026, time.August, 5, 12, 0, 0, 0, time.UTC)
 	if err := store.db.Create(&RequestLog{
@@ -207,6 +213,8 @@ func TestAdminRequestLogsSearchesExistingAuditFields(t *testing.T) {
 		"Alpha Finance",
 		"jade channel",
 		"key-needle-id",
+		"BATCH PROCESSING",
+		"batch",
 		"gpt-needle-model",
 		"provider_search",
 		"resource-needle-id",
@@ -235,6 +243,17 @@ func TestAdminRequestLogsSearchesExistingAuditFields(t *testing.T) {
 				t.Fatalf("keyword %q returned unexpected metadata: pagination=%+v summary=%+v", keyword, payload.Pagination, payload.Summary)
 			}
 		})
+	}
+	rawKeySearch := doJSON(t, app, http.MethodGet, "/api/admin/audit/requests?q=thk_search_key", nil, "")
+	if rawKeySearch.Code != http.StatusOK {
+		t.Fatalf("expected raw key search 200, got %d: %s", rawKeySearch.Code, rawKeySearch.Body)
+	}
+	var rawKeyPayload RequestLogPage
+	if err := json.Unmarshal([]byte(rawKeySearch.Body), &rawKeyPayload); err != nil {
+		t.Fatal(err)
+	}
+	if len(rawKeyPayload.Data) != 0 {
+		t.Fatalf("raw API key search must not return request logs: %+v", rawKeyPayload.Data)
 	}
 	for _, literal := range []string{"%", "!"} {
 		wildcard := doJSON(t, app, http.MethodGet, "/api/admin/audit/requests?q="+url.QueryEscape(literal), nil, "")

--- a/backend/internal/server/store_request_logs.go
+++ b/backend/internal/server/store_request_logs.go
@@ -129,8 +129,8 @@ func applyRequestLogKeyword(db *gorm.DB, keyword string) *gorm.DB {
 		"provider_model",
 		"error_code",
 	}
-	conditions := make([]string, 0, len(columns)+3)
-	args := make([]any, 0, len(columns)+3)
+	conditions := make([]string, 0, len(columns)+4)
+	args := make([]any, 0, len(columns)+4)
 	for _, column := range columns {
 		conditions = append(conditions, "LOWER(COALESCE("+column+", '')) LIKE ? ESCAPE '!'")
 		args = append(args, pattern)
@@ -138,9 +138,10 @@ func applyRequestLogKeyword(db *gorm.DB, keyword string) *gorm.DB {
 	conditions = append(conditions,
 		"LOWER(CAST(status_code AS TEXT)) LIKE ? ESCAPE '!'",
 		"EXISTS (SELECT 1 FROM projects WHERE projects.id = request_logs.project_id AND LOWER(COALESCE(projects.name, '')) LIKE ? ESCAPE '!')",
+		"EXISTS (SELECT 1 FROM api_keys WHERE api_keys.id = request_logs.api_key_id AND LOWER(COALESCE(api_keys.name, '')) LIKE ? ESCAPE '!')",
 		"EXISTS (SELECT 1 FROM providers WHERE providers.id = request_logs.provider_id AND LOWER(COALESCE(providers.name, '')) LIKE ? ESCAPE '!')",
 	)
-	args = append(args, pattern, pattern, pattern)
+	args = append(args, pattern, pattern, pattern, pattern)
 	return db.Where("("+strings.Join(conditions, " OR ")+")", args...)
 }
 

--- a/frontend/features/admin/i18n/en.tsx
+++ b/frontend/features/admin/i18n/en.tsx
@@ -539,7 +539,7 @@ export const enTranslations: Record<string, string> = {
     "日志类型": "Log Type",
     "请求状态筛选": "Request Status Filter",
     "搜索请求历史": "Search request history",
-    "搜索请求 ID、模型、Provider、状态码": "Search request ID, model, Provider, or status code",
+    "搜索请求 ID、API Key 名称或 ID、模型、Provider、状态码": "Search request ID, API Key name or ID, model, Provider, or status code",
     "全部": "All",
     "图像": "Image",
     "视频": "Video",

--- a/frontend/features/admin/i18n/ja.tsx
+++ b/frontend/features/admin/i18n/ja.tsx
@@ -539,7 +539,7 @@ export const jaTranslations: Record<string, string> = {
     "日志类型": "ログ種別",
     "请求状态筛选": "リクエスト状態フィルタ",
     "搜索请求历史": "リクエスト履歴を検索",
-    "搜索请求 ID、模型、Provider、状态码": "リクエスト ID、モデル、Provider、状態コードを検索",
+    "搜索请求 ID、API Key 名称或 ID、模型、Provider、状态码": "リクエスト ID、API Key の名前または ID、モデル、Provider、ステータスコードを検索",
     "全部": "すべて",
     "图像": "画像",
     "视频": "動画",

--- a/frontend/features/admin/views/audit.tsx
+++ b/frontend/features/admin/views/audit.tsx
@@ -215,7 +215,7 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
                     setQuery(event.target.value);
                     setRequestPage(1);
                   }}
-                  placeholder={tx("搜索请求 ID、模型、Provider、状态码")}
+                  placeholder={tx("搜索请求 ID、API Key 名称或 ID、模型、Provider、状态码")}
                 />
               </label>
               <div className="request-filter-tabs" role="tablist" aria-label={tx("请求状态筛选")}>


### PR DESCRIPTION
## Summary

Allow the existing request history keyword search to match the name of the API Key that made a request. This makes per-key troubleshooting possible without exposing or searching raw API key secrets.

## Related Issue

N/A

## Changes

- Match `api_keys.name` through the existing `request_logs.api_key_id` relation in request-log keyword searches.
- Keep the current case-insensitive partial-match behavior and API Key ID search.
- Update the request-history search placeholder in English, Simplified Chinese, and Japanese.
- Add coverage for API Key name, name fragment, and raw-secret non-matching behavior.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...` (backend)
- `go vet ./...` (backend)
- `npx tsc --noEmit` (frontend)
- `node --test tools/*.test.mjs`
- `node tools/check-doc-translations.mjs`
- `node tools/check-ui-translations.mjs`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- `git diff --check`

## Compatibility, Security, and Operations

The existing `q` query parameter gains API Key name matching; its request and response shapes are unchanged. No schema migration, configuration, deployment change, or raw API key lookup is introduced.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable. No environment variables changed.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable. No catalog changes.
- [x] `git diff --check` passes.