### PR TITLE
chore(github): require English agent contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,105 @@
+name: Bug report
+description: Report reproducible behavior that differs from expected TokenHub behavior.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Write the issue title and all explanatory text in English. Machine-generated output and code may remain in their original form.
+
+        Search existing issues before submitting a new report. Never include API keys, provider credentials, tokens, cookies, or other secrets.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Select the area most closely related to the problem.
+      options:
+        - OpenAI-compatible API
+        - Anthropic Messages API
+        - Authentication and API keys
+        - Provider and model routing
+        - Admin console
+        - Persistence and migrations
+        - Deployment and configuration
+        - SDK smoke tests
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: TokenHub version
+      description: Provide the release, container image tag, or commit SHA.
+      placeholder: v1.2.3 or 0123456789abcdef
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment method
+      options:
+        - Source checkout using ./start.sh
+        - Docker Compose with SQLite
+        - Docker Compose with PostgreSQL
+        - Custom container or orchestrator
+        - Not deployment-related
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current behavior
+      description: Describe what happened, including relevant error messages or symptoms.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Describe what should have happened instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest reliable sequence that reproduces the problem.
+      placeholder: |
+        1. Configure ...
+        2. Send ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or configuration
+      description: Paste only the minimum redacted output needed to investigate the problem.
+      render: shell
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add links, screenshots, or other information that may help with investigation.
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Submission checklist
+      options:
+        - label: I searched open and closed issues for duplicates.
+          required: true
+        - label: The issue title and all explanatory text are written in English.
+          required: true
+        - label: I removed or redacted all credentials and other secrets.
+          required: true

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -1,0 +1,67 @@
+name: Feature request
+description: Propose an improvement that solves a concrete TokenHub use case.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Write the issue title and all explanatory text in English. Search existing issues before submitting a new request.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Select the area most closely related to the request.
+      options:
+        - OpenAI-compatible API
+        - Anthropic Messages API
+        - Authentication and API keys
+        - Provider and model routing
+        - Admin console
+        - Persistence and migrations
+        - Deployment and configuration
+        - SDKs and integrations
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: Describe the limitation or user need without assuming a particular solution.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior or interface that would address the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe existing workarounds or other approaches that were considered.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add examples, related issues, diagrams, or compatibility considerations.
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Submission checklist
+      options:
+        - label: I searched open and closed issues for related requests.
+          required: true
+        - label: The issue title and all explanatory text are written in English.
+          required: true
+        - label: I removed or redacted all credentials and other secrets.
+          required: true

--- a/.github/ISSUE_TEMPLATE/03-question.yml
+++ b/.github/ISSUE_TEMPLATE/03-question.yml
@@ -1,0 +1,61 @@
+name: Question or support request
+description: Ask about configuring, integrating, or operating TokenHub.
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Write the issue title and all explanatory text in English. Check the documentation and existing issues before submitting a question.
+
+        Never include API keys, provider credentials, tokens, cookies, or other secrets.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Related area
+      options:
+        - API integration
+        - Authentication and API keys
+        - Provider and model configuration
+        - Admin console
+        - Deployment and operations
+        - Data and migrations
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: State the question and the intended outcome clearly.
+    validations:
+      required: true
+
+  - type: textarea
+    id: attempted
+    attributes:
+      label: What have you tried?
+      description: List the documentation, configuration, commands, or approaches already checked.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Relevant environment or configuration
+      description: Provide only the minimum redacted details needed to understand the question.
+      render: shell
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Submission checklist
+      options:
+        - label: I checked the documentation and searched existing issues.
+          required: true
+        - label: The issue title and all explanatory text are written in English.
+          required: true
+        - label: I removed or redacted all credentials and other secrets.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+# Keep blank issues available to human contributors. Agents must use the closest
+# matching form under the repository instructions in AGENTS.md.
+blank_issues_enabled: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
-> PR title format: `<type>[optional scope][!]: <short summary>` in English, max 72 characters.
+> Write the PR title and every body section in English.
+> PR title format: `<type>[optional scope][!]: <short summary>`, max 72 characters.
 > Common types include `feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `style`, and `revert`. Use a lowercase imperative summary without a trailing period.
 
 ## Summary
@@ -37,6 +38,7 @@ None.
 
 ## Checklist
 
+- [ ] The PR title and body are written in English.
 - [ ] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
 - [ ] No credentials, local `.env` files, databases, backups, or runtime logs are included.
 - [ ] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,9 +79,22 @@ Use a workflow only when the user explicitly names it; otherwise follow the norm
 - Next.js may rewrite `frontend/next-env.d.ts` during development or production builds. Do not commit incidental mode-dependent changes to that generated file.
 - Keep `data/model-catalog.yaml` tracked; other files under runtime data directories are intentionally ignored.
 
+## GitHub contribution language
+
+- Agents must write every GitHub issue and pull request title and body in English, regardless of whether they use the GitHub website, an API, a connector, or `gh`.
+- Keep unavoidable machine-generated output, logs, identifiers, and code in their original form, but explain them in English.
+
+## GitHub issue guidelines
+
+- Search open and closed issues before creating a new issue.
+- Read and follow the closest matching form under `.github/ISSUE_TEMPLATE/`, including every required field. Do not create a blank issue when an existing form applies.
+- When a CLI or API cannot submit an Issue Form directly, preserve the form's headings and required information in the issue body.
+- Never include API keys, provider credentials, tokens, cookies, unredacted environment files, or other secrets in an issue.
+
 ## Pull request guidelines
 
 - Use an English Conventional Commits-style PR title in the format `<type>[optional scope][!]: <short summary>`, limited to 72 characters. Common types include `feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `style`, and `revert`. Use a lowercase imperative summary without a trailing period.
+- Write every pull request body section in English.
 - Before creating a pull request, read and complete `.github/pull_request_template.md`.
 - Preserve every template section, replace all placeholders, and explain any skipped or non-applicable checks.
 - Do not use `gh pr create --fill` or an ad hoc body that bypasses the template; use the completed template as the final pull request body.

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -101,6 +101,7 @@ Agent 固有のリポジトリ指示については、[AGENTS.md](AGENTS.md#opti
 
 ## Pull Request
 
+- タイトルと本文のすべてのセクションを英語で記述します。
 - 英語の Conventional Commits 形式のタイトル `<type>[optional scope][!]: <short summary>` を使用します。
 - タイトルは 72 文字以内とし、要約は小文字の命令形で記述し、末尾にピリオドを付けません。
 - [Pull Request テンプレート](.github/pull_request_template.md)のすべてのセクションを記入し、スキップしたチェックや該当しないチェックについて説明します。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,7 @@ See [AGENTS.md](AGENTS.md#optional-development-workflows) for agent-specific rep
 
 ## Pull Requests
 
+- Write the title and every body section in English.
 - Use an English Conventional Commits-style title: `<type>[optional scope][!]: <short summary>`.
 - Keep the title at or below 72 characters, use a lowercase imperative summary, and omit the trailing period.
 - Complete every section of [the pull request template](.github/pull_request_template.md). Explain skipped or non-applicable checks.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -101,6 +101,7 @@ Agent 专用的仓库指令见 [AGENTS.md](AGENTS.md#optional-development-workfl
 
 ## Pull Request
 
+- 标题和正文的每一节均使用英文。
 - 使用英文 Conventional Commits 风格的标题：`<type>[optional scope][!]: <short summary>`。
 - 标题不超过 72 个字符，摘要使用小写祈使句，不添加句号。
 - 完整填写 [Pull Request 模板](.github/pull_request_template.md)的每一节，并说明跳过或不适用的检查。


### PR DESCRIPTION
## Summary

Require AI agents to write GitHub issue and pull request titles and bodies in English, and provide structured Issue Forms for common TokenHub contributions.

## Related Issue

N/A

## Changes

- Add agent instructions for English issue and pull request content, template use, duplicate searches, and secret redaction.
- Add Bug Report, Feature Request, and Question or Support Request Issue Forms with TokenHub-specific fields.
- Keep blank issues available to human contributors while requiring agents to use the closest matching form.
- Extend the pull request template to require an English title and body.
- Synchronize the English PR body requirement across the English, Simplified Chinese, and Japanese contribution guides.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `ruby -ryaml`: validated all four files under `.github/ISSUE_TEMPLATE/` and confirmed required form keys and unique field IDs.
- `node --test tools/*.test.mjs`: passed 122 tests.
- `node tools/check-doc-translations.mjs --base $(git rev-parse origin/main) --head HEAD`: passed the full existence and co-change checks.
- `node tools/check-ui-translations.mjs`: passed.
- `node tools/check-env-contract.mjs`: passed.
- `node tools/check-source-lines.mjs`: passed.
- `git diff --check`: passed.

## Compatibility, Security, and Operations

No API, data, deployment, rollout, or rollback impact. The Issue Forms reinforce credential redaction. Blank issues remain enabled for human contributors, so this change only requires agents to follow the matching form.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
