### PR TITLE
refactor(server): route static gateway endpoints by method

### DIFF
--- a/backend/internal/server/analytics_http.go
+++ b/backend/internal/server/analytics_http.go
@@ -109,10 +109,6 @@ func (s *Server) handleAdminAnalyticsCredentialItem(w http.ResponseWriter, r *ht
 }
 
 func (s *Server) handleTokenCostAnalytics(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	credential, err := s.store.ValidateAnalyticsCredential(bearerToken(r))
 	if err != nil {
 		s.recordTokenCostAudit(r, AnalyticsCredential{}, "failed", AsHTTPError(err).Code, nil)

--- a/backend/internal/server/anthropic_messages.go
+++ b/backend/internal/server/anthropic_messages.go
@@ -22,10 +22,6 @@ type anthropicMessagesRequest struct {
 const anthropicMidConversationSystemBeta = "mid-conversation-system-2026-04-07"
 
 func (s *Server) handleAnthropicMessages(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeAnthropicError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	project, key, err := s.authenticate(r)
 	if err != nil {
 		writeAnthropicError(w, r, err)
@@ -74,10 +70,6 @@ func (s *Server) handleAnthropicMessages(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) handleAnthropicCountTokens(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeAnthropicError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	_, key, err := s.authenticate(r)
 	if err != nil {
 		writeAnthropicError(w, r, err)

--- a/backend/internal/server/gateway_http.go
+++ b/backend/internal/server/gateway_http.go
@@ -17,10 +17,6 @@ import (
 )
 
 func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	project, key, err := s.authenticate(r)
 	if err != nil {
 		writeError(w, r, err)
@@ -146,10 +142,6 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleResponses(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	project, key, err := s.authenticate(r)
 	if err != nil {
 		writeError(w, r, err)
@@ -256,10 +248,6 @@ func (s *Server) handleResponses(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleResponsesCompact(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	project, key, err := s.authenticate(r)
 	if err != nil {
 		writeError(w, r, err)
@@ -311,10 +299,6 @@ func (s *Server) handleResponsesCompact(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) handleEmbeddings(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	project, key, err := s.authenticate(r)
 	if err != nil {
 		writeError(w, r, err)

--- a/backend/internal/server/gateway_static_method_routing_contract_test.go
+++ b/backend/internal/server/gateway_static_method_routing_contract_test.go
@@ -1,0 +1,254 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type staticGatewayMethodRoute struct {
+	method    string
+	wrong     string
+	path      string
+	anthropic bool
+	inFlight  bool
+	authCode  string
+}
+
+var staticGatewayMethodRoutes = []staticGatewayMethodRoute{
+	{method: http.MethodGet, wrong: http.MethodPost, path: "/v1/models", authCode: "invalid_api_key"},
+	{method: http.MethodPost, wrong: http.MethodGet, path: "/v1/chat/completions", inFlight: true, authCode: "invalid_api_key"},
+	{method: http.MethodPost, wrong: http.MethodGet, path: "/v1/responses", inFlight: true, authCode: "invalid_api_key"},
+	{method: http.MethodPost, wrong: http.MethodGet, path: "/v1/responses/compact", inFlight: true, authCode: "invalid_api_key"},
+	{method: http.MethodPost, wrong: http.MethodGet, path: "/v1/embeddings", inFlight: true, authCode: "invalid_api_key"},
+	{method: http.MethodPost, wrong: http.MethodGet, path: "/v1/images/generations", authCode: "invalid_api_key"},
+	{method: http.MethodPost, wrong: http.MethodGet, path: "/v1/images/edits", authCode: "invalid_api_key"},
+	{method: http.MethodGet, wrong: http.MethodPost, path: "/api/v1/analytics/token-costs", authCode: "invalid_analytics_credential"},
+	{method: http.MethodPost, wrong: http.MethodGet, path: "/v1/messages", anthropic: true, inFlight: true, authCode: "invalid_api_key"},
+	{method: http.MethodPost, wrong: http.MethodGet, path: "/v1/messages/count_tokens", anthropic: true, authCode: "invalid_api_key"},
+}
+
+func TestStaticGatewayMethodRoutesRejectWrongMethods(t *testing.T) {
+	store := NewMemoryStore()
+	if err := SeedDemoData(store); err != nil {
+		t.Fatal(err)
+	}
+	app := New(store).Handler()
+	requestLogsBefore := len(store.ListRequestLogs())
+	auditEventsBefore := len(store.ListAuditEvents())
+	imageJobsBefore := len(store.ListImageJobs(1000))
+
+	for _, route := range staticGatewayMethodRoutes {
+		t.Run(route.wrong+" "+route.path, func(t *testing.T) {
+			response := methodRoutingRequest(app, route.wrong, route.path, "")
+			if route.anthropic {
+				assertAnthropicMethodError(t, response)
+			} else {
+				assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+			}
+			assertAllowHeader(t, response, route.method)
+		})
+	}
+
+	if got := len(store.ListRequestLogs()); got != requestLogsBefore {
+		t.Fatalf("wrong methods created request logs: got %d, want %d", got, requestLogsBefore)
+	}
+	if got := len(store.ListAuditEvents()); got != auditEventsBefore {
+		t.Fatalf("wrong methods created audit events: got %d, want %d", got, auditEventsBefore)
+	}
+	if got := len(store.ListImageJobs(1000)); got != imageJobsBefore {
+		t.Fatalf("wrong methods created image jobs: got %d, want %d", got, imageJobsBefore)
+	}
+}
+
+func TestStaticGatewayMethodRoutesReachAuthentication(t *testing.T) {
+	app := newTestServer()
+	for _, route := range staticGatewayMethodRoutes {
+		t.Run(route.method+" "+route.path, func(t *testing.T) {
+			response := methodRoutingRequest(app, route.method, route.path, "")
+			assertAllowHeader(t, response, "")
+			if route.anthropic {
+				assertAnthropicError(t, response, http.StatusUnauthorized, "authentication_error", route.authCode, "Invalid API key")
+			} else {
+				assertJSONError(t, response, http.StatusUnauthorized, route.authCode)
+			}
+		})
+	}
+}
+
+func TestStaticGatewayGETRoutesRejectRealHEAD(t *testing.T) {
+	server := httptest.NewServer(newTestServer())
+	t.Cleanup(server.Close)
+
+	for _, path := range []string{"/v1/models", "/api/v1/analytics/token-costs"} {
+		t.Run(path, func(t *testing.T) {
+			request, err := http.NewRequest(http.MethodHead, server.URL+path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			response, err := server.Client().Do(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer response.Body.Close()
+
+			if response.StatusCode != http.StatusMethodNotAllowed {
+				t.Fatalf("expected 405, got %d", response.StatusCode)
+			}
+			if got := response.Header.Get("Allow"); got != http.MethodGet {
+				t.Fatalf("Allow = %q, want %q", got, http.MethodGet)
+			}
+			if contentType := response.Header.Get("content-type"); !strings.HasPrefix(contentType, "application/json") {
+				t.Fatalf("content type = %q, want application/json", contentType)
+			}
+			if response.Header.Get("x-request-id") == "" {
+				t.Fatal("x-request-id is empty")
+			}
+			body, err := io.ReadAll(response.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(body) != 0 {
+				t.Fatalf("HEAD response body = %q, want empty", body)
+			}
+		})
+	}
+}
+
+func TestStaticGatewayMethodRoutesPreserveCORSPreflight(t *testing.T) {
+	app := newTestServer()
+	for _, route := range staticGatewayMethodRoutes {
+		t.Run(route.path, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodOptions, route.path, nil)
+			request.Header.Set("origin", "https://console.example.com")
+			request.Header.Set("access-control-request-method", route.method)
+			response := httptest.NewRecorder()
+
+			app.ServeHTTP(response, request)
+
+			if response.Code != http.StatusNoContent {
+				t.Fatalf("expected 204, got %d: %s", response.Code, response.Body.String())
+			}
+			if got := response.Header().Get("access-control-allow-methods"); got != "GET,POST,PUT,PATCH,DELETE,OPTIONS" {
+				t.Fatalf("access-control-allow-methods = %q", got)
+			}
+			assertAllowHeader(t, response, "")
+		})
+	}
+}
+
+func TestStaticGatewayMethodRoutesPreserveMetricsScope(t *testing.T) {
+	store := NewMemoryStore()
+	if err := SeedDemoData(store); err != nil {
+		t.Fatal(err)
+	}
+	server := NewWithConfig(store, Config{AdminToken: "dev_admin_token", MetricsEnabled: true})
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+	spy := &incrementCountingGauge{Gauge: server.metrics.inFlight}
+	server.metrics.inFlight = spy
+
+	for _, route := range staticGatewayMethodRoutes {
+		if !route.inFlight {
+			continue
+		}
+		t.Run(route.path, func(t *testing.T) {
+			inFlightBefore := spy.increments.Load()
+			requestSeriesBefore, requestCountBefore := gatewayRequestMetricSnapshot(t, server.metrics)
+			response := methodRoutingRequest(server.Handler(), route.wrong, route.path, "")
+			if route.anthropic {
+				assertAnthropicMethodError(t, response)
+			} else {
+				assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+			}
+			assertAllowHeader(t, response, route.method)
+			if got := spy.increments.Load(); got != inFlightBefore {
+				t.Fatalf("wrong method entered in-flight middleware: increments = %d, want %d", got, inFlightBefore)
+			}
+			requestSeriesAfter, requestCountAfter := gatewayRequestMetricSnapshot(t, server.metrics)
+			if requestSeriesAfter != requestSeriesBefore || requestCountAfter != requestCountBefore {
+				t.Fatalf(
+					"wrong method changed gateway request metrics: series %d -> %d, count %v -> %v",
+					requestSeriesBefore, requestSeriesAfter, requestCountBefore, requestCountAfter,
+				)
+			}
+
+			response = methodRoutingRequest(server.Handler(), route.method, route.path, "")
+			assertAllowHeader(t, response, "")
+			if route.anthropic {
+				assertAnthropicError(t, response, http.StatusUnauthorized, "authentication_error", route.authCode, "Invalid API key")
+			} else {
+				assertJSONError(t, response, http.StatusUnauthorized, route.authCode)
+			}
+			if got := spy.increments.Load(); got != inFlightBefore+1 {
+				t.Fatalf("allowed method in-flight increments = %d, want %d", got, inFlightBefore+1)
+			}
+		})
+	}
+}
+
+func gatewayRequestMetricSnapshot(t *testing.T, metrics *GatewayMetrics) (int, float64) {
+	t.Helper()
+	families, err := metrics.registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, family := range families {
+		if family.GetName() != "tokenhub_gateway_requests_total" {
+			continue
+		}
+		var total float64
+		for _, metric := range family.GetMetric() {
+			total += metric.GetCounter().GetValue()
+		}
+		return len(family.GetMetric()), total
+	}
+	return 0, 0
+}
+
+type incrementCountingGauge struct {
+	prometheus.Gauge
+	increments atomic.Int64
+}
+
+func (g *incrementCountingGauge) Inc() {
+	g.increments.Add(1)
+	g.Gauge.Inc()
+}
+
+func assertAnthropicMethodError(t *testing.T, response *httptest.ResponseRecorder) {
+	t.Helper()
+	assertAnthropicError(t, response, http.StatusMethodNotAllowed, "invalid_request_error", "method_not_allowed", "Method not allowed")
+}
+
+func assertAnthropicError(t *testing.T, response *httptest.ResponseRecorder, wantStatus int, wantType string, wantCode string, wantMessage string) {
+	t.Helper()
+	if response.Code != wantStatus {
+		t.Fatalf("expected %d, got %d: %s", wantStatus, response.Code, response.Body.String())
+	}
+	if contentType := response.Header().Get("content-type"); !strings.HasPrefix(contentType, "application/json") {
+		t.Fatalf("content type = %q, want application/json", contentType)
+	}
+	var payload struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+		RequestID string `json:"request_id"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode Anthropic error: %v", err)
+	}
+	if payload.Type != "error" || payload.Error.Type != wantType || payload.Error.Code != wantCode || payload.Error.Message != wantMessage {
+		t.Fatalf("unexpected Anthropic error: %#v", payload)
+	}
+	assertRequestID(t, response, payload.RequestID)
+}

--- a/backend/internal/server/gemini_native_http.go
+++ b/backend/internal/server/gemini_native_http.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *Server) registerModelRoutes() {
-	s.mux.HandleFunc("/v1/models", s.handleModels)
+	s.registerSingleMethodRoute(http.MethodGet, "/v1/models", s.handleModels, jsonMethodNotAllowed(http.MethodGet))
 	s.mux.HandleFunc("/v1/models/", s.handleModel)
 	s.mux.HandleFunc("/v1beta/models", s.handleGeminiModels)
 	s.mux.HandleFunc("/v1beta/models/", s.handleGeminiModel)

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -208,10 +208,6 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	_, key, err := s.authenticate(r)
 	if err != nil {
 		writeError(w, r, err)

--- a/backend/internal/server/image_generation.go
+++ b/backend/internal/server/image_generation.go
@@ -66,10 +66,6 @@ func defaultImageStorageDir() string {
 }
 
 func (s *Server) handleImageGenerations(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	project, key, err := s.authenticate(r)
 	if err != nil {
 		writeError(w, r, err)
@@ -151,10 +147,6 @@ func (s *Server) handleImageGenerations(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) handleImageEdits(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
-		return
-	}
 	project, key, err := s.authenticate(r)
 	if err != nil {
 		writeError(w, r, err)

--- a/backend/internal/server/method_routes.go
+++ b/backend/internal/server/method_routes.go
@@ -19,6 +19,13 @@ func jsonMethodNotAllowed(allowedMethod string) http.HandlerFunc {
 	}
 }
 
+func anthropicMethodNotAllowed(allowedMethod string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Allow", allowedMethod)
+		writeAnthropicError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+	}
+}
+
 func plainTextMethodNotAllowed(allowedMethod string) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Allow", allowedMethod)

--- a/backend/internal/server/method_routing_contract_test.go
+++ b/backend/internal/server/method_routing_contract_test.go
@@ -25,8 +25,8 @@ func TestMethodRoutingContracts(t *testing.T) {
 		wantCode  string
 		wantAllow string
 	}{
-		{name: "gateway wrong method", method: http.MethodGet, path: "/v1/chat/completions", wantCode: "method_not_allowed", wantAllow: ""},
-		{name: "models rejects head", method: http.MethodHead, path: "/v1/models", wantCode: "method_not_allowed", wantAllow: ""},
+		{name: "gateway wrong method", method: http.MethodGet, path: "/v1/chat/completions", wantCode: "method_not_allowed", wantAllow: http.MethodPost},
+		{name: "models rejects head", method: http.MethodHead, path: "/v1/models", wantCode: "method_not_allowed", wantAllow: http.MethodGet},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -222,7 +222,7 @@ func TestMethodRoutingPreservesAnthropicErrorShape(t *testing.T) {
 		t.Fatalf("unexpected Anthropic method error: %#v", payload)
 	}
 	assertRequestID(t, response, payload.RequestID)
-	assertAllowHeader(t, response, "")
+	assertAllowHeader(t, response, http.MethodPost)
 }
 
 func TestMethodRoutingPreservesCORSPreflight(t *testing.T) {
@@ -332,6 +332,9 @@ func assertJSONError(t *testing.T, response *httptest.ResponseRecorder, wantStat
 	}
 	if payload.Error.Message == "" {
 		t.Fatal("error message is empty")
+	}
+	if wantCode == "method_not_allowed" && payload.Error.Message != "Method not allowed" {
+		t.Fatalf("error message = %q, want %q", payload.Error.Message, "Method not allowed")
 	}
 	assertRequestID(t, response, payload.RequestID)
 }

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -15,18 +15,18 @@ func (s *Server) routes() {
 	// it stays comparable with requests_total. Catalog lookups and count_tokens are
 	// local and never produce a request count, and admin traffic and scrapes are not
 	// gateway load at all.
-	s.mux.HandleFunc("/v1/chat/completions", s.gatewayInFlight(s.handleChatCompletions))
-	s.mux.HandleFunc("/v1/messages", s.gatewayInFlight(s.handleAnthropicMessages))
-	s.mux.HandleFunc("/v1/messages/count_tokens", s.handleAnthropicCountTokens)
-	s.mux.HandleFunc("/v1/responses", s.gatewayInFlight(s.handleResponses))
+	s.registerSingleMethodRoute(http.MethodPost, "/v1/chat/completions", s.gatewayInFlight(s.handleChatCompletions), jsonMethodNotAllowed(http.MethodPost))
+	s.registerSingleMethodRoute(http.MethodPost, "/v1/messages", s.gatewayInFlight(s.handleAnthropicMessages), anthropicMethodNotAllowed(http.MethodPost))
+	s.registerSingleMethodRoute(http.MethodPost, "/v1/messages/count_tokens", s.handleAnthropicCountTokens, anthropicMethodNotAllowed(http.MethodPost))
+	s.registerSingleMethodRoute(http.MethodPost, "/v1/responses", s.gatewayInFlight(s.handleResponses), jsonMethodNotAllowed(http.MethodPost))
 	s.mux.HandleFunc("/v1/responses/", s.handleResponseJob)
-	s.mux.HandleFunc("/v1/responses/compact", s.gatewayInFlight(s.handleResponsesCompact))
-	s.mux.HandleFunc("/v1/embeddings", s.gatewayInFlight(s.handleEmbeddings))
-	s.mux.HandleFunc("/v1/images/generations", s.handleImageGenerations)
-	s.mux.HandleFunc("/v1/images/edits", s.handleImageEdits)
+	s.registerSingleMethodRoute(http.MethodPost, "/v1/responses/compact", s.gatewayInFlight(s.handleResponsesCompact), jsonMethodNotAllowed(http.MethodPost))
+	s.registerSingleMethodRoute(http.MethodPost, "/v1/embeddings", s.gatewayInFlight(s.handleEmbeddings), jsonMethodNotAllowed(http.MethodPost))
+	s.registerSingleMethodRoute(http.MethodPost, "/v1/images/generations", s.handleImageGenerations, jsonMethodNotAllowed(http.MethodPost))
+	s.registerSingleMethodRoute(http.MethodPost, "/v1/images/edits", s.handleImageEdits, jsonMethodNotAllowed(http.MethodPost))
 	s.mux.HandleFunc("/v1/image-jobs/", s.handleImageJob)
 	s.mux.HandleFunc("/v1/image-assets/", s.handleImageAsset)
-	s.mux.HandleFunc("/api/v1/analytics/token-costs", s.handleTokenCostAnalytics)
+	s.registerSingleMethodRoute(http.MethodGet, "/api/v1/analytics/token-costs", s.handleTokenCostAnalytics, jsonMethodNotAllowed(http.MethodGet))
 
 	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/auth/login", s.handleAdminLogin, jsonMethodNotAllowed(http.MethodPost))
 	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/auth/logout", s.handleAdminLogout, jsonMethodNotAllowed(http.MethodPost))


### PR DESCRIPTION
## Summary

Move method checks for the static public gateway endpoints from individual handlers into Go's method-aware `ServeMux` patterns.

Wrong methods still use TokenHub's existing JSON error contract, while Anthropic endpoints keep the Anthropic error shape. These responses now include the appropriate `Allow` header.

## Related Issue

Related #145 

## Changes

The following endpoints now declare their method when the route is registered:

  - `GET /v1/models`
  - `POST /v1/chat/completions`
  - `POST /v1/responses`
  - `POST /v1/responses/compact`
  - `POST /v1/embeddings`
  - `POST /v1/images/generations`
  - `POST /v1/images/edits`
  - `GET /api/v1/analytics/token-costs`
  - `POST /v1/messages`
  - `POST /v1/messages/count_tokens`

Regression coverage checks the 405 body and headers, request IDs, authentication order, HEAD behavior, CORS preflight, side effects, and gateway metrics.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...`
- `go vet ./...`
- `node --test tools/*.test.mjs`
- `node tools/check-ui-translations.mjs`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- SDK smoke tests weren't run because they require a configured compatible backend and provider credentials

## Compatibility, Security, and Operations

Wrong-method responses keep their existing status, JSON schema, message, request ID, authentication order, and CORS behavior. The intended API change is the addition of the correct `Allow` header.

Explicit HEAD fallbacks preserve the previous 405 behavior for GET endpoints. Wrong methods no longer enter the gateway in-flight metric or create request logs, audit events, image jobs, or gateway request metrics.

No data, configuration, deployment, or credential changes are included.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.