### PR TITLE
perf(usage): eliminate N+1 queries in usage breakdown

### DIFF
--- a/backend/internal/server/admin_authorization.go
+++ b/backend/internal/server/admin_authorization.go
@@ -277,12 +277,22 @@ func (s *Server) usageSummaryForUser(user AdminUser) map[string]any {
 
 func (s *Server) usageBreakdownForUser(user AdminUser) map[string]any {
 	records := s.filterUsageRecordsForUser(user, s.store.ListUsageRecords())
-	breakdown := s.usageBreakdownFromRecords(records)
-	breakdown["members"] = s.aggregateUsageByMember(user, records)
+	projectsByID := indexProjectsByID(s.store.ListProjects())
+	breakdown := s.usageBreakdownFromRecords(records, projectsByID)
+	breakdown["members"] = s.aggregateUsageByMember(user, records, projectsByID)
 	return breakdown
 }
 
-func (s *Server) usageBreakdownFromRecords(records []UsageRecord) map[string]any {
+func indexProjectsByID(projects []Project) map[string]Project {
+	projectsByID := make(map[string]Project, len(projects))
+	for _, project := range projects {
+		projectsByID[project.ID] = project
+	}
+	return projectsByID
+}
+
+func (s *Server) usageBreakdownFromRecords(records []UsageRecord, projectsByID map[string]Project) map[string]any {
+	costCentersByProjectID := s.usageCostCentersByProjectID(records, projectsByID)
 	return map[string]any{
 		"projects":  aggregateUsage(records, func(record UsageRecord) string { return record.ProjectID }),
 		"models":    aggregateUsage(records, func(record UsageRecord) string { return record.ModelName }),
@@ -291,23 +301,15 @@ func (s *Server) usageBreakdownFromRecords(records []UsageRecord) map[string]any
 			return record.ProviderResourceID
 		}),
 		"cost_centers": aggregateUsage(records, func(record UsageRecord) string {
-			project, ok := s.store.GetProject(record.ProjectID)
-			if !ok {
-				return "unknown"
-			}
-			return s.costCenterForProject(project)
+			return costCentersByProjectID[record.ProjectID]
 		}),
 	}
 }
 
-func (s *Server) aggregateUsageByMember(user AdminUser, records []UsageRecord) []map[string]any {
+func (s *Server) aggregateUsageByMember(user AdminUser, records []UsageRecord, projectsByID map[string]Project) []map[string]any {
 	keysByID := map[string]APIKey{}
 	for _, key := range s.store.ListAPIKeys() {
 		keysByID[key.ID] = key
-	}
-	projectsByID := map[string]Project{}
-	for _, project := range s.store.ListProjects() {
-		projectsByID[project.ID] = project
 	}
 	usersByID := map[string]AdminUser{}
 	for _, item := range s.store.ListAdminUsers() {
@@ -535,25 +537,61 @@ func (s *Server) visibleAPIKeyIDSet(user AdminUser) map[string]bool {
 	return out
 }
 
-func (s *Server) costCenterForProject(project Project) string {
+func (s *Server) usageCostCentersByProjectID(records []UsageRecord, projectsByID map[string]Project) map[string]string {
+	projectsWithUsage := map[string]Project{}
+	needsTeams := false
+	needsQuotas := false
+	for _, record := range records {
+		if _, seen := projectsWithUsage[record.ProjectID]; seen {
+			continue
+		}
+		project, ok := projectsByID[record.ProjectID]
+		if !ok {
+			continue
+		}
+		projectsWithUsage[record.ProjectID] = project
+		if strings.TrimSpace(project.CostCenter) == "" {
+			needsTeams = needsTeams || strings.TrimSpace(project.TeamID) != ""
+			needsQuotas = needsQuotas || strings.TrimSpace(project.DefaultQuotaRef) != ""
+		}
+	}
+	if len(projectsWithUsage) == 0 {
+		return map[string]string{}
+	}
+	teamsByID := map[string]AdminResource{}
+	if needsTeams {
+		for _, team := range s.store.ListResources("teams") {
+			teamsByID[team.ID] = team
+		}
+	}
+	quotasByID := map[string]AdminResource{}
+	if needsQuotas {
+		for _, quota := range s.store.ListResources("quota-policies") {
+			quotasByID[quota.ID] = quota
+		}
+	}
+	costCenters := make(map[string]string, len(projectsWithUsage))
+	for projectID, project := range projectsWithUsage {
+		costCenters[projectID] = costCenterForProject(project, teamsByID, quotasByID)
+	}
+	return costCenters
+}
+
+func costCenterForProject(project Project, teamsByID, quotasByID map[string]AdminResource) string {
 	if costCenter := strings.TrimSpace(project.CostCenter); costCenter != "" {
 		return costCenter
 	}
 	if strings.TrimSpace(project.TeamID) != "" {
-		for _, team := range s.store.ListResources("teams") {
-			if team.ID == project.TeamID {
-				if costCenter := strings.TrimSpace(stringField(team.Fields, "cost_center")); costCenter != "" {
-					return costCenter
-				}
+		if team, ok := teamsByID[project.TeamID]; ok {
+			if costCenter := strings.TrimSpace(stringField(team.Fields, "cost_center")); costCenter != "" {
+				return costCenter
 			}
 		}
 	}
 	if strings.TrimSpace(project.DefaultQuotaRef) != "" {
-		for _, quota := range s.store.ListResources("quota-policies") {
-			if quota.ID == project.DefaultQuotaRef {
-				if costCenter := strings.TrimSpace(stringField(quota.Fields, "cost_center")); costCenter != "" {
-					return costCenter
-				}
+		if quota, ok := quotasByID[project.DefaultQuotaRef]; ok {
+			if costCenter := strings.TrimSpace(stringField(quota.Fields, "cost_center")); costCenter != "" {
+				return costCenter
 			}
 		}
 	}

--- a/backend/internal/server/admin_operations_http.go
+++ b/backend/internal/server/admin_operations_http.go
@@ -772,7 +772,11 @@ func (s *Server) handleAdminExport(w http.ResponseWriter, r *http.Request) {
 			}
 			records = filtered
 		}
-		breakdown := s.usageBreakdownFromRecords(records)
+		projectsByID := map[string]Project{}
+		if len(records) > 0 {
+			projectsByID = indexProjectsByID(s.store.ListProjects())
+		}
+		breakdown := s.usageBreakdownFromRecords(records, projectsByID)
 		for _, dimension := range []string{"projects", "models", "providers", "provider_resources", "cost_centers"} {
 			rows, _ := breakdown[dimension].([]map[string]any)
 			for _, row := range rows {

--- a/backend/internal/server/store_test.go
+++ b/backend/internal/server/store_test.go
@@ -165,7 +165,7 @@ func TestFinishCallPersistsCachedInputTokensInUsageAggregates(t *testing.T) {
 		t.Fatalf("summary cached input tokens = %#v, want 400", got)
 	}
 
-	breakdown := New(store).usageBreakdownFromRecords(store.ListUsageRecords())
+	breakdown := New(store).usageBreakdownFromRecords(store.ListUsageRecords(), indexProjectsByID(store.ListProjects()))
 	models, ok := breakdown["models"].([]map[string]any)
 	if !ok || len(models) != 1 {
 		t.Fatalf("model breakdown = %#v, want one row", breakdown["models"])

--- a/backend/internal/server/usage_breakdown_test.go
+++ b/backend/internal/server/usage_breakdown_test.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestUsageBreakdownQueryCountDoesNotGrowWithRecords(t *testing.T) {
+	store := NewMemoryStore()
+	project := store.CreateProject(Project{
+		ID:         "prj_breakdown_query_count",
+		Name:       "Breakdown query count",
+		CostCenter: "CC-BREAKDOWN",
+		Status:     StatusActive,
+	})
+	server := New(store)
+	admin := AdminUser{ID: "usr_breakdown_admin", Role: "admin", Status: StatusActive}
+
+	insertUsageRecords := func(start, count int) {
+		t.Helper()
+		records := make([]UsageRecord, count)
+		for index := range records {
+			number := start + index
+			records[index] = UsageRecord{
+				ID:        fmt.Sprintf("use_breakdown_%d", number),
+				RequestID: fmt.Sprintf("req_breakdown_%d", number),
+				ProjectID: project.ID,
+				CostUSD:   1,
+				CreatedAt: time.Now().UTC(),
+			}
+		}
+		if err := store.db.Create(&records).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	insertUsageRecords(0, 1)
+	server.usageBreakdownForUser(admin)
+	smallQueries := countStoreQueries(t, store, func() {
+		server.usageBreakdownForUser(admin)
+	})
+	insertUsageRecords(1, 99)
+	var breakdown map[string]any
+	largeQueries := countStoreQueries(t, store, func() {
+		breakdown = server.usageBreakdownForUser(admin)
+	})
+
+	if largeQueries > smallQueries {
+		t.Fatalf("usage breakdown query count grew with records: small=%d large=%d", smallQueries, largeQueries)
+	}
+	costCenters, ok := breakdown["cost_centers"].([]map[string]any)
+	if !ok || len(costCenters) != 1 {
+		t.Fatalf("cost center breakdown = %#v, want one row", breakdown["cost_centers"])
+	}
+	if got := costCenters[0]["id"]; got != "CC-BREAKDOWN" {
+		t.Fatalf("cost center = %#v, want CC-BREAKDOWN", got)
+	}
+	if got := costCenters[0]["request_count"]; got != int64(100) {
+		t.Fatalf("cost center request count = %#v, want 100", got)
+	}
+}
+
+func TestUsageBreakdownUsesUnknownForMissingProject(t *testing.T) {
+	server := New(NewMemoryStore())
+	breakdown := server.usageBreakdownFromRecords([]UsageRecord{{ProjectID: "prj_missing"}}, nil)
+	costCenters, ok := breakdown["cost_centers"].([]map[string]any)
+	if !ok || len(costCenters) != 1 || costCenters[0]["id"] != "unknown" {
+		t.Fatalf("cost center breakdown = %#v, want one unknown row", breakdown["cost_centers"])
+	}
+}
+
+func TestCostCenterForProjectPreservesFallbackOrder(t *testing.T) {
+	teamsByID := map[string]AdminResource{
+		"team_cost_center": {ID: "team_cost_center", Fields: map[string]any{"cost_center": "CC-TEAM"}},
+		"team_fallback":    {ID: "team_fallback"},
+	}
+	quotasByID := map[string]AdminResource{
+		"quota_cost_center": {ID: "quota_cost_center", Fields: map[string]any{"cost_center": "CC-QUOTA"}},
+	}
+	tests := []struct {
+		name    string
+		project Project
+		want    string
+	}{
+		{
+			name:    "project overrides team and quota",
+			project: Project{ID: "prj_direct", TeamID: "team_cost_center", DefaultQuotaRef: "quota_cost_center", CostCenter: "CC-PROJECT"},
+			want:    "CC-PROJECT",
+		},
+		{
+			name:    "team overrides quota",
+			project: Project{ID: "prj_team", TeamID: "team_cost_center", DefaultQuotaRef: "quota_cost_center"},
+			want:    "CC-TEAM",
+		},
+		{
+			name:    "quota follows team without cost center",
+			project: Project{ID: "prj_quota", TeamID: "team_fallback", DefaultQuotaRef: "quota_cost_center"},
+			want:    "CC-QUOTA",
+		},
+		{
+			name:    "team id fallback",
+			project: Project{ID: "prj_team_fallback", TeamID: "team_fallback"},
+			want:    "team_fallback",
+		},
+		{
+			name:    "project id fallback",
+			project: Project{ID: "prj_fallback"},
+			want:    "project:prj_fallback",
+		},
+		{
+			name: "unknown fallback",
+			want: "unknown",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := costCenterForProject(test.project, teamsByID, quotasByID); got != test.want {
+				t.Fatalf("cost center = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The usage breakdown endpoint previously loaded a project and its team associations for every usage record while aggregating cost centers. Repeated records for the same project therefore produced a large number of redundant database queries and significantly increased Overview loading time, especially with a remote PostgreSQL database.

This change preloads projects and related lookup data in batches, then reuses in-memory maps throughout the aggregation.

Before:

<img width="668" height="110" alt="97e1cc5a03be0a471f157b97bd62b22c" src="https://github.com/user-attachments/assets/49e0acfe-e7a4-4c73-98e3-76e1b9c34626" />

After:

<img width="535" height="96" alt="de0d583623589d17500b5d74457d5da2" src="https://github.com/user-attachments/assets/a789bf5f-e74b-4f52-9eca-4b33803c87ce" />


## Related Issue

N/A

## Changes

- Batch-load projects and project-team relationships before calculating usage breakdowns.
- Reuse the same project index for cost-center and member aggregation.
- Load team and quota-policy resources only when they are required for cost-center fallback resolution.
- Apply the same batched lookup path to usage CSV exports.
- Preserve the existing cost-center fallback order and missing-project behavior.
- Add regression coverage ensuring query counts do not grow with the number of usage records.
- Add tests for missing projects and cost-center fallback precedence.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go vet ./...` — passed on the extracted PR branch.
- `go test ./...` — passed for the same commit before branch extraction; the repeated run on the extracted branch was not awaited to completion at the user's request.
- Focused usage-breakdown regression tests passed for 20 consecutive runs.
- Repository Node test suite passed: 122 tests.
- Documentation translation, UI translation, environment contract, source-line, and `git diff --check` gates passed.

## Compatibility, Security, and Operations

None.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
