### PR TITLE
refactor(server): route system endpoints by method

### DIFF
--- a/backend/internal/server/http_transport.go
+++ b/backend/internal/server/http_transport.go
@@ -421,12 +421,6 @@ func (s *Server) cors(next http.Handler) http.Handler {
 }
 
 func (s *Server) handleAdminSystemDBStatus(w http.ResponseWriter, r *http.Request) {
-	// Only allow GET requests.
-	if r.Method != http.MethodGet {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
 	// Verify administrator permissions.
 	if _, ok := s.requireAdmin(w, r, "system", r.Method); !ok {
 		return

--- a/backend/internal/server/method_routes.go
+++ b/backend/internal/server/method_routes.go
@@ -19,6 +19,13 @@ func jsonMethodNotAllowed(allowedMethod string) http.HandlerFunc {
 	}
 }
 
+func plainTextMethodNotAllowed(allowedMethod string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Allow", allowedMethod)
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
 func (s *Server) adminAuthenticationMethodNotAllowed(allowedMethod string) http.HandlerFunc {
 	reject := jsonMethodNotAllowed(allowedMethod)
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/server/metrics.go
+++ b/backend/internal/server/metrics.go
@@ -530,10 +530,6 @@ func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	if r.Method != http.MethodGet {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	token := strings.TrimSpace(s.config.MetricsToken)
 	if token == "" {
 		token = strings.TrimSpace(s.config.AdminToken)
@@ -547,6 +543,17 @@ func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.metrics.Handler().ServeHTTP(w, r)
+}
+
+func (s *Server) metricsMethodNotAllowed(allowedMethod string) http.HandlerFunc {
+	reject := jsonMethodNotAllowed(allowedMethod)
+	return func(w http.ResponseWriter, r *http.Request) {
+		if s.metrics == nil {
+			http.NotFound(w, r)
+			return
+		}
+		reject(w, r)
+	}
 }
 
 // metricsTokenMatches accepts the token only from an Authorization: Bearer header.

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -9,7 +9,7 @@ func (s *Server) routes() {
 	s.registerSingleMethodRoute(http.MethodGet, "/livez", s.handleLive, jsonMethodNotAllowed(http.MethodGet))
 	s.registerSingleMethodRoute(http.MethodGet, "/readyz", s.handleHealth, jsonMethodNotAllowed(http.MethodGet))
 	s.registerSingleMethodRoute(http.MethodGet, "/healthz", s.handleHealth, jsonMethodNotAllowed(http.MethodGet))
-	s.mux.HandleFunc("/metrics", s.handleMetrics)
+	s.registerSingleMethodRoute(http.MethodGet, "/metrics", s.handleMetrics, s.metricsMethodNotAllowed(http.MethodGet))
 	s.registerModelRoutes()
 	// The in-flight gauge covers exactly the endpoints that route to an upstream, so
 	// it stays comparable with requests_total. Catalog lookups and count_tokens are
@@ -90,10 +90,10 @@ func (s *Server) routes() {
 	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/alert-deliveries", s.handleAdminAlertDeliveries, s.adminMethodNotAllowed("alert", http.MethodGet))
 	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/approvals", s.handleAdminApprovals, s.adminMethodNotAllowed("approval", http.MethodGet))
 	s.mux.HandleFunc("/api/admin/approvals/", s.handleAdminApprovalItem)
-	s.mux.HandleFunc("/api/admin/system/db-status", s.handleAdminSystemDBStatus)
-	s.mux.HandleFunc("/api/admin/system/version", s.handleAdminSystemVersion)
-	s.mux.HandleFunc("/api/admin/system/update", s.handleAdminSystemUpdate)
-	s.mux.HandleFunc("/api/admin/system/rollback", s.handleAdminSystemRollback)
-	s.mux.HandleFunc("/api/admin/system/restart", s.handleAdminSystemRestart)
-	s.mux.HandleFunc("/api/admin/system/rollback-versions", s.handleAdminRollbackVersions)
+	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/system/db-status", s.handleAdminSystemDBStatus, plainTextMethodNotAllowed(http.MethodGet))
+	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/system/version", s.handleAdminSystemVersion, jsonMethodNotAllowed(http.MethodGet))
+	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/system/update", s.handleAdminSystemUpdate, jsonMethodNotAllowed(http.MethodPost))
+	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/system/rollback", s.handleAdminSystemRollback, jsonMethodNotAllowed(http.MethodPost))
+	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/system/restart", s.handleAdminSystemRestart, jsonMethodNotAllowed(http.MethodPost))
+	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/system/rollback-versions", s.handleAdminRollbackVersions, jsonMethodNotAllowed(http.MethodGet))
 }

--- a/backend/internal/server/system_method_routing_contract_test.go
+++ b/backend/internal/server/system_method_routing_contract_test.go
@@ -1,0 +1,355 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type systemMethodRouteContract struct {
+	name          string
+	allowedMethod string
+	wrongMethod   string
+	path          string
+}
+
+func TestSystemMethodRoutesRejectWrongMethodsBeforeAuthentication(t *testing.T) {
+	app := newSystemMethodRoutingServer("system-method-routing-token")
+
+	for _, test := range systemMethodRouteContracts() {
+		for _, credential := range []struct {
+			name  string
+			token string
+		}{
+			{name: "no_token"},
+			{name: "admin", token: "system-method-routing-token"},
+		} {
+			t.Run(test.name+"/"+credential.name, func(t *testing.T) {
+				response := methodRoutingRequest(app, test.wrongMethod, test.path, credential.token)
+				assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+				assertAllowHeader(t, response, test.allowedMethod)
+			})
+		}
+	}
+}
+
+func TestSystemMethodRoutesAuthenticateAllowedMethods(t *testing.T) {
+	app := newSystemMethodRoutingServer("system-method-routing-token")
+
+	for _, test := range systemMethodRouteContracts() {
+		t.Run(test.name, func(t *testing.T) {
+			response := methodRoutingRequest(app, test.allowedMethod, test.path, "")
+			assertJSONError(t, response, http.StatusUnauthorized, "invalid_admin_token")
+			assertAllowHeader(t, response, "")
+		})
+	}
+}
+
+func TestSystemMethodRoutesPreserveRBACForAllowedMethods(t *testing.T) {
+	config := Config{AdminToken: "system-method-routing-token"}
+	store := NewMemoryStoreWithConfig(config)
+	user, err := store.CreateAdminUser(AdminUser{
+		Username: "system-method-routing-user",
+		Name:     "System Method Routing User",
+		Email:    "system-method-routing-user@tokenhub.local",
+		Role:     "user",
+		Status:   StatusActive,
+	}, "system-method-routing-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, session, err := store.CreateAdminSession(user.ID, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := NewWithConfig(store, config).Handler()
+
+	for _, test := range systemMethodRouteContracts() {
+		t.Run(test.name, func(t *testing.T) {
+			response := methodRoutingRequest(app, test.allowedMethod, test.path, session.Token)
+			assertJSONError(t, response, http.StatusForbidden, "admin_forbidden")
+			assertAllowHeader(t, response, "")
+		})
+	}
+}
+
+func TestSystemGETMethodRoutesRejectHEADBeforeAuthentication(t *testing.T) {
+	server := httptest.NewServer(newSystemMethodRoutingServer("system-method-routing-token"))
+	defer server.Close()
+
+	for _, path := range []string{
+		"/api/admin/system/version",
+		"/api/admin/system/rollback-versions",
+	} {
+		t.Run(path, func(t *testing.T) {
+			response := doSystemMethodRoutingHEAD(t, server, path, "")
+			defer response.Body.Close()
+
+			assertRealHEADResponse(t, response, http.StatusMethodNotAllowed, http.MethodGet, "application/json", true)
+		})
+	}
+}
+
+func TestDBStatusMethodRoutePreservesPlainTextRejection(t *testing.T) {
+	app := newSystemMethodRoutingServer("db-status-method-routing-token")
+
+	wrongMethod := methodRoutingRequest(app, http.MethodPost, "/api/admin/system/db-status", "")
+	if wrongMethod.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST db-status: expected 405, got %d: %s", wrongMethod.Code, wrongMethod.Body.String())
+	}
+	assertAllowHeader(t, wrongMethod, http.MethodGet)
+	if got := wrongMethod.Header().Get("content-type"); got != "text/plain; charset=utf-8" {
+		t.Fatalf("POST db-status: content type = %q, want text/plain; charset=utf-8", got)
+	}
+	if got := wrongMethod.Header().Get("x-content-type-options"); got != "nosniff" {
+		t.Fatalf("POST db-status: x-content-type-options = %q, want nosniff", got)
+	}
+	if got := wrongMethod.Body.String(); got != "Method not allowed\n" {
+		t.Fatalf("POST db-status: body = %q, want %q", got, "Method not allowed\n")
+	}
+	if requestID := wrongMethod.Header().Get("x-request-id"); requestID != "" {
+		t.Fatalf("POST db-status: x-request-id = %q, want empty", requestID)
+	}
+
+	unauthorized := methodRoutingRequest(app, http.MethodGet, "/api/admin/system/db-status", "")
+	assertJSONError(t, unauthorized, http.StatusUnauthorized, "invalid_admin_token")
+	assertAllowHeader(t, unauthorized, "")
+}
+
+func TestDBStatusMethodRouteRejectsHEADAsPlainText(t *testing.T) {
+	server := httptest.NewServer(newSystemMethodRoutingServer("db-status-method-routing-token"))
+	defer server.Close()
+
+	response := doSystemMethodRoutingHEAD(t, server, "/api/admin/system/db-status", "")
+	defer response.Body.Close()
+
+	assertRealHEADResponse(t, response, http.StatusMethodNotAllowed, http.MethodGet, "text/plain; charset=utf-8", false)
+	if got := response.Header.Get("x-content-type-options"); got != "nosniff" {
+		t.Fatalf("HEAD db-status: x-content-type-options = %q, want nosniff", got)
+	}
+}
+
+func TestDBStatusMethodRouteReachesHandler(t *testing.T) {
+	app := newSystemMethodRoutingServer("db-status-method-routing-token")
+	response := methodRoutingRequest(app, http.MethodGet, "/api/admin/system/db-status", "db-status-method-routing-token")
+	if response.Code != http.StatusOK {
+		t.Fatalf("GET db-status: expected 200, got %d: %s", response.Code, response.Body.String())
+	}
+	if got := response.Header().Get("content-type"); !strings.HasPrefix(got, "application/json") {
+		t.Fatalf("GET db-status: content type = %q, want application/json", got)
+	}
+	var payload map[string]any
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	for _, field := range []string{"database_type", "is_docker", "connection_ok"} {
+		if _, ok := payload[field]; !ok {
+			t.Fatalf("GET db-status: response is missing %q: %#v", field, payload)
+		}
+	}
+}
+
+func TestDBStatusMethodRoutePreservesRBAC(t *testing.T) {
+	config := Config{AdminToken: "db-status-method-routing-token"}
+	store := NewMemoryStoreWithConfig(config)
+	user, err := store.CreateAdminUser(AdminUser{
+		Username: "db-status-method-routing-user",
+		Name:     "DB Status Method Routing User",
+		Email:    "db-status-method-routing-user@tokenhub.local",
+		Role:     "user",
+		Status:   StatusActive,
+	}, "db-status-method-routing-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, session, err := store.CreateAdminSession(user.ID, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := NewWithConfig(store, config).Handler()
+
+	response := methodRoutingRequest(app, http.MethodGet, "/api/admin/system/db-status", session.Token)
+	assertJSONError(t, response, http.StatusForbidden, "admin_forbidden")
+	assertAllowHeader(t, response, "")
+}
+
+func TestSystemRollbackMethodRoutePreservesRequestAndAudit(t *testing.T) {
+	root := prepareNativeInstallRoot(t, "0.3.2", map[string]string{"0.3.1": "previous"})
+	releases := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unexpected release lookup", http.StatusInternalServerError)
+	}))
+	defer releases.Close()
+
+	config := Config{
+		AdminToken:     "system-rollback-routing-token",
+		AppVersion:     "0.3.2",
+		BuildType:      releaseBuildType,
+		DeploymentType: nativeDeploymentType,
+		InstallRoot:    root,
+	}
+	store := NewMemoryStoreWithConfig(config)
+	app := NewWithConfig(store, config)
+	app.versions = nativeTestVersionService(root, "0.3.2", releases)
+
+	response := methodRoutingJSONRequest(t, app.Handler(), http.MethodPost, "/api/admin/system/rollback", map[string]any{
+		"version": "0.3.1",
+	}, "system-rollback-routing-token")
+	if response.Code != http.StatusOK {
+		t.Fatalf("POST rollback: expected 200, got %d: %s", response.Code, response.Body.String())
+	}
+	var payload struct {
+		NeedRestart   bool   `json:"need_restart"`
+		TargetVersion string `json:"target_version"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if !payload.NeedRestart || payload.TargetVersion != "0.3.1" {
+		t.Fatalf("POST rollback: unexpected response: %#v", payload)
+	}
+	assertNativeCurrentVersion(t, root, "0.3.1")
+	assertSystemVersionAudit(t, store, "rollback", "success", "0.3.1")
+}
+
+func TestMetricsMethodRoutePreservesDisabledState(t *testing.T) {
+	config := Config{AdminToken: "metrics-method-routing-token", MetricsEnabled: false}
+	app := NewWithConfig(NewMemoryStoreWithConfig(config), config).Handler()
+
+	for _, method := range []string{http.MethodGet, http.MethodPost} {
+		t.Run(method, func(t *testing.T) {
+			response := methodRoutingRequest(app, method, "/metrics", "metrics-method-routing-token")
+			if response.Code != http.StatusNotFound {
+				t.Fatalf("%s disabled metrics: expected 404, got %d: %s", method, response.Code, response.Body.String())
+			}
+			assertAllowHeader(t, response, "")
+		})
+	}
+
+	server := httptest.NewServer(app)
+	defer server.Close()
+	response := doSystemMethodRoutingHEAD(t, server, "/metrics", "metrics-method-routing-token")
+	defer response.Body.Close()
+	assertRealHEADResponse(t, response, http.StatusNotFound, "", "text/plain; charset=utf-8", false)
+}
+
+func TestMetricsMethodRouteRejectsWrongMethodsBeforeTokenValidation(t *testing.T) {
+	config := Config{AdminToken: "metrics-method-routing-token", MetricsEnabled: true}
+	app := NewWithConfig(NewMemoryStoreWithConfig(config), config).Handler()
+
+	for _, token := range []string{"", "wrong-token", "metrics-method-routing-token"} {
+		response := methodRoutingRequest(app, http.MethodPost, "/metrics", token)
+		assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+		assertAllowHeader(t, response, http.MethodGet)
+	}
+
+	server := httptest.NewServer(app)
+	defer server.Close()
+	response := doSystemMethodRoutingHEAD(t, server, "/metrics", "")
+	defer response.Body.Close()
+	assertRealHEADResponse(t, response, http.StatusMethodNotAllowed, http.MethodGet, "application/json", true)
+}
+
+func TestMetricsMethodRouteHidesEnabledEndpointWithoutUsableToken(t *testing.T) {
+	config := Config{MetricsEnabled: true}
+	app := NewWithConfig(NewMemoryStoreWithConfig(config), config).Handler()
+
+	response := methodRoutingRequest(app, http.MethodGet, "/metrics", "")
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("GET metrics without configured token: expected 404, got %d: %s", response.Code, response.Body.String())
+	}
+	assertAllowHeader(t, response, "")
+}
+
+func TestMetricsMethodRouteRejectsWrongMethodWithoutUsableToken(t *testing.T) {
+	config := Config{MetricsEnabled: true}
+	app := NewWithConfig(NewMemoryStoreWithConfig(config), config).Handler()
+
+	response := methodRoutingRequest(app, http.MethodPost, "/metrics", "")
+	assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+	assertAllowHeader(t, response, http.MethodGet)
+}
+
+func TestSystemMethodRoutesPreserveCORSPreflight(t *testing.T) {
+	app := newSystemMethodRoutingServer("system-method-routing-token")
+	for _, path := range []string{
+		"/api/admin/system/version",
+		"/api/admin/system/db-status",
+		"/metrics",
+	} {
+		t.Run(path, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodOptions, path, nil)
+			request.Header.Set("origin", "https://console.example.com")
+			request.Header.Set("access-control-request-method", http.MethodGet)
+			response := httptest.NewRecorder()
+			app.ServeHTTP(response, request)
+
+			if response.Code != http.StatusNoContent {
+				t.Fatalf("OPTIONS %s: expected 204, got %d: %s", path, response.Code, response.Body.String())
+			}
+			assertAllowHeader(t, response, "")
+		})
+	}
+}
+
+func systemMethodRouteContracts() []systemMethodRouteContract {
+	return []systemMethodRouteContract{
+		{name: "version", allowedMethod: http.MethodGet, wrongMethod: http.MethodPost, path: "/api/admin/system/version"},
+		{name: "rollback_versions", allowedMethod: http.MethodGet, wrongMethod: http.MethodPost, path: "/api/admin/system/rollback-versions"},
+		{name: "update", allowedMethod: http.MethodPost, wrongMethod: http.MethodGet, path: "/api/admin/system/update"},
+		{name: "rollback", allowedMethod: http.MethodPost, wrongMethod: http.MethodGet, path: "/api/admin/system/rollback"},
+		{name: "restart", allowedMethod: http.MethodPost, wrongMethod: http.MethodGet, path: "/api/admin/system/restart"},
+	}
+}
+
+func newSystemMethodRoutingServer(adminToken string) http.Handler {
+	config := Config{AdminToken: adminToken}
+	return NewWithConfig(NewMemoryStoreWithConfig(config), config).Handler()
+}
+
+func doSystemMethodRoutingHEAD(t *testing.T, server *httptest.Server, path string, token string) *http.Response {
+	t.Helper()
+	request, err := http.NewRequest(http.MethodHead, server.URL+path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "" {
+		request.Header.Set("authorization", "Bearer "+token)
+	}
+	response, err := server.Client().Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return response
+}
+
+func assertRealHEADResponse(t *testing.T, response *http.Response, wantStatus int, wantAllow string, wantContentType string, wantRequestID bool) {
+	t.Helper()
+	if response.StatusCode != wantStatus {
+		t.Fatalf("HEAD status = %d, want %d", response.StatusCode, wantStatus)
+	}
+	allowValues, allowPresent := response.Header[http.CanonicalHeaderKey("Allow")]
+	if wantAllow == "" {
+		if allowPresent {
+			t.Fatalf("HEAD Allow is present with value %q, want absent", allowValues)
+		}
+	} else if !allowPresent || response.Header.Get("Allow") != wantAllow {
+		t.Fatalf("HEAD Allow = %q, want %q", response.Header.Get("Allow"), wantAllow)
+	}
+	if got := response.Header.Get("content-type"); !strings.HasPrefix(got, wantContentType) {
+		t.Fatalf("HEAD content type = %q, want %q", got, wantContentType)
+	}
+	if requestID := response.Header.Get("x-request-id"); wantRequestID != (requestID != "") {
+		t.Fatalf("HEAD x-request-id = %q, want presence %t", requestID, wantRequestID)
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) != 0 {
+		t.Fatalf("HEAD body = %q, want empty", body)
+	}
+}

--- a/backend/internal/server/version.go
+++ b/backend/internal/server/version.go
@@ -726,10 +726,6 @@ func parseNumericIdentifier(value string) (uint64, bool) {
 }
 
 func (s *Server) handleAdminSystemVersion(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	if _, ok := s.requireAdmin(w, r, "system", r.Method); !ok {
 		return
 	}
@@ -739,10 +735,6 @@ func (s *Server) handleAdminSystemVersion(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Server) handleAdminRollbackVersions(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	if _, ok := s.requireAdmin(w, r, "system", r.Method); !ok {
 		return
 	}

--- a/backend/internal/server/version_update.go
+++ b/backend/internal/server/version_update.go
@@ -663,10 +663,6 @@ func (s *Server) recordSystemVersionAudit(
 }
 
 func (s *Server) handleAdminSystemUpdate(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	actor, ok := s.requireAdmin(w, r, "system", r.Method)
 	if !ok {
 		return
@@ -690,10 +686,6 @@ func (s *Server) handleAdminSystemUpdate(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) handleAdminSystemRollback(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	actor, ok := s.requireAdmin(w, r, "system", r.Method)
 	if !ok {
 		return
@@ -729,10 +721,6 @@ func (s *Server) handleAdminSystemRollback(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) handleAdminSystemRestart(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	actor, ok := s.requireAdmin(w, r, "system", r.Method)
 	if !ok {
 		return


### PR DESCRIPTION
## Summary

Move method checks for the remaining system and metrics endpoints into Go's method-aware `ServeMux` registration.

These endpoints don't all share the same rejection contract. The routing keeps the existing JSON, plain-text, authentication, and metrics-state behavior instead of relying on ServeMux's default text response.

## Related Issue

Related #145 

## Changes

- Route these endpoints by method:
  - `GET /api/admin/system/version`
  - `GET /api/admin/system/rollback-versions`
  - `POST /api/admin/system/update`
  - `POST /api/admin/system/rollback`
  - `POST /api/admin/system/restart`
  - `GET /api/admin/system/db-status`
  - `GET /metrics`
- Keep wrong-method rejection ahead of authentication for the five system operation endpoints.
- Preserve the plain-text 405 contract for `/api/admin/system/db-status`.
- Preserve `/metrics` behavior when metrics are disabled or no usable token is configured.
- Cover 405, `Allow`, request IDs, authentication and RBAC order, HEAD, CORS, rollback execution, audit records, and metrics state combinations.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...`
- `go vet ./...`
- `node --test tools/*.test.mjs`
- `node tools/check-ui-translations.mjs`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- Frontend build and SDK smoke tests weren't run because this change doesn't touch the frontend or public `/v1` APIs.

## Compatibility, Security, and Operations

Wrong-method responses now include the allowed method in the `Allow` header.

The existing response formats and evaluation order remain unchanged. System routes still reject wrong methods before authentication, `db-status` still uses its plain-text error response, and disabled metrics still return 404 for every method. Authentication, RBAC, request parsing, metrics token precedence, persistence, configuration, and deployment behavior aren't changed.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.