### PR TITLE
fix(bootstrap): preserve admin team assignments on upgrade

### DIFF
--- a/backend/internal/server/multi_instance_e2e_test.go
+++ b/backend/internal/server/multi_instance_e2e_test.go
@@ -69,6 +69,9 @@ func TestMultiInstancePostgresE2E(t *testing.T) {
 	t.Run("analytics migration preserves legacy time windows", func(t *testing.T) {
 		testPostgresAnalyticsLegacySequenceMigration(t, storeA, config)
 	})
+	t.Run("v0.4 bootstrap upgrade preserves customized admin teams", func(t *testing.T) {
+		testPostgresV040BootstrapUpgrade(t, storeA, config)
+	})
 	t.Run("OAuth state and refresh coordination survive replica changes", func(t *testing.T) {
 		testSharedOAuthAndRefresh(t, storeA, storeB, config)
 	})

--- a/backend/internal/server/seed.go
+++ b/backend/internal/server/seed.go
@@ -145,18 +145,8 @@ func BootstrapBaseData(store Store) error {
 
 func BootstrapBaseDataWithConfig(store Store, config Config) error {
 	seedDefaultOrgResources(store)
-	if _, err := store.CreateAdminUser(AdminUser{
-		ID:       "usr_admin",
-		Username: "admin",
-		Name:     "Platform Admin",
-		Email:    "admin@tokenhub.local",
-		Role:     "admin",
-		TeamID:   "team_platform",
-		Status:   StatusActive,
-	}, config.BootstrapAdminPassword); err != nil {
-		if AsHTTPError(err).Code != "admin_user_conflict" {
-			return err
-		}
+	if err := seedBootstrapAdmin(store, config.BootstrapAdminPassword); err != nil {
+		return err
 	}
 	seedDefaultProject(store)
 	if err := seedBuiltinProviderCatalog(store); err != nil {
@@ -165,6 +155,29 @@ func BootstrapBaseDataWithConfig(store Store, config Config) error {
 	pruneProviderImportedModelCatalog(store)
 	if err := seedDefaultModelCatalog(store, config.ModelCatalogFile); err != nil {
 		return err
+	}
+	return nil
+}
+
+func seedBootstrapAdmin(store Store, password string) error {
+	admin := AdminUser{
+		ID:       "usr_admin",
+		Username: "admin",
+		Name:     "Platform Admin",
+		Email:    "admin@tokenhub.local",
+		Role:     "admin",
+		TeamID:   "team_platform",
+		Status:   StatusActive,
+	}
+	for _, existing := range store.ListAdminUsers() {
+		if existing.ID == admin.ID || existing.Username == admin.Username || existing.Email == admin.Email {
+			return nil
+		}
+	}
+	if _, err := store.CreateAdminUser(admin, password); err != nil {
+		if AsHTTPError(err).Code != "admin_user_conflict" {
+			return err
+		}
 	}
 	return nil
 }

--- a/backend/internal/server/seed_postgres_integration_test.go
+++ b/backend/internal/server/seed_postgres_integration_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+package server
+
+import (
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func testPostgresV040BootstrapUpgrade(t *testing.T, adminStore *GormStore, config Config) {
+	t.Helper()
+	schema := fmt.Sprintf("tokenhub_e2e_bootstrap_upgrade_%d", time.Now().UnixNano())
+	if err := adminStore.db.Exec("CREATE SCHEMA " + schema).Error; err != nil {
+		t.Fatalf("create bootstrap upgrade schema: %v", err)
+	}
+	defer func() {
+		if err := adminStore.db.Exec("DROP SCHEMA " + schema + " CASCADE").Error; err != nil {
+			t.Errorf("drop bootstrap upgrade schema: %v", err)
+		}
+	}()
+
+	legacySchema := []string{
+		fmt.Sprintf(`CREATE TABLE %s.admin_resources (
+			id text,
+			kind text,
+			name text,
+			description text,
+			status text,
+			fields text,
+			created_at timestamptz,
+			updated_at timestamptz,
+			PRIMARY KEY (id, kind)
+		)`, schema),
+		fmt.Sprintf(`CREATE TABLE %s.admin_users (
+			id text PRIMARY KEY,
+			username text,
+			name text,
+			email text,
+			role text,
+			team_id text,
+			status text,
+			password_hash text,
+			created_at timestamptz,
+			updated_at timestamptz,
+			last_login_at timestamptz
+		)`, schema),
+		fmt.Sprintf(`INSERT INTO %s.admin_resources
+			(id, kind, name, status, fields, created_at, updated_at) VALUES
+			('team_platform', 'teams', 'Platform Engineering Team', 'disabled', '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+			('team_custom', 'teams', 'Custom Team', 'active', '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, schema),
+		fmt.Sprintf(`INSERT INTO %s.admin_users
+			(id, username, name, email, role, team_id, status, password_hash, created_at, updated_at) VALUES
+			('usr_admin', 'admin', 'Platform Admin', 'admin@tokenhub.local', 'admin', 'team_custom', 'active', 'legacy-password-hash', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`, schema),
+	}
+	for _, statement := range legacySchema {
+		if err := adminStore.db.Exec(statement).Error; err != nil {
+			t.Fatalf("create v0.4 bootstrap fixture: %v", err)
+		}
+	}
+
+	parsedURL, err := url.Parse(config.DatabaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := parsedURL.Query()
+	query.Set("search_path", schema)
+	parsedURL.RawQuery = query.Encode()
+	config.DatabaseURL = parsedURL.String()
+	config.ModelCatalogFile = filepath.Join(t.TempDir(), "model-catalog.yaml")
+	if err := os.WriteFile(config.ModelCatalogFile, []byte("version: 1\nmodels:\n  - name: postgres-upgrade-test-model\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	upgradedStore, err := NewStoreWithDialect(config.DatabaseURL, config)
+	if err != nil {
+		t.Fatalf("upgrade v0.4 PostgreSQL database: %v", err)
+	}
+	defer closePostgresUpgradeStore(upgradedStore)
+	if err := RunStartupBootstrap(t.Context(), upgradedStore, config); err != nil {
+		t.Fatalf("bootstrap upgraded v0.4 PostgreSQL database: %v", err)
+	}
+	assigned, err := upgradedStore.CreateAdminUser(AdminUser{
+		ID:       "usr_custom_member",
+		Username: "custom-member",
+		Name:     "Custom Team Member",
+		Email:    "custom-member@tokenhub.local",
+		Role:     "user",
+		TeamID:   "team_custom",
+		Status:   StatusActive,
+	}, "postgres-upgrade-test-password")
+	if err != nil {
+		t.Fatalf("assign user to active custom team after upgrade: %v", err)
+	}
+	if assigned.TeamID != "team_custom" || !userHasTeam(assigned, "team_custom") {
+		t.Fatalf("post-upgrade user assignment = %+v", assigned)
+	}
+
+	var existingAdmin AdminUser
+	if err := upgradedStore.db.First(&existingAdmin, "id = ?", "usr_admin").Error; err != nil {
+		t.Fatal(err)
+	}
+	if existingAdmin.TeamID != "team_custom" || !userHasTeam(existingAdmin, "team_custom") || userHasTeam(existingAdmin, "team_platform") {
+		t.Fatalf("upgrade changed the existing admin assignment: %+v", existingAdmin)
+	}
+	var defaultTeam AdminResource
+	if err := upgradedStore.db.First(&defaultTeam, "kind = ? AND id = ?", "teams", "team_platform").Error; err != nil {
+		t.Fatal(err)
+	}
+	if defaultTeam.Status != StatusDisabled {
+		t.Fatalf("upgrade changed the disabled default team: %+v", defaultTeam)
+	}
+}
+
+func closePostgresUpgradeStore(store *GormStore) {
+	for _, database := range []interface{ DB() (*sql.DB, error) }{store.db, store.analyticsDB} {
+		sqlDB, err := database.DB()
+		if err == nil {
+			_ = sqlDB.Close()
+		}
+	}
+}

--- a/backend/internal/server/seed_test.go
+++ b/backend/internal/server/seed_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,6 +47,81 @@ func TestRunStartupBootstrapReloadsCatalogOnEveryStart(t *testing.T) {
 	}
 	if got := modelCategory(); got != "second-start" {
 		t.Fatalf("catalog edit was not applied on restart: category=%q", got)
+	}
+}
+
+func TestRunStartupBootstrapUpgradesV040DatabaseWithDisabledDefaultTeam(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "v0.4.0.db")
+	legacyDB, err := sql.Open("sqlite3", databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacyDB.Exec(`CREATE TABLE admin_resources (
+		id text,
+		kind text,
+		name text,
+		description text,
+		status text,
+		fields text,
+		created_at datetime,
+		updated_at datetime,
+		PRIMARY KEY (id, kind)
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacyDB.Exec(`CREATE TABLE admin_users (
+		id text primary key,
+		username text,
+		name text,
+		email text,
+		role text,
+		team_id text,
+		status text,
+		password_hash text,
+		created_at datetime,
+		updated_at datetime,
+		last_login_at datetime
+	)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacyDB.Exec(`INSERT INTO admin_resources
+		(id, kind, name, status, fields, created_at, updated_at) VALUES
+		('team_platform', 'teams', 'Platform Engineering Team', 'disabled', '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		('team_custom', 'teams', 'Custom Team', 'active', '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacyDB.Exec(`INSERT INTO admin_users
+		(id, username, name, email, role, team_id, status, password_hash, created_at, updated_at) VALUES
+		('usr_admin', 'admin', 'Platform Admin', 'admin@tokenhub.local', 'admin', 'team_custom', 'active', 'legacy-password-hash', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := legacyDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	catalogPath := filepath.Join(t.TempDir(), "model-catalog.yaml")
+	if err := os.WriteFile(catalogPath, []byte("version: 1\nmodels:\n  - name: startup-test-model\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config := Config{
+		BootstrapAdminPassword: "startup-bootstrap-test-password",
+		ModelCatalogFile:       catalogPath,
+	}
+	store, err := NewSQLiteStoreWithConfig("sqlite://"+databasePath, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := RunStartupBootstrap(context.Background(), store, config); err != nil {
+		t.Fatalf("v0.4.0 database upgrade should preserve the existing admin assignment: %v", err)
+	}
+	users := store.ListAdminUsers()
+	if len(users) != 1 || users[0].ID != "usr_admin" || users[0].TeamID != "team_custom" || userHasTeam(users[0], "team_platform") {
+		t.Fatalf("startup changed the existing admin assignment: %+v", users)
+	}
+	for _, team := range store.ListResources("teams") {
+		if team.ID == "team_platform" && team.Status != StatusDisabled {
+			t.Fatalf("startup re-enabled the disabled default team: %+v", team)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix startup failures when upgrading a preserved v0.4.0 database after the bootstrap administrator has been moved to a custom team and the default team has been disabled.

The v0.5.0 bootstrap attempted to create the fixed admin user on every start. New active-team validation ran before duplicate-user detection, so startup failed with “Only an active team can be assigned to a user” instead of recognizing the existing administrator.

## Related Issue

Fixes https://github.com/astaxie/TokenHub/issues/205

## Changes

- Skip bootstrap-admin creation when the persisted administrator identity already exists.
- Preserve customized administrator team assignments and disabled default-team state.
- Add a v0.4.0-shaped database upgrade regression test that runs current schema migration and startup bootstrap.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- go test ./...
- go vet ./...
- node --test tools/*.test.mjs
- node tools/check-doc-translations.mjs
- node tools/check-ui-translations.mjs
- node tools/check-env-contract.mjs
- node tools/check-source-lines.mjs
- git diff --check
- PostgreSQL integration suite not run locally because TEST_POSTGRES_URL is not configured; the persisted v0.4.0 upgrade path is covered with the SQLite regression fixture.

## Compatibility, Security, and Operations

No public API, persistence schema, authentication policy, environment, deployment, or rollback changes. Existing data is preserved; rollback is the normal code rollback.

## Checklist

- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local .env files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, start.sh, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] data/model-catalog.yaml remains tracked and catalog changes were reviewed where applicable.
- [x] git diff --check passes.
