### PR TITLE
refactor(server): route admin governance endpoints by method

### DIFF
--- a/backend/internal/server/admin_credential_method_routing_contract_test.go
+++ b/backend/internal/server/admin_credential_method_routing_contract_test.go
@@ -1,0 +1,436 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+type adminCredentialMethodRoute struct {
+	name          string
+	path          string
+	allowed       []string
+	allow         string
+	wrongMethod   string
+	authenticated bool
+}
+
+func TestAdminCredentialMethodRoutesPreserveAuthorizationOrder(t *testing.T) {
+	store, _, app, adminToken, ordinaryToken, teamLeaderToken, securityToken, credentialID, _ := newAdminCredentialMethodRoutingServer(t)
+	credentialsBefore := len(store.ListAnalyticsCredentials())
+	auditsBefore := len(store.ListAuditEvents())
+
+	for _, route := range adminCredentialMethodRoutes(credentialID)[:2] {
+		for _, credential := range []struct {
+			name       string
+			token      string
+			wantStatus int
+			wantCode   string
+			wantAllow  string
+		}{
+			{name: "no_token", wantStatus: http.StatusUnauthorized, wantCode: "invalid_admin_token"},
+			{name: "admin", token: adminToken, wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: route.allow},
+			{name: "ordinary_user", token: ordinaryToken, wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+			{name: "team_leader", token: teamLeaderToken, wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+			{name: "security_admin", token: securityToken, wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+		} {
+			t.Run(route.name+"/"+credential.name, func(t *testing.T) {
+				response := methodRoutingRequest(app, route.wrongMethod, route.path, credential.token)
+				assertJSONError(t, response, credential.wantStatus, credential.wantCode)
+				assertAllowHeader(t, response, credential.wantAllow)
+			})
+		}
+	}
+
+	assertAdminCredentialMethodRouteCounts(t, store, credentialsBefore, auditsBefore)
+}
+
+func TestAdminAnalyticsCredentialMethodRoutesPreserveAllowedMethodAuthorization(t *testing.T) {
+	store, _, app, _, ordinaryToken, teamLeaderToken, securityToken, credentialID, _ := newAdminCredentialMethodRoutingServer(t)
+	credentialsBefore := len(store.ListAnalyticsCredentials())
+	auditsBefore := len(store.ListAuditEvents())
+
+	for _, route := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "list", method: http.MethodGet, path: "/api/admin/analytics/credentials"},
+		{name: "create", method: http.MethodPost, path: "/api/admin/analytics/credentials"},
+		{name: "revoke", method: http.MethodDelete, path: "/api/admin/analytics/credentials/" + credentialID},
+	} {
+		for _, credential := range []struct {
+			name   string
+			token  string
+			code   string
+			status int
+		}{
+			{name: "no_token", status: http.StatusUnauthorized, code: "invalid_admin_token"},
+			{name: "ordinary_user", token: ordinaryToken, status: http.StatusForbidden, code: "admin_forbidden"},
+			{name: "team_leader", token: teamLeaderToken, status: http.StatusForbidden, code: "admin_forbidden"},
+			{name: "security_admin", token: securityToken, status: http.StatusForbidden, code: "admin_forbidden"},
+		} {
+			t.Run(route.name+"/"+credential.name, func(t *testing.T) {
+				response := methodRoutingRequest(app, route.method, route.path, credential.token)
+				assertJSONError(t, response, credential.status, credential.code)
+				assertAllowHeader(t, response, "")
+			})
+		}
+	}
+
+	assertAdminCredentialMethodRouteCounts(t, store, credentialsBefore, auditsBefore)
+}
+
+func TestAdminCredentialMethodRoutesRejectEveryUnsupportedMethod(t *testing.T) {
+	store, _, app, adminToken, _, _, _, credentialID, _ := newAdminCredentialMethodRoutingServer(t)
+	credentialsBefore := len(store.ListAnalyticsCredentials())
+	auditsBefore := len(store.ListAuditEvents())
+
+	for _, route := range adminCredentialMethodRoutes(credentialID) {
+		for _, method := range unsupportedAdminCredentialMethods(route.allowed) {
+			t.Run(route.name+"/"+method, func(t *testing.T) {
+				token := ""
+				if route.authenticated {
+					token = adminToken
+				}
+				response := methodRoutingRequest(app, method, route.path, token)
+				assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+				assertAllowHeader(t, response, route.allow)
+			})
+		}
+	}
+
+	assertAdminCredentialMethodRouteCounts(t, store, credentialsBefore, auditsBefore)
+}
+
+func TestAdminCredentialMethodRoutesRejectRealHEAD(t *testing.T) {
+	_, server, _, adminToken, ordinaryToken, teamLeaderToken, securityToken, credentialID, _ := newAdminCredentialMethodRoutingServer(t)
+	httpServer := httptest.NewServer(server.Handler())
+	t.Cleanup(httpServer.Close)
+
+	for _, route := range adminCredentialMethodRoutes(credentialID) {
+		credentials := []struct {
+			name       string
+			token      string
+			wantStatus int
+			wantAllow  string
+		}{
+			{name: "public", wantStatus: http.StatusMethodNotAllowed, wantAllow: route.allow},
+		}
+		if route.authenticated {
+			credentials = []struct {
+				name       string
+				token      string
+				wantStatus int
+				wantAllow  string
+			}{
+				{name: "no_token", wantStatus: http.StatusUnauthorized},
+				{name: "admin", token: adminToken, wantStatus: http.StatusMethodNotAllowed, wantAllow: route.allow},
+				{name: "ordinary_user", token: ordinaryToken, wantStatus: http.StatusForbidden},
+				{name: "team_leader", token: teamLeaderToken, wantStatus: http.StatusForbidden},
+				{name: "security_admin", token: securityToken, wantStatus: http.StatusForbidden},
+			}
+		}
+		for _, credential := range credentials {
+			t.Run(route.name+"/"+credential.name, func(t *testing.T) {
+				request, err := http.NewRequest(http.MethodHead, httpServer.URL+route.path, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if credential.token != "" {
+					request.Header.Set("authorization", "Bearer "+credential.token)
+				}
+				response, err := httpServer.Client().Do(request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer response.Body.Close()
+				assertRealHEADResponse(t, response, credential.wantStatus, credential.wantAllow, "application/json", true)
+			})
+		}
+	}
+}
+
+func TestAdminCredentialMethodRoutesPreserveCORSPreflight(t *testing.T) {
+	_, _, app, _, _, _, _, credentialID, _ := newAdminCredentialMethodRoutingServer(t)
+	for _, route := range adminCredentialMethodRoutes(credentialID) {
+		t.Run(route.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodOptions, route.path, nil)
+			request.Header.Set("origin", "https://console.example.com")
+			request.Header.Set("access-control-request-method", route.wrongMethod)
+			response := httptest.NewRecorder()
+
+			app.ServeHTTP(response, request)
+
+			if response.Code != http.StatusNoContent {
+				t.Fatalf("expected 204, got %d: %s", response.Code, response.Body.String())
+			}
+			if got := response.Header().Get("access-control-allow-methods"); got != "GET,POST,PUT,PATCH,DELETE,OPTIONS" {
+				t.Fatalf("access-control-allow-methods = %q", got)
+			}
+			assertAllowHeader(t, response, "")
+		})
+	}
+}
+
+func TestAdminAnalyticsCredentialMethodRoutesPreserveMalformedPathOrder(t *testing.T) {
+	store, _, app, adminToken, ordinaryToken, _, _, credentialID, _ := newAdminCredentialMethodRoutingServer(t)
+	credentialsBefore := len(store.ListAnalyticsCredentials())
+	auditsBefore := len(store.ListAuditEvents())
+	paths := []string{
+		"/api/admin/analytics/credentials/",
+		"/api/admin/analytics/credentials/" + credentialID + "/",
+		"/api/admin/analytics/credentials/" + credentialID + "/unknown",
+		"/api/admin/analytics/credentials/encoded%2Fcredential",
+	}
+
+	for _, path := range paths {
+		t.Run(path+"/delete", func(t *testing.T) {
+			response := methodRoutingRequest(app, http.MethodDelete, path, adminToken)
+			assertJSONError(t, response, http.StatusNotFound, "analytics_credential_not_found")
+			assertAllowHeader(t, response, "")
+		})
+
+		t.Run(path+"/wrong_method", func(t *testing.T) {
+			response := methodRoutingRequest(app, http.MethodPatch, path, adminToken)
+			assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+			assertAllowHeader(t, response, http.MethodDelete)
+		})
+	}
+
+	path := "/api/admin/analytics/credentials/" + credentialID + "/unknown"
+	for _, method := range []string{http.MethodDelete, http.MethodPatch} {
+		for _, credential := range []struct {
+			name       string
+			token      string
+			wantStatus int
+			wantCode   string
+		}{
+			{name: "no_token", wantStatus: http.StatusUnauthorized, wantCode: "invalid_admin_token"},
+			{name: "ordinary_user", token: ordinaryToken, wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+		} {
+			t.Run("authorization/"+method+"/"+credential.name, func(t *testing.T) {
+				response := methodRoutingRequest(app, method, path, credential.token)
+				assertJSONError(t, response, credential.wantStatus, credential.wantCode)
+				assertAllowHeader(t, response, "")
+			})
+		}
+	}
+
+	assertAdminCredentialMethodRouteCounts(t, store, credentialsBefore, auditsBefore)
+}
+
+func TestAdminAnalyticsCredentialMethodRoutesPreserveLifecycleAndHeaders(t *testing.T) {
+	store, _, app, adminToken, _, _, _, _, _ := newAdminCredentialMethodRoutingServer(t)
+	created := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/analytics/credentials", map[string]any{
+		"name":       "method-routing-analytics",
+		"scope_type": AnalyticsScopeProject,
+		"project_id": defaultProjectID,
+	}, adminToken)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", created.Code, created.Body.String())
+	}
+	if got := created.Header().Get("cache-control"); got != "no-store" {
+		t.Fatalf("create cache-control = %q, want no-store", got)
+	}
+	createdBody := created.Body.String()
+	var payload struct {
+		Credential AnalyticsCredential `json:"credential"`
+		Token      string              `json:"token"`
+	}
+	if err := json.Unmarshal([]byte(createdBody), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Credential.ID == "" || !strings.HasPrefix(payload.Token, "tha_") {
+		t.Fatalf("incomplete credential response: %#v", payload)
+	}
+	if strings.Contains(createdBody, "key_hash") {
+		t.Fatalf("create response exposed key hash: %s", createdBody)
+	}
+
+	listed := methodRoutingRequest(app, http.MethodGet, "/api/admin/analytics/credentials", adminToken)
+	if listed.Code != http.StatusOK || !strings.Contains(listed.Body.String(), payload.Credential.ID) {
+		t.Fatalf("list: expected created credential, got %d: %s", listed.Code, listed.Body.String())
+	}
+	if strings.Contains(listed.Body.String(), payload.Token) || strings.Contains(listed.Body.String(), "key_hash") {
+		t.Fatalf("list response exposed credential secret: %s", listed.Body.String())
+	}
+
+	revoked := methodRoutingRequest(app, http.MethodDelete, "/api/admin/analytics/credentials/"+payload.Credential.ID, adminToken)
+	if revoked.Code != http.StatusOK || !strings.Contains(revoked.Body.String(), payload.Credential.ID) {
+		t.Fatalf("revoke: expected 200, got %d: %s", revoked.Code, revoked.Body.String())
+	}
+	if _, err := store.ValidateAnalyticsCredential(payload.Token); AsHTTPError(err).Code != "invalid_analytics_credential" {
+		t.Fatalf("revoked credential still validates: %v", err)
+	}
+
+	wantAudits := map[string]bool{"create": false, "revoke": false}
+	for _, event := range store.ListAuditEvents() {
+		if event.ResourceType == "analytics_credential" && event.ResourceID == payload.Credential.ID {
+			wantAudits[event.Action] = true
+		}
+	}
+	for action, found := range wantAudits {
+		if !found {
+			t.Fatalf("missing %s audit event for analytics credential", action)
+		}
+	}
+}
+
+func TestOpenAIAccountOAuthCallbackMethodRoutePreservesRedirectBranches(t *testing.T) {
+	store, _, app, _, _, _, _, _, _ := newAdminCredentialMethodRoutingServer(t)
+
+	for _, test := range []struct {
+		name      string
+		session   providerAccountOAuthSession
+		query     string
+		wantQuery map[string]string
+	}{
+		{
+			name: "success",
+			session: providerAccountOAuthSession{
+				ID: "oauth-method-success", State: "oauth-method-success-state", CodeVerifier: "oauth-method-success-verifier",
+				ReturnURL: "http://localhost:3001/providers?source=settings", CreatedAt: time.Now().UTC(),
+			},
+			query: "code=oauth-code&state=oauth-method-success-state",
+			wantQuery: map[string]string{
+				"source": "settings", "provider_account_oauth": "1", "provider_account_oauth_session_id": "oauth-method-success",
+				"provider_account_oauth_state": "oauth-method-success-state", "code": "oauth-code",
+			},
+		},
+		{
+			name: "provider error",
+			session: providerAccountOAuthSession{
+				ID: "oauth-method-provider-error", State: "oauth-method-provider-error-state", CodeVerifier: "oauth-method-provider-error-verifier",
+				ReturnURL: "http://localhost:3001/providers", CreatedAt: time.Now().UTC(),
+			},
+			query:     "error=access_denied&state=oauth-method-provider-error-state",
+			wantQuery: map[string]string{"provider_account_oauth_error": "provider_error"},
+		},
+		{
+			name: "missing code",
+			session: providerAccountOAuthSession{
+				ID: "oauth-method-missing-code", State: "oauth-method-missing-code-state", CodeVerifier: "oauth-method-missing-code-verifier",
+				ReturnURL: "http://localhost:3001/providers", CreatedAt: time.Now().UTC(),
+			},
+			query:     "state=oauth-method-missing-code-state",
+			wantQuery: map[string]string{"provider_account_oauth_error": "missing_code"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := store.SaveProviderAccountOAuthSession(test.session); err != nil {
+				t.Fatal(err)
+			}
+			response := methodRoutingRequest(app, http.MethodGet, "/api/admin/provider-account-oauth/openai/oauth/callback?"+test.query, "")
+			if response.Code != http.StatusFound {
+				t.Fatalf("expected 302, got %d: %s", response.Code, response.Body.String())
+			}
+			location, err := url.Parse(response.Header().Get("location"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for key, want := range test.wantQuery {
+				if got := location.Query().Get(key); got != want {
+					t.Fatalf("redirect query %s = %q, want %q: %s", key, got, want, location.String())
+				}
+			}
+		})
+	}
+
+	invalid := methodRoutingRequest(app, http.MethodGet, "/api/admin/provider-account-oauth/openai/oauth/callback?state=invalid", "")
+	assertJSONError(t, invalid, http.StatusBadRequest, "invalid_oauth_state")
+	assertAllowHeader(t, invalid, "")
+}
+
+func TestOpenAIAccountOAuthCallbackRejectsMethodBeforeSessionLookup(t *testing.T) {
+	store, _, app, _, _, _, _, _, _ := newAdminCredentialMethodRoutingServer(t)
+	sqlDB, err := store.db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	response := methodRoutingRequest(app, http.MethodPost, "/api/admin/provider-account-oauth/openai/oauth/callback?state=unreadable", "")
+	assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+	assertAllowHeader(t, response, http.MethodGet)
+	if location := response.Header().Get("location"); location != "" {
+		t.Fatalf("wrong method returned Location %q", location)
+	}
+}
+
+func adminCredentialMethodRoutes(credentialID string) []adminCredentialMethodRoute {
+	return []adminCredentialMethodRoute{
+		{name: "analytics collection", path: "/api/admin/analytics/credentials", allowed: []string{http.MethodGet, http.MethodPost}, allow: "GET, POST", wrongMethod: http.MethodDelete, authenticated: true},
+		{name: "analytics credential", path: "/api/admin/analytics/credentials/" + credentialID, allowed: []string{http.MethodDelete}, allow: http.MethodDelete, wrongMethod: http.MethodGet, authenticated: true},
+		{name: "OAuth callback", path: "/api/admin/provider-account-oauth/openai/oauth/callback?state=missing", allowed: []string{http.MethodGet}, allow: http.MethodGet, wrongMethod: http.MethodPost},
+	}
+}
+
+func unsupportedAdminCredentialMethods(allowed []string) []string {
+	allowedSet := map[string]bool{}
+	for _, method := range allowed {
+		allowedSet[method] = true
+	}
+	methods := []string{}
+	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		if !allowedSet[method] {
+			methods = append(methods, method)
+		}
+	}
+	return methods
+}
+
+func newAdminCredentialMethodRoutingServer(t *testing.T) (*GormStore, *Server, http.Handler, string, string, string, string, string, string) {
+	t.Helper()
+	config := ConfigFromEnv()
+	config.AdminToken = "dev_admin_token"
+	config.BootstrapAdminPassword = "admin-credential-method-password"
+	store := NewMemoryStoreWithConfig(config)
+	if err := BootstrapBaseDataWithConfig(store, config); err != nil {
+		t.Fatal(err)
+	}
+	ordinaryToken := createAdminCredentialMethodSession(t, store, AdminUser{Username: "credential-method-user", Email: "credential-method-user@tokenhub.local", Role: "user", Status: StatusActive})
+	teamLeaderToken := createAdminCredentialMethodSession(t, store, AdminUser{Username: "credential-method-leader", Email: "credential-method-leader@tokenhub.local", Role: "team_leader", TeamID: "team_platform", Status: StatusActive})
+	securityToken := createAdminCredentialMethodSession(t, store, AdminUser{Username: "credential-method-security", Email: "credential-method-security@tokenhub.local", Role: "security_admin", Status: StatusActive})
+	credential, credentialToken, err := store.CreateAnalyticsCredential(AnalyticsCredential{
+		Name: "Method routing analytics credential", ScopeType: AnalyticsScopeProject, ProjectID: defaultProjectID, CreatedBy: "usr_admin",
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := NewWithConfig(store, config)
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+	app := server.Handler()
+	adminToken, _ := loginMethodRoutingAdmin(t, app, config.BootstrapAdminPassword)
+	return store, server, app, adminToken, ordinaryToken, teamLeaderToken, securityToken, credential.ID, credentialToken
+}
+
+func createAdminCredentialMethodSession(t *testing.T, store *GormStore, user AdminUser) string {
+	t.Helper()
+	created, err := store.CreateAdminUser(user, "admin-credential-role-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, session, err := store.CreateAdminSession(created.ID, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return session.Token
+}
+
+func assertAdminCredentialMethodRouteCounts(t *testing.T, store *GormStore, wantCredentials int, wantAudits int) {
+	t.Helper()
+	if got := len(store.ListAnalyticsCredentials()); got != wantCredentials {
+		t.Fatalf("wrong methods changed analytics credentials: got %d, want %d", got, wantCredentials)
+	}
+	if got := len(store.ListAuditEvents()); got != wantAudits {
+		t.Fatalf("wrong methods changed audit events: got %d, want %d", got, wantAudits)
+	}
+}

--- a/backend/internal/server/admin_guardrail_method_routing_contract_test.go
+++ b/backend/internal/server/admin_guardrail_method_routing_contract_test.go
@@ -1,0 +1,350 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"tokenhub/backend/internal/guardrails"
+)
+
+type adminGuardrailMethodRoute struct {
+	name        string
+	path        string
+	allowed     []string
+	allow       string
+	wrongMethod string
+}
+
+func TestAdminGuardrailMethodRoutesPreserveAuthorizationOrder(t *testing.T) {
+	store, _, app, adminToken, securityToken, ordinaryToken, teamLeaderToken, policyID, _ := newAdminGuardrailMethodRoutingServer(t)
+	policiesBefore := adminGuardrailPolicyCount(t, store)
+	auditsBefore := len(store.ListAuditEvents())
+
+	for _, route := range adminGuardrailMethodRoutes(policyID) {
+		for _, credential := range []struct {
+			name       string
+			token      string
+			wantStatus int
+			wantCode   string
+			wantAllow  string
+		}{
+			{name: "no_token", wantStatus: http.StatusUnauthorized, wantCode: "invalid_admin_token"},
+			{name: "admin", token: adminToken, wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: route.allow},
+			{name: "security_admin", token: securityToken, wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: route.allow},
+			{name: "ordinary_user", token: ordinaryToken, wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+			{name: "team_leader", token: teamLeaderToken, wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+		} {
+			t.Run(route.name+"/"+credential.name, func(t *testing.T) {
+				response := methodRoutingRequest(app, route.wrongMethod, route.path, credential.token)
+				assertJSONError(t, response, credential.wantStatus, credential.wantCode)
+				assertAllowHeader(t, response, credential.wantAllow)
+			})
+		}
+	}
+
+	assertAdminGuardrailMethodRouteCounts(t, store, policiesBefore, auditsBefore)
+}
+
+func TestAdminGuardrailMethodRoutesRejectEveryUnsupportedMethod(t *testing.T) {
+	store, _, app, adminToken, _, _, _, policyID, _ := newAdminGuardrailMethodRoutingServer(t)
+	policiesBefore := adminGuardrailPolicyCount(t, store)
+	auditsBefore := len(store.ListAuditEvents())
+
+	for _, route := range adminGuardrailMethodRoutes(policyID) {
+		for _, method := range unsupportedAdminGuardrailMethods(route.allowed) {
+			t.Run(route.name+"/"+method, func(t *testing.T) {
+				response := methodRoutingRequest(app, method, route.path, adminToken)
+				assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+				assertAllowHeader(t, response, route.allow)
+			})
+		}
+	}
+
+	assertAdminGuardrailMethodRouteCounts(t, store, policiesBefore, auditsBefore)
+}
+
+func TestAdminGuardrailMethodRoutesRejectRealHEAD(t *testing.T) {
+	_, server, _, adminToken, securityToken, ordinaryToken, teamLeaderToken, policyID, _ := newAdminGuardrailMethodRoutingServer(t)
+	httpServer := httptest.NewServer(server.Handler())
+	t.Cleanup(httpServer.Close)
+
+	for _, test := range []struct {
+		name  string
+		path  string
+		allow string
+	}{
+		{name: "collection", path: "/api/admin/guardrail-policies", allow: "GET, POST"},
+		{name: "test action", path: adminGuardrailPolicyTestPath, allow: http.MethodPost},
+		{name: "policy item", path: "/api/admin/guardrail-policies/" + policyID, allow: "GET, PUT, DELETE"},
+	} {
+		for _, credential := range []struct {
+			name       string
+			token      string
+			wantStatus int
+			wantAllow  string
+		}{
+			{name: "no_token", wantStatus: http.StatusUnauthorized},
+			{name: "admin", token: adminToken, wantStatus: http.StatusMethodNotAllowed, wantAllow: test.allow},
+			{name: "security_admin", token: securityToken, wantStatus: http.StatusMethodNotAllowed, wantAllow: test.allow},
+			{name: "ordinary_user", token: ordinaryToken, wantStatus: http.StatusForbidden},
+			{name: "team_leader", token: teamLeaderToken, wantStatus: http.StatusForbidden},
+		} {
+			t.Run(test.name+"/"+credential.name, func(t *testing.T) {
+				request, err := http.NewRequest(http.MethodHead, httpServer.URL+test.path, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if credential.token != "" {
+					request.Header.Set("authorization", "Bearer "+credential.token)
+				}
+				response, err := httpServer.Client().Do(request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer response.Body.Close()
+				assertRealHEADResponse(t, response, credential.wantStatus, credential.wantAllow, "application/json", true)
+			})
+		}
+	}
+}
+
+func TestAdminGuardrailMethodRoutesPreserveCORSPreflight(t *testing.T) {
+	_, _, app, _, _, _, _, policyID, _ := newAdminGuardrailMethodRoutingServer(t)
+	for _, route := range adminGuardrailMethodRoutes(policyID) {
+		t.Run(route.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodOptions, route.path, nil)
+			request.Header.Set("origin", "https://console.example.com")
+			request.Header.Set("access-control-request-method", route.wrongMethod)
+			response := httptest.NewRecorder()
+
+			app.ServeHTTP(response, request)
+
+			if response.Code != http.StatusNoContent {
+				t.Fatalf("expected 204, got %d: %s", response.Code, response.Body.String())
+			}
+			if got := response.Header().Get("access-control-allow-methods"); got != "GET,POST,PUT,PATCH,DELETE,OPTIONS" {
+				t.Fatalf("access-control-allow-methods = %q", got)
+			}
+			assertAllowHeader(t, response, "")
+		})
+	}
+}
+
+func TestAdminGuardrailMethodRoutesPreserveStaticAndDynamicPathBoundaries(t *testing.T) {
+	store, _, app, adminToken, _, _, _, policyID, encodedPolicyID := newAdminGuardrailMethodRoutingServer(t)
+	policiesBefore := adminGuardrailPolicyCount(t, store)
+	auditsBefore := len(store.ListAuditEvents())
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantStatus int
+		wantCode   string
+		wantAllow  string
+		wantText   string
+	}{
+		{name: "test GET stays action", method: http.MethodGet, path: adminGuardrailPolicyTestPath, wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: http.MethodPost},
+		{name: "test trailing slash stays policy item", method: http.MethodGet, path: adminGuardrailPolicyTestPath + "/", wantStatus: http.StatusNotFound, wantCode: "guardrail_policy_not_found"},
+		{name: "policy POST rejects before lookup", method: http.MethodPost, path: "/api/admin/guardrail-policies/missing", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: "GET, PUT, DELETE"},
+		{name: "policy trailing slash wrong method", method: http.MethodPost, path: "/api/admin/guardrail-policies/" + policyID + "/", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: "GET, PUT, DELETE"},
+		{name: "unknown child", method: http.MethodGet, path: "/api/admin/guardrail-policies/" + policyID + "/unknown", wantStatus: http.StatusNotFound, wantCode: "not_found"},
+		{name: "unknown child wrong method", method: http.MethodPatch, path: "/api/admin/guardrail-policies/" + policyID + "/unknown", wantStatus: http.StatusNotFound, wantCode: "not_found"},
+		{name: "blank policy id", method: http.MethodGet, path: "/api/admin/guardrail-policies/%20", wantStatus: http.StatusNotFound, wantCode: "not_found"},
+		{name: "blank policy id wrong method", method: http.MethodPost, path: "/api/admin/guardrail-policies/%20", wantStatus: http.StatusNotFound, wantCode: "not_found"},
+		{name: "encoded policy id", method: http.MethodGet, path: "/api/admin/guardrail-policies/" + strings.ReplaceAll(encodedPolicyID, "/", "%2F"), wantStatus: http.StatusOK, wantText: "Encoded guardrail policy"},
+		{name: "encoded policy wrong method", method: http.MethodPost, path: "/api/admin/guardrail-policies/" + strings.ReplaceAll(encodedPolicyID, "/", "%2F"), wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: "GET, PUT, DELETE"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := methodRoutingRequest(app, test.method, test.path, adminToken)
+			if test.wantCode != "" {
+				assertJSONError(t, response, test.wantStatus, test.wantCode)
+				assertAllowHeader(t, response, test.wantAllow)
+				return
+			}
+			if response.Code != test.wantStatus || !strings.Contains(response.Body.String(), test.wantText) {
+				t.Fatalf("expected %d containing %q, got %d: %s", test.wantStatus, test.wantText, response.Code, response.Body.String())
+			}
+			assertAllowHeader(t, response, "")
+		})
+	}
+
+	assertAdminGuardrailMethodRouteCounts(t, store, policiesBefore, auditsBefore)
+}
+
+func TestAdminGuardrailMethodRoutesAuthorizeBeforeMalformedPathValidation(t *testing.T) {
+	_, _, app, adminToken, securityToken, ordinaryToken, teamLeaderToken, policyID, _ := newAdminGuardrailMethodRoutingServer(t)
+	path := "/api/admin/guardrail-policies/" + policyID + "/unknown"
+
+	for _, credential := range []struct {
+		name       string
+		token      string
+		wantStatus int
+		wantCode   string
+	}{
+		{name: "no_token", wantStatus: http.StatusUnauthorized, wantCode: "invalid_admin_token"},
+		{name: "admin", token: adminToken, wantStatus: http.StatusNotFound, wantCode: "not_found"},
+		{name: "security_admin", token: securityToken, wantStatus: http.StatusNotFound, wantCode: "not_found"},
+		{name: "ordinary_user", token: ordinaryToken, wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+		{name: "team_leader", token: teamLeaderToken, wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+	} {
+		t.Run(credential.name, func(t *testing.T) {
+			response := methodRoutingRequest(app, http.MethodPatch, path, credential.token)
+			assertJSONError(t, response, credential.wantStatus, credential.wantCode)
+			assertAllowHeader(t, response, "")
+		})
+	}
+}
+
+func TestAdminGuardrailMethodRoutesPreserveTrailingSlashMutations(t *testing.T) {
+	store, _, app, adminToken, _, _, _, _, _ := newAdminGuardrailMethodRoutingServer(t)
+	policy, err := store.CreateGuardrailPolicy(testGuardrailPolicy("Trailing guardrail policy", defaultProjectID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := "/api/admin/guardrail-policies/" + policy.ID + "/"
+
+	update := testGuardrailPolicy("Trailing guardrail policy updated", defaultProjectID)
+	updated := methodRoutingJSONRequest(t, app, http.MethodPut, path, update, adminToken)
+	if updated.Code != http.StatusOK || !strings.Contains(updated.Body.String(), "Trailing guardrail policy updated") {
+		t.Fatalf("trailing slash PUT: expected 200, got %d: %s", updated.Code, updated.Body.String())
+	}
+	deleted := methodRoutingRequest(app, http.MethodDelete, path, adminToken)
+	if deleted.Code != http.StatusNoContent {
+		t.Fatalf("trailing slash DELETE: expected 204, got %d: %s", deleted.Code, deleted.Body.String())
+	}
+	if _, err := store.GetGuardrailPolicy(policy.ID); AsHTTPError(err).Code != "guardrail_policy_not_found" {
+		t.Fatalf("trailing slash DELETE left policy behind: %v", err)
+	}
+
+	wantAudit := map[string]bool{"update": false, "delete": false}
+	for _, event := range store.ListAuditEvents() {
+		if event.ResourceType == "guardrail_policy" && event.ResourceID == policy.ID {
+			wantAudit[event.Action] = true
+		}
+	}
+	for action, found := range wantAudit {
+		if !found {
+			t.Fatalf("missing %s audit event for trailing slash mutation", action)
+		}
+	}
+}
+
+func TestAdminGuardrailMethodRoutesPreserveEncodedPolicyIDMutations(t *testing.T) {
+	store, _, app, adminToken, _, _, _, _, encodedPolicyID := newAdminGuardrailMethodRoutingServer(t)
+	path := "/api/admin/guardrail-policies/" + strings.ReplaceAll(encodedPolicyID, "/", "%2F")
+
+	update := testGuardrailPolicy("Encoded guardrail policy updated", defaultProjectID)
+	updated := methodRoutingJSONRequest(t, app, http.MethodPut, path, update, adminToken)
+	if updated.Code != http.StatusOK || !strings.Contains(updated.Body.String(), "Encoded guardrail policy updated") {
+		t.Fatalf("encoded policy PUT: expected 200, got %d: %s", updated.Code, updated.Body.String())
+	}
+	deleted := methodRoutingRequest(app, http.MethodDelete, path, adminToken)
+	if deleted.Code != http.StatusNoContent {
+		t.Fatalf("encoded policy DELETE: expected 204, got %d: %s", deleted.Code, deleted.Body.String())
+	}
+	if _, err := store.GetGuardrailPolicy(encodedPolicyID); AsHTTPError(err).Code != "guardrail_policy_not_found" {
+		t.Fatalf("encoded policy DELETE left policy behind: %v", err)
+	}
+
+	wantAudit := map[string]bool{"update": false, "delete": false}
+	for _, event := range store.ListAuditEvents() {
+		if event.ResourceType == "guardrail_policy" && event.ResourceID == encodedPolicyID {
+			wantAudit[event.Action] = true
+		}
+	}
+	for action, found := range wantAudit {
+		if !found {
+			t.Fatalf("missing %s audit event for encoded policy ID %q", action, encodedPolicyID)
+		}
+	}
+}
+
+func adminGuardrailMethodRoutes(policyID string) []adminGuardrailMethodRoute {
+	return []adminGuardrailMethodRoute{
+		{name: "collection", path: "/api/admin/guardrail-policies", allowed: []string{http.MethodGet, http.MethodPost}, allow: "GET, POST", wrongMethod: http.MethodPut},
+		{name: "test action", path: adminGuardrailPolicyTestPath, allowed: []string{http.MethodPost}, allow: http.MethodPost, wrongMethod: http.MethodGet},
+		{name: "policy item", path: "/api/admin/guardrail-policies/" + policyID, allowed: []string{http.MethodGet, http.MethodPut, http.MethodDelete}, allow: "GET, PUT, DELETE", wrongMethod: http.MethodPost},
+	}
+}
+
+func unsupportedAdminGuardrailMethods(allowed []string) []string {
+	allowedSet := map[string]bool{}
+	for _, method := range allowed {
+		allowedSet[method] = true
+	}
+	methods := []string{}
+	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		if !allowedSet[method] {
+			methods = append(methods, method)
+		}
+	}
+	return methods
+}
+
+func newAdminGuardrailMethodRoutingServer(t *testing.T) (*GormStore, *Server, http.Handler, string, string, string, string, string, string) {
+	t.Helper()
+	config := ConfigFromEnv()
+	config.AdminToken = "dev_admin_token"
+	config.BootstrapAdminPassword = "guardrail-method-password"
+	store := NewMemoryStoreWithConfig(config)
+	if err := BootstrapBaseDataWithConfig(store, config); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := store.CreateGuardrailPolicy(testGuardrailPolicy("Method guardrail policy", defaultProjectID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	encodedPolicy := testGuardrailPolicy("Encoded guardrail policy", defaultProjectID)
+	encodedPolicy.ID = "grp/encoded"
+	encodedPolicy, err = store.CreateGuardrailPolicy(encodedPolicy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	securityToken := createAdminGuardrailMethodSession(t, store, AdminUser{Username: "guardrail-security", Email: "guardrail-security@tokenhub.local", Role: "security_admin", Status: StatusActive})
+	ordinaryToken := createAdminGuardrailMethodSession(t, store, AdminUser{Username: "guardrail-user", Email: "guardrail-user@tokenhub.local", Role: "user", Status: StatusActive})
+	teamLeaderToken := createAdminGuardrailMethodSession(t, store, AdminUser{Username: "guardrail-leader", Email: "guardrail-leader@tokenhub.local", Role: "team_leader", TeamID: "team_platform", Status: StatusActive})
+	server := NewWithConfig(store, config)
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+	app := server.Handler()
+	adminToken, _ := loginMethodRoutingAdmin(t, app, config.BootstrapAdminPassword)
+	return store, server, app, adminToken, securityToken, ordinaryToken, teamLeaderToken, policy.ID, encodedPolicy.ID
+}
+
+func createAdminGuardrailMethodSession(t *testing.T, store *GormStore, user AdminUser) string {
+	t.Helper()
+	created, err := store.CreateAdminUser(user, "guardrail-method-role-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, session, err := store.CreateAdminSession(created.ID, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return session.Token
+}
+
+func adminGuardrailPolicyCount(t *testing.T, store *GormStore) int64 {
+	t.Helper()
+	var count int64
+	if err := store.db.Model(&guardrails.Policy{}).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	return count
+}
+
+func assertAdminGuardrailMethodRouteCounts(t *testing.T, store *GormStore, wantPolicies int64, wantAudits int) {
+	t.Helper()
+	if got := adminGuardrailPolicyCount(t, store); got != wantPolicies {
+		t.Fatalf("wrong methods changed policies: got %d, want %d", got, wantPolicies)
+	}
+	if got := len(store.ListAuditEvents()); got != wantAudits {
+		t.Fatalf("wrong methods changed audit events: got %d, want %d", got, wantAudits)
+	}
+}

--- a/backend/internal/server/admin_guardrails_http.go
+++ b/backend/internal/server/admin_guardrails_http.go
@@ -28,12 +28,46 @@ type guardrailPolicyTestFinding struct {
 	End   int `json:"end"`
 }
 
-func (s *Server) handleAdminGuardrailPolicyTest(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r, "security", r.Method); !ok {
-		return
+const adminGuardrailPolicyTestPath = "/api/admin/guardrail-policies/test"
+
+func (s *Server) registerAdminGuardrailPolicyRoutes() {
+	s.registerMethodRoutes("/api/admin/guardrail-policies", func(allowedMethods string) http.HandlerFunc {
+		return s.adminMethodNotAllowed("security", allowedMethods)
+	},
+		methodRoute{Method: http.MethodGet, Handler: s.handleAdminGuardrailPoliciesGet},
+		methodRoute{Method: http.MethodPost, Handler: s.handleAdminGuardrailPoliciesPost},
+	)
+	s.mux.HandleFunc(http.MethodPost+" "+adminGuardrailPolicyTestPath, s.handleAdminGuardrailPolicyTestPost)
+
+	itemRoutes := []methodRoute{
+		{Method: http.MethodGet, Handler: s.handleAdminGuardrailPolicyGet},
+		{Method: http.MethodPut, Handler: s.handleAdminGuardrailPolicyPut},
+		{Method: http.MethodDelete, Handler: s.handleAdminGuardrailPolicyDelete},
 	}
-	if r.Method != http.MethodPost {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+	itemAllowedMethods := methodRoutesAllow(itemRoutes)
+	itemMethodNotAllowed := s.adminGuardrailPolicyMethodNotAllowed(itemAllowedMethods)
+	for _, pattern := range []string{
+		"/api/admin/guardrail-policies/{policy_id}",
+		"/api/admin/guardrail-policies/{policy_id}/{$}",
+	} {
+		for _, route := range itemRoutes {
+			if route.Method == http.MethodGet {
+				s.registerDynamicGETRoute(pattern, route.Handler, itemMethodNotAllowed)
+				continue
+			}
+			s.registerDynamicMethodRoute(route.Method, pattern, route.Handler)
+		}
+	}
+
+	// Unsupported methods and malformed nested paths still need the legacy
+	// parser because /test and {policy_id} overlap for different methods.
+	s.mux.HandleFunc("/api/admin/guardrail-policies/", func(w http.ResponseWriter, r *http.Request) {
+		s.handleAdminGuardrailPolicyItem(w, r, itemAllowedMethods)
+	})
+}
+
+func (s *Server) handleAdminGuardrailPolicyTestPost(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r, "security", r.Method); !ok {
 		return
 	}
 	var request guardrailPolicyTestRequest
@@ -79,41 +113,45 @@ func (s *Server) handleAdminGuardrailPolicyTest(w http.ResponseWriter, r *http.R
 	writeJSON(w, http.StatusOK, response)
 }
 
-func (s *Server) handleAdminGuardrailPolicies(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleAdminGuardrailPoliciesGet(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r, "security", r.Method); !ok {
+		return
+	}
+	policies, err := s.store.ListGuardrailPolicies()
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"data": policies})
+}
+
+func (s *Server) handleAdminGuardrailPoliciesPost(w http.ResponseWriter, r *http.Request) {
 	user, ok := s.requireAdmin(w, r, "security", r.Method)
 	if !ok {
 		return
 	}
-	switch r.Method {
-	case http.MethodGet:
-		policies, err := s.store.ListGuardrailPolicies()
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		writeJSON(w, http.StatusOK, map[string]any{"data": policies})
-	case http.MethodPost:
-		var policy guardrails.Policy
-		if err := s.decodeJSON(w, r, &policy); err != nil {
-			writeError(w, r, err)
-			return
-		}
-		resetGuardrailRequestOwnedFields(&policy, false)
-		created, err := s.store.CreateGuardrailPolicy(policy)
-		if err != nil {
-			writeError(w, r, guardrailStoreError(err))
-			return
-		}
-		s.recordAdminAudit(r, user, "create", "guardrail_policy", created.ID, nil, guardrailPolicyAuditSnapshot(created))
-		writeJSON(w, http.StatusCreated, created)
-	default:
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+	var policy guardrails.Policy
+	if err := s.decodeJSON(w, r, &policy); err != nil {
+		writeError(w, r, err)
+		return
 	}
+	resetGuardrailRequestOwnedFields(&policy, false)
+	created, err := s.store.CreateGuardrailPolicy(policy)
+	if err != nil {
+		writeError(w, r, guardrailStoreError(err))
+		return
+	}
+	s.recordAdminAudit(r, user, "create", "guardrail_policy", created.ID, nil, guardrailPolicyAuditSnapshot(created))
+	writeJSON(w, http.StatusCreated, created)
 }
 
-func (s *Server) handleAdminGuardrailPolicyItem(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleAdminGuardrailPolicyItem(w http.ResponseWriter, r *http.Request, allowedMethods string) {
 	user, ok := s.requireAdmin(w, r, "security", r.Method)
 	if !ok {
+		return
+	}
+	if r.URL.Path == adminGuardrailPolicyTestPath {
+		jsonMethodNotAllowed(http.MethodPost)(w, r)
 		return
 	}
 	parts := splitEscapedAdminPath(r.URL.EscapedPath(), "/api/admin/guardrail-policies/")
@@ -124,37 +162,93 @@ func (s *Server) handleAdminGuardrailPolicyItem(w http.ResponseWriter, r *http.R
 	policyID := strings.TrimSpace(parts[0])
 	switch r.Method {
 	case http.MethodGet:
-		policy, err := s.store.GetGuardrailPolicy(policyID)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		writeJSON(w, http.StatusOK, policy)
+		s.serveAdminGuardrailPolicyGet(w, r, user, policyID)
 	case http.MethodPut:
-		var policy guardrails.Policy
-		if err := s.decodeJSON(w, r, &policy); err != nil {
-			writeError(w, r, err)
-			return
-		}
-		resetGuardrailRequestOwnedFields(&policy, true)
-		before, updated, err := s.store.UpdateGuardrailPolicy(policyID, policy)
-		if err != nil {
-			writeError(w, r, guardrailStoreError(err))
-			return
-		}
-		s.recordAdminAudit(r, user, "update", "guardrail_policy", policyID, guardrailPolicyAuditSnapshot(before), guardrailPolicyAuditSnapshot(updated))
-		writeJSON(w, http.StatusOK, updated)
+		s.serveAdminGuardrailPolicyPut(w, r, user, policyID)
 	case http.MethodDelete:
-		before, err := s.store.DeleteGuardrailPolicy(policyID)
-		if err != nil {
-			writeError(w, r, err)
+		s.serveAdminGuardrailPolicyDelete(w, r, user, policyID)
+	default:
+		jsonMethodNotAllowed(allowedMethods)(w, r)
+	}
+}
+
+func (s *Server) handleAdminGuardrailPolicyGet(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminGuardrailPolicyRoute(w, r, s.serveAdminGuardrailPolicyGet)
+}
+
+func (s *Server) handleAdminGuardrailPolicyPut(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminGuardrailPolicyRoute(w, r, s.serveAdminGuardrailPolicyPut)
+}
+
+func (s *Server) handleAdminGuardrailPolicyDelete(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminGuardrailPolicyRoute(w, r, s.serveAdminGuardrailPolicyDelete)
+}
+
+func (s *Server) handleAdminGuardrailPolicyRoute(w http.ResponseWriter, r *http.Request, handler func(http.ResponseWriter, *http.Request, AdminUser, string)) {
+	user, ok := s.requireAdmin(w, r, "security", r.Method)
+	if !ok {
+		return
+	}
+	if r.URL.Path == adminGuardrailPolicyTestPath {
+		jsonMethodNotAllowed(http.MethodPost)(w, r)
+		return
+	}
+	policyID := strings.TrimSpace(r.PathValue("policy_id"))
+	if policyID == "" {
+		writeError(w, r, NewHTTPError(http.StatusNotFound, "not_found", "Not found"))
+		return
+	}
+	handler(w, r, user, policyID)
+}
+
+func (s *Server) adminGuardrailPolicyMethodNotAllowed(allowedMethods string) http.HandlerFunc {
+	itemReject := jsonMethodNotAllowed(allowedMethods)
+	testReject := jsonMethodNotAllowed(http.MethodPost)
+	return func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := s.requireAdmin(w, r, "security", r.Method); !ok {
 			return
 		}
-		s.recordAdminAudit(r, user, "delete", "guardrail_policy", policyID, guardrailPolicyAuditSnapshot(before), nil)
-		w.WriteHeader(http.StatusNoContent)
-	default:
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+		if r.URL.Path == adminGuardrailPolicyTestPath {
+			testReject(w, r)
+			return
+		}
+		itemReject(w, r)
 	}
+}
+
+func (s *Server) serveAdminGuardrailPolicyGet(w http.ResponseWriter, r *http.Request, _ AdminUser, policyID string) {
+	policy, err := s.store.GetGuardrailPolicy(policyID)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, policy)
+}
+
+func (s *Server) serveAdminGuardrailPolicyPut(w http.ResponseWriter, r *http.Request, user AdminUser, policyID string) {
+	var policy guardrails.Policy
+	if err := s.decodeJSON(w, r, &policy); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	resetGuardrailRequestOwnedFields(&policy, true)
+	before, updated, err := s.store.UpdateGuardrailPolicy(policyID, policy)
+	if err != nil {
+		writeError(w, r, guardrailStoreError(err))
+		return
+	}
+	s.recordAdminAudit(r, user, "update", "guardrail_policy", policyID, guardrailPolicyAuditSnapshot(before), guardrailPolicyAuditSnapshot(updated))
+	writeJSON(w, http.StatusOK, updated)
+}
+
+func (s *Server) serveAdminGuardrailPolicyDelete(w http.ResponseWriter, r *http.Request, user AdminUser, policyID string) {
+	before, err := s.store.DeleteGuardrailPolicy(policyID)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "delete", "guardrail_policy", policyID, guardrailPolicyAuditSnapshot(before), nil)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func resetGuardrailRequestOwnedFields(policy *guardrails.Policy, preserveDetectionItemIDs bool) {

--- a/backend/internal/server/admin_identity_api_key_method_routing_contract_test.go
+++ b/backend/internal/server/admin_identity_api_key_method_routing_contract_test.go
@@ -1,0 +1,593 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type adminIdentityAPIKeyMethodRoute struct {
+	name        string
+	path        string
+	wrongMethod string
+	allow       string
+	resource    string
+}
+
+func TestAdminIdentityAndAPIKeyMethodRoutesPreserveAuthorizationOrder(t *testing.T) {
+	store, _, app, adminToken, userToken, teamLeaderToken, securityToken, targetUserID, keyID := newAdminIdentityAPIKeyMethodRoutingServer(t)
+	messages := configureTestSMTPChannel(t, store)
+	routes := adminIdentityAPIKeyMethodRoutes(targetUserID, keyID)
+	usersBefore := len(store.ListAdminUsers())
+	keysBefore := len(store.ListAPIKeys())
+	auditsBefore := len(store.ListAuditEvents())
+	approvalsBefore := len(store.ListApprovalRequests())
+	policiesBefore := len(store.ListResources(routingPolicyResourceKind))
+	resetTokensBefore := adminIdentityAPIKeyMethodModelCount(t, store, &AdminPasswordResetToken{})
+	sessionsBefore := adminIdentityAPIKeyMethodModelCount(t, store, &AdminSession{})
+
+	for _, route := range routes {
+		t.Run(route.name+"/no_token", func(t *testing.T) {
+			response := methodRoutingRequest(app, route.wrongMethod, route.path, "")
+			assertJSONError(t, response, http.StatusUnauthorized, "invalid_admin_token")
+			assertAllowHeader(t, response, "")
+		})
+
+		t.Run(route.name+"/admin", func(t *testing.T) {
+			response := methodRoutingRequest(app, route.wrongMethod, route.path, adminToken)
+			assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+			assertAllowHeader(t, response, route.allow)
+		})
+
+		t.Run(route.name+"/ordinary_user", func(t *testing.T) {
+			response := methodRoutingRequest(app, route.wrongMethod, route.path, userToken)
+			if route.resource == "api_key" {
+				assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+				assertAllowHeader(t, response, route.allow)
+				return
+			}
+			assertJSONError(t, response, http.StatusForbidden, "admin_forbidden")
+			assertAllowHeader(t, response, "")
+		})
+
+		t.Run(route.name+"/team_leader", func(t *testing.T) {
+			response := methodRoutingRequest(app, route.wrongMethod, route.path, teamLeaderToken)
+			assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+			assertAllowHeader(t, response, route.allow)
+		})
+
+		t.Run(route.name+"/security_admin", func(t *testing.T) {
+			response := methodRoutingRequest(app, route.wrongMethod, route.path, securityToken)
+			assertJSONError(t, response, http.StatusForbidden, "admin_forbidden")
+			assertAllowHeader(t, response, "")
+		})
+	}
+
+	if got := len(store.ListAdminUsers()); got != usersBefore {
+		t.Fatalf("wrong methods changed users: got %d, want %d", got, usersBefore)
+	}
+	if got := len(store.ListAPIKeys()); got != keysBefore {
+		t.Fatalf("wrong methods changed API keys: got %d, want %d", got, keysBefore)
+	}
+	if got := len(store.ListAuditEvents()); got != auditsBefore {
+		t.Fatalf("wrong methods changed audit events: got %d, want %d", got, auditsBefore)
+	}
+	if got := len(store.ListApprovalRequests()); got != approvalsBefore {
+		t.Fatalf("wrong methods changed approvals: got %d, want %d", got, approvalsBefore)
+	}
+	if got := len(store.ListResources(routingPolicyResourceKind)); got != policiesBefore {
+		t.Fatalf("wrong methods changed routing policies: got %d, want %d", got, policiesBefore)
+	}
+	if got := adminIdentityAPIKeyMethodModelCount(t, store, &AdminPasswordResetToken{}); got != resetTokensBefore {
+		t.Fatalf("wrong methods changed reset tokens: got %d, want %d", got, resetTokensBefore)
+	}
+	if got := adminIdentityAPIKeyMethodModelCount(t, store, &AdminSession{}); got != sessionsBefore {
+		t.Fatalf("wrong methods changed admin sessions: got %d, want %d", got, sessionsBefore)
+	}
+	select {
+	case message := <-messages:
+		t.Fatalf("wrong methods sent email: %s", message)
+	default:
+	}
+}
+
+func TestAdminIdentityAndAPIKeyMethodRoutesCoverUnsupportedStandardMethods(t *testing.T) {
+	_, _, app, adminToken, _, _, _, targetUserID, keyID := newAdminIdentityAPIKeyMethodRoutingServer(t)
+	for _, route := range adminIdentityAPIKeyMethodRoutes(targetUserID, keyID) {
+		for _, method := range unsupportedAdminIdentityAPIKeyMethods(route.allow) {
+			t.Run(route.name+"/"+method, func(t *testing.T) {
+				response := methodRoutingRequest(app, method, route.path, adminToken)
+				assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+				assertAllowHeader(t, response, route.allow)
+			})
+		}
+	}
+}
+
+func TestAdminAPIKeyMethodRoutesPreserveResourceAuthorizationBefore405(t *testing.T) {
+	store, _, app, adminToken, userToken, _, _, _, keyID := newAdminIdentityAPIKeyMethodRoutingServer(t)
+	otherProject := store.CreateProject(Project{Name: "Other Method Routing Project", Status: StatusActive})
+	otherKey, _, err := store.CreateAPIKey(otherProject.ID, APIKey{Name: "Other Method Routing Key", Status: StatusActive}, "thk_other_method_routing")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name  string
+		path  string
+		allow string
+	}{
+		{name: "item", path: "/api/admin/api-keys/" + otherKey.ID, allow: "PATCH, DELETE"},
+		{name: "rotate", path: "/api/admin/api-keys/" + otherKey.ID + "/rotate", allow: http.MethodPost},
+	} {
+		t.Run(test.name+"/inaccessible", func(t *testing.T) {
+			response := methodRoutingRequest(app, http.MethodGet, test.path, userToken)
+			assertJSONError(t, response, http.StatusForbidden, "api_key_forbidden")
+			assertAllowHeader(t, response, "")
+		})
+		t.Run(test.name+"/admin_missing", func(t *testing.T) {
+			path := "/api/admin/api-keys/missing"
+			if test.name == "rotate" {
+				path += "/rotate"
+			}
+			response := methodRoutingRequest(app, http.MethodGet, path, adminToken)
+			assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+			assertAllowHeader(t, response, test.allow)
+		})
+	}
+
+	accessible := methodRoutingRequest(app, http.MethodGet, "/api/admin/api-keys/"+keyID, userToken)
+	assertJSONError(t, accessible, http.StatusMethodNotAllowed, "method_not_allowed")
+	assertAllowHeader(t, accessible, "PATCH, DELETE")
+}
+
+func TestAdminIdentityAndAPIKeyMethodRoutesPreservePathBoundaries(t *testing.T) {
+	_, _, app, adminToken, _, _, _, targetUserID, keyID := newAdminIdentityAPIKeyMethodRoutingServer(t)
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantStatus int
+		wantCode   string
+		wantAllow  string
+	}{
+		{name: "empty user id", method: http.MethodGet, path: "/api/admin/users/", wantStatus: http.StatusNotFound, wantCode: "not_found"},
+		{name: "user trailing slash", method: http.MethodGet, path: "/api/admin/users/" + targetUserID + "/", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: "PATCH, DELETE"},
+		{name: "unknown user action", method: http.MethodGet, path: "/api/admin/users/" + targetUserID + "/unknown", wantStatus: http.StatusNotFound, wantCode: "not_found"},
+		{name: "reset wrong method", method: http.MethodGet, path: "/api/admin/users/" + targetUserID + "/reset-password-email", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: http.MethodPost},
+		{name: "import wrong dynamic method", method: http.MethodPatch, path: "/api/admin/users/import", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: http.MethodPost},
+		{name: "import trailing slash stays user item", method: http.MethodGet, path: "/api/admin/users/import/", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: "PATCH, DELETE"},
+		{name: "encoded user separator", method: http.MethodGet, path: "/api/admin/users/" + targetUserID + "%2Funknown", wantStatus: http.StatusNotFound, wantCode: "not_found"},
+		{name: "empty key id", method: http.MethodGet, path: "/api/admin/api-keys/", wantStatus: http.StatusNotFound, wantCode: "not_found"},
+		{name: "key trailing slash", method: http.MethodGet, path: "/api/admin/api-keys/" + keyID + "/", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: "PATCH, DELETE"},
+		{name: "unknown key action", method: http.MethodGet, path: "/api/admin/api-keys/" + keyID + "/unknown", wantStatus: http.StatusNotFound, wantCode: "not_found"},
+		{name: "rotate wrong method", method: http.MethodGet, path: "/api/admin/api-keys/" + keyID + "/rotate", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: http.MethodPost},
+		{name: "encoded key separator", method: http.MethodGet, path: "/api/admin/api-keys/" + keyID + "%2Funknown", wantStatus: http.StatusNotFound, wantCode: "not_found"},
+		{name: "encoded reset user separator", method: http.MethodGet, path: "/api/admin/users/" + targetUserID + "%2Funknown/reset-password-email", wantStatus: http.StatusNotFound, wantCode: "not_found"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := methodRoutingRequest(app, test.method, test.path, adminToken)
+			assertJSONError(t, response, test.wantStatus, test.wantCode)
+			assertAllowHeader(t, response, test.wantAllow)
+		})
+	}
+}
+
+func TestAdminIdentityAndAPIKeyMethodRoutesPreserveCORSPreflight(t *testing.T) {
+	_, _, app, _, _, _, _, targetUserID, keyID := newAdminIdentityAPIKeyMethodRoutingServer(t)
+	for _, route := range adminIdentityAPIKeyMethodRoutes(targetUserID, keyID) {
+		t.Run(route.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodOptions, route.path, nil)
+			request.Header.Set("origin", "https://console.example.com")
+			request.Header.Set("access-control-request-method", route.wrongMethod)
+			response := httptest.NewRecorder()
+			app.ServeHTTP(response, request)
+
+			if response.Code != http.StatusNoContent {
+				t.Fatalf("expected 204, got %d: %s", response.Code, response.Body.String())
+			}
+			if got := response.Header().Get("access-control-allow-methods"); got != "GET,POST,PUT,PATCH,DELETE,OPTIONS" {
+				t.Fatalf("access-control-allow-methods = %q", got)
+			}
+			assertAllowHeader(t, response, "")
+		})
+	}
+}
+
+func TestAdminIdentityAndAPIKeyMethodRoutesRejectRealHEAD(t *testing.T) {
+	_, _, app, adminToken, _, _, _, targetUserID, keyID := newAdminIdentityAPIKeyMethodRoutingServer(t)
+	httpServer := httptest.NewServer(app)
+	t.Cleanup(httpServer.Close)
+
+	for _, route := range adminIdentityAPIKeyMethodRoutes(targetUserID, keyID) {
+		t.Run(route.name, func(t *testing.T) {
+			request, err := http.NewRequest(http.MethodHead, httpServer.URL+route.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			request.Header.Set("authorization", "Bearer "+adminToken)
+			response, err := httpServer.Client().Do(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer response.Body.Close()
+			assertRealHEADResponse(t, response, http.StatusMethodNotAllowed, route.allow, "application/json", true)
+		})
+	}
+}
+
+func TestAdminIdentityAndAPIKeyMethodRoutesPreserveSuccessHandlers(t *testing.T) {
+	store, _, app, adminToken, _, _, _, targetUserID, keyID := newAdminIdentityAPIKeyMethodRoutingServer(t)
+
+	users := methodRoutingRequest(app, http.MethodGet, "/api/admin/users", adminToken)
+	if users.Code != http.StatusOK {
+		t.Fatalf("users GET: expected 200, got %d: %s", users.Code, users.Body.String())
+	}
+	createdUser := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/users", map[string]any{
+		"username": "created-method-user", "email": "created-method-user@tokenhub.local", "role": "user", "password": "created-method-password",
+	}, adminToken)
+	if createdUser.Code != http.StatusCreated {
+		t.Fatalf("users POST: expected 201, got %d: %s", createdUser.Code, createdUser.Body.String())
+	}
+	updatedUser := methodRoutingJSONRequest(t, app, http.MethodPatch, "/api/admin/users/"+targetUserID, map[string]any{"name": "Updated Method User"}, adminToken)
+	if updatedUser.Code != http.StatusOK {
+		t.Fatalf("user PATCH: expected 200, got %d: %s", updatedUser.Code, updatedUser.Body.String())
+	}
+
+	keys := methodRoutingRequest(app, http.MethodGet, "/api/admin/api-keys", adminToken)
+	if keys.Code != http.StatusOK {
+		t.Fatalf("API keys GET: expected 200, got %d: %s", keys.Code, keys.Body.String())
+	}
+	updatedKey := methodRoutingJSONRequest(t, app, http.MethodPatch, "/api/admin/api-keys/"+keyID, map[string]any{"name": "Updated Method Key"}, adminToken)
+	if updatedKey.Code != http.StatusOK {
+		t.Fatalf("API key PATCH: expected 200, got %d: %s", updatedKey.Code, updatedKey.Body.String())
+	}
+	rotatedKey := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/api-keys/"+keyID+"/rotate", map[string]any{}, adminToken)
+	if rotatedKey.Code != http.StatusCreated {
+		t.Fatalf("API key rotate: expected 201, got %d: %s", rotatedKey.Code, rotatedKey.Body.String())
+	}
+	var rotated struct {
+		ID     string `json:"id"`
+		APIKey string `json:"api_key"`
+	}
+	if err := json.NewDecoder(rotatedKey.Body).Decode(&rotated); err != nil {
+		t.Fatal(err)
+	}
+	if rotated.ID == "" || rotated.APIKey == "" {
+		t.Fatalf("incomplete rotate response: %#v", rotated)
+	}
+
+	deleteUser, err := store.CreateAdminUser(AdminUser{Username: "delete-method-user", Email: "delete-method-user@tokenhub.local", Role: "user", Status: StatusActive}, "delete-method-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deletedUser := methodRoutingRequest(app, http.MethodDelete, "/api/admin/users/"+deleteUser.ID, adminToken)
+	if deletedUser.Code != http.StatusNoContent {
+		t.Fatalf("user DELETE: expected 204, got %d: %s", deletedUser.Code, deletedUser.Body.String())
+	}
+	deleteKey, _, err := store.CreateAPIKey(defaultProjectID, APIKey{Name: "Delete Method Key", Status: StatusActive}, "thk_delete_method")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deletedKey := methodRoutingRequest(app, http.MethodDelete, "/api/admin/api-keys/"+deleteKey.ID, adminToken)
+	if deletedKey.Code != http.StatusNoContent {
+		t.Fatalf("API key DELETE: expected 204, got %d: %s", deletedKey.Code, deletedKey.Body.String())
+	}
+
+	wantAudit := map[string]bool{"create/admin_user": false, "update/admin_user": false, "delete/admin_user": false, "update/api_key": false, "delete/api_key": false, "rotate/api_key": false}
+	for _, event := range store.ListAuditEvents() {
+		key := event.Action + "/" + event.ResourceType
+		if _, ok := wantAudit[key]; ok {
+			wantAudit[key] = true
+		}
+	}
+	for event, found := range wantAudit {
+		if !found {
+			t.Fatalf("missing %s audit event", event)
+		}
+	}
+}
+
+func TestAdminUserMethodRoutesPreserveTeamLeaderScope(t *testing.T) {
+	store, _, app, _, _, teamLeaderToken, _, targetUserID, _ := newAdminIdentityAPIKeyMethodRoutingServer(t)
+	messages := configureTestSMTPChannel(t, store)
+	teamUser, err := store.CreateAdminUser(AdminUser{
+		Username: "leader-team-method-user", Email: "leader-team-method-user@tokenhub.local", Role: "user", TeamID: "team_platform", Status: StatusActive,
+	}, "leader-team-method-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	teamAdmin, err := store.CreateAdminUser(AdminUser{
+		Username: "leader-team-method-admin", Email: "leader-team-method-admin@tokenhub.local", Role: "admin", TeamID: "team_platform", Status: StatusActive,
+	}, "leader-team-admin-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/users", map[string]any{
+		"username": "leader-created-method-user", "email": "leader-created-method-user@tokenhub.local", "role": "user", "team_id": "team_platform", "password": "leader-created-password",
+	}, teamLeaderToken)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("team leader user create: expected 201, got %d: %s", created.Code, created.Body.String())
+	}
+	var createdUser AdminUser
+	if err := json.NewDecoder(created.Body).Decode(&createdUser); err != nil {
+		t.Fatal(err)
+	}
+	if createdUser.TeamID != "team_platform" || normalizeAdminRole(createdUser.Role) != "user" {
+		t.Fatalf("team leader created user outside enforced scope: %#v", createdUser)
+	}
+
+	roleCreate := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/users", map[string]any{
+		"username": "leader-created-method-admin", "email": "leader-created-method-admin@tokenhub.local", "role": "admin", "password": "leader-created-admin-password",
+	}, teamLeaderToken)
+	assertJSONError(t, roleCreate, http.StatusForbidden, "role_forbidden")
+	assertAllowHeader(t, roleCreate, "")
+
+	teamCreate := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/users", map[string]any{
+		"username": "leader-created-other-team", "email": "leader-created-other-team@tokenhub.local", "role": "user", "team_id": "team_other", "password": "leader-created-other-password",
+	}, teamLeaderToken)
+	assertJSONError(t, teamCreate, http.StatusForbidden, "team_forbidden")
+	assertAllowHeader(t, teamCreate, "")
+
+	updated := methodRoutingJSONRequest(t, app, http.MethodPatch, "/api/admin/users/"+teamUser.ID, map[string]any{"name": "Leader Updated Method User"}, teamLeaderToken)
+	if updated.Code != http.StatusOK {
+		t.Fatalf("team leader user update: expected 200, got %d: %s", updated.Code, updated.Body.String())
+	}
+	outsideUpdate := methodRoutingJSONRequest(t, app, http.MethodPatch, "/api/admin/users/"+targetUserID, map[string]any{"name": "Forbidden Update"}, teamLeaderToken)
+	assertJSONError(t, outsideUpdate, http.StatusForbidden, "team_forbidden")
+	roleUpdate := methodRoutingJSONRequest(t, app, http.MethodPatch, "/api/admin/users/"+teamUser.ID, map[string]any{"role": "admin"}, teamLeaderToken)
+	assertJSONError(t, roleUpdate, http.StatusForbidden, "role_forbidden")
+
+	resetRequest := httptest.NewRequest(http.MethodPost, "/api/admin/users/"+teamUser.ID+"/reset-password-email", nil)
+	resetRequest.Header.Set("authorization", "Bearer "+teamLeaderToken)
+	resetRequest.Header.Set("x-forwarded-proto", "https")
+	resetRequest.Header.Set("x-forwarded-host", "console.tokenhub.example")
+	resetResponse := httptest.NewRecorder()
+	app.ServeHTTP(resetResponse, resetRequest)
+	if resetResponse.Code != http.StatusOK {
+		t.Fatalf("team leader reset email: expected 200, got %d: %s", resetResponse.Code, resetResponse.Body.String())
+	}
+	select {
+	case message := <-messages:
+		if !strings.Contains(message, "To: "+teamUser.Email) || !strings.Contains(message, "https://console.tokenhub.example/?reset_token=") {
+			t.Fatalf("reset email did not preserve forwarded headers: %s", message)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for team leader reset email")
+	}
+	outsideReset := methodRoutingRequest(app, http.MethodPost, "/api/admin/users/"+targetUserID+"/reset-password-email", teamLeaderToken)
+	assertJSONError(t, outsideReset, http.StatusForbidden, "team_forbidden")
+
+	adminDelete := methodRoutingRequest(app, http.MethodDelete, "/api/admin/users/"+teamAdmin.ID, teamLeaderToken)
+	assertJSONError(t, adminDelete, http.StatusForbidden, "team_forbidden")
+	deleted := methodRoutingRequest(app, http.MethodDelete, "/api/admin/users/"+createdUser.ID, teamLeaderToken)
+	if deleted.Code != http.StatusNoContent {
+		t.Fatalf("team leader user delete: expected 204, got %d: %s", deleted.Code, deleted.Body.String())
+	}
+
+	imported := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/users/import", map[string]any{
+		"source": "team_leader_method_route_test",
+		"users": []map[string]any{{
+			"username": "leader-imported-method-user", "email": "leader-imported-method-user@tokenhub.local", "role": "user", "team_id": "team_other", "status": StatusActive,
+		}},
+	}, teamLeaderToken)
+	if imported.Code != http.StatusOK {
+		t.Fatalf("team leader user import: expected 200, got %d: %s", imported.Code, imported.Body.String())
+	}
+	assertPasswordResetEmail(t, messages, "leader-imported-method-user@tokenhub.local")
+	var importedUser AdminUser
+	for _, user := range store.ListAdminUsers() {
+		if user.Email == "leader-imported-method-user@tokenhub.local" {
+			importedUser = user
+			break
+		}
+	}
+	if importedUser.ID == "" || importedUser.TeamID != "team_platform" || normalizeAdminRole(importedUser.Role) != "user" {
+		t.Fatalf("team leader import escaped enforced scope: %#v", importedUser)
+	}
+}
+
+func TestAdminIdentityAndAPIKeyMethodRoutesPreserveSpecialPostHandlers(t *testing.T) {
+	store, _, app, adminToken, userToken, _, _, targetUserID, _ := newAdminIdentityAPIKeyMethodRoutingServer(t)
+	messages := configureTestSMTPChannel(t, store)
+
+	imported := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/users/import", map[string]any{
+		"source": "method_route_test",
+		"format": "json",
+		"users": []map[string]any{{
+			"username": "imported-method-user", "email": "imported-method-user@tokenhub.local", "role": "user", "status": StatusActive,
+		}},
+	}, adminToken)
+	if imported.Code != http.StatusOK {
+		t.Fatalf("users import POST: expected 200, got %d: %s", imported.Code, imported.Body.String())
+	}
+	assertPasswordResetEmail(t, messages, "imported-method-user@tokenhub.local")
+
+	reset := methodRoutingRequest(app, http.MethodPost, "/api/admin/users/"+targetUserID+"/reset-password-email", adminToken)
+	if reset.Code != http.StatusOK {
+		t.Fatalf("reset password email POST: expected 200, got %d: %s", reset.Code, reset.Body.String())
+	}
+	assertPasswordResetEmail(t, messages, "target-method-user@tokenhub.local")
+
+	createdKey := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/api-keys", map[string]any{"name": "Created Method Key"}, userToken)
+	if createdKey.Code != http.StatusCreated {
+		t.Fatalf("API keys POST: expected 201, got %d: %s", createdKey.Code, createdKey.Body.String())
+	}
+	var keyPayload struct {
+		ID     string `json:"id"`
+		APIKey string `json:"api_key"`
+	}
+	if err := json.NewDecoder(createdKey.Body).Decode(&keyPayload); err != nil {
+		t.Fatal(err)
+	}
+	if keyPayload.ID == "" || keyPayload.APIKey == "" {
+		t.Fatalf("incomplete API key create response: %#v", keyPayload)
+	}
+
+	wantAudit := map[string]bool{"import/admin_user": false, "send_reset_password_email/admin_user": false, "create/api_key": false}
+	for _, event := range store.ListAuditEvents() {
+		key := event.Action + "/" + event.ResourceType
+		if _, ok := wantAudit[key]; ok {
+			wantAudit[key] = true
+		}
+	}
+	for event, found := range wantAudit {
+		if !found {
+			t.Fatalf("missing %s audit event", event)
+		}
+	}
+}
+
+func TestAdminIdentityAndAPIKeyMethodRoutesPreserveTrailingSlashPostHandlers(t *testing.T) {
+	store, _, app, adminToken, _, _, _, targetUserID, keyID := newAdminIdentityAPIKeyMethodRoutingServer(t)
+	messages := configureTestSMTPChannel(t, store)
+
+	reset := methodRoutingRequest(app, http.MethodPost, "/api/admin/users/"+targetUserID+"/reset-password-email/", adminToken)
+	if reset.Code != http.StatusOK {
+		t.Fatalf("reset password email with trailing slash: expected 200, got %d: %s", reset.Code, reset.Body.String())
+	}
+	assertPasswordResetEmail(t, messages, "target-method-user@tokenhub.local")
+
+	rotated := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/api-keys/"+keyID+"/rotate/", map[string]any{}, adminToken)
+	if rotated.Code != http.StatusCreated {
+		t.Fatalf("API key rotate with trailing slash: expected 201, got %d: %s", rotated.Code, rotated.Body.String())
+	}
+	var payload struct {
+		ID     string `json:"id"`
+		APIKey string `json:"api_key"`
+	}
+	if err := json.NewDecoder(rotated.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.ID == "" || payload.APIKey == "" {
+		t.Fatalf("incomplete trailing-slash rotate response: %#v", payload)
+	}
+}
+
+func TestAdminIdentityAndAPIKeyMethodRoutesRejectEncodedPathSeparatorsWithoutSideEffects(t *testing.T) {
+	store, _, app, adminToken, _, _, _, targetUserID, keyID := newAdminIdentityAPIKeyMethodRoutingServer(t)
+	messages := configureTestSMTPChannel(t, store)
+	usersBefore := len(store.ListAdminUsers())
+	keysBefore := len(store.ListAPIKeys())
+	auditsBefore := len(store.ListAuditEvents())
+	resetTokensBefore := adminIdentityAPIKeyMethodModelCount(t, store, &AdminPasswordResetToken{})
+
+	for _, test := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "user patch", method: http.MethodPatch, path: "/api/admin/users/" + targetUserID + "%2Funknown"},
+		{name: "user reset", method: http.MethodPost, path: "/api/admin/users/" + targetUserID + "%2Funknown/reset-password-email"},
+		{name: "API key patch", method: http.MethodPatch, path: "/api/admin/api-keys/" + keyID + "%2Funknown"},
+		{name: "API key rotate", method: http.MethodPost, path: "/api/admin/api-keys/" + keyID + "%2Funknown/rotate"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			response := methodRoutingRequest(app, test.method, test.path, adminToken)
+			assertJSONError(t, response, http.StatusNotFound, "not_found")
+			assertAllowHeader(t, response, "")
+		})
+	}
+
+	if got := len(store.ListAdminUsers()); got != usersBefore {
+		t.Fatalf("encoded paths changed users: got %d, want %d", got, usersBefore)
+	}
+	if got := len(store.ListAPIKeys()); got != keysBefore {
+		t.Fatalf("encoded paths changed API keys: got %d, want %d", got, keysBefore)
+	}
+	if got := len(store.ListAuditEvents()); got != auditsBefore {
+		t.Fatalf("encoded paths changed audit events: got %d, want %d", got, auditsBefore)
+	}
+	if got := adminIdentityAPIKeyMethodModelCount(t, store, &AdminPasswordResetToken{}); got != resetTokensBefore {
+		t.Fatalf("encoded paths changed reset tokens: got %d, want %d", got, resetTokensBefore)
+	}
+	select {
+	case message := <-messages:
+		t.Fatalf("encoded paths sent email: %s", message)
+	default:
+	}
+}
+
+func adminIdentityAPIKeyMethodRoutes(userID string, keyID string) []adminIdentityAPIKeyMethodRoute {
+	return []adminIdentityAPIKeyMethodRoute{
+		{name: "users", path: "/api/admin/users", wrongMethod: http.MethodPut, allow: "GET, POST", resource: "identity"},
+		{name: "users import", path: "/api/admin/users/import", wrongMethod: http.MethodGet, allow: http.MethodPost, resource: "identity"},
+		{name: "user item", path: "/api/admin/users/" + userID, wrongMethod: http.MethodGet, allow: "PATCH, DELETE", resource: "identity"},
+		{name: "user reset email", path: "/api/admin/users/" + userID + "/reset-password-email", wrongMethod: http.MethodGet, allow: http.MethodPost, resource: "identity"},
+		{name: "API keys", path: "/api/admin/api-keys", wrongMethod: http.MethodPut, allow: "GET, POST", resource: "api_key"},
+		{name: "API key item", path: "/api/admin/api-keys/" + keyID, wrongMethod: http.MethodGet, allow: "PATCH, DELETE", resource: "api_key"},
+		{name: "API key rotate", path: "/api/admin/api-keys/" + keyID + "/rotate", wrongMethod: http.MethodGet, allow: http.MethodPost, resource: "api_key"},
+	}
+}
+
+func unsupportedAdminIdentityAPIKeyMethods(allow string) []string {
+	allowed := map[string]bool{}
+	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		if allow == method || allow == "GET, POST" && (method == http.MethodGet || method == http.MethodPost) || allow == "PATCH, DELETE" && (method == http.MethodPatch || method == http.MethodDelete) {
+			allowed[method] = true
+		}
+	}
+	methods := []string{}
+	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		if !allowed[method] {
+			methods = append(methods, method)
+		}
+	}
+	return methods
+}
+
+func newAdminIdentityAPIKeyMethodRoutingServer(t *testing.T) (*GormStore, *Server, http.Handler, string, string, string, string, string, string) {
+	t.Helper()
+	config := ConfigFromEnv()
+	config.AdminToken = "dev_admin_token"
+	config.BootstrapAdminPassword = "identity-api-key-method-password"
+	store := NewMemoryStoreWithConfig(config)
+	if err := BootstrapBaseDataWithConfig(store, config); err != nil {
+		t.Fatal(err)
+	}
+	target, err := store.CreateAdminUser(AdminUser{Username: "target-method-user", Email: "target-method-user@tokenhub.local", Role: "user", Status: StatusActive}, "target-method-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ordinary, ordinaryToken := createAdminIdentityAPIKeyMethodSession(t, store, AdminUser{Username: "ordinary-method-user", Email: "ordinary-method-user@tokenhub.local", Role: "user", Status: StatusActive})
+	_, teamLeaderToken := createAdminIdentityAPIKeyMethodSession(t, store, AdminUser{Username: "leader-method-user", Email: "leader-method-user@tokenhub.local", Role: "team_leader", TeamID: "team_platform", Status: StatusActive})
+	_, securityToken := createAdminIdentityAPIKeyMethodSession(t, store, AdminUser{Username: "security-method-user", Email: "security-method-user@tokenhub.local", Role: "security_admin", Status: StatusActive})
+	key, _, err := store.CreateAPIKey(defaultProjectID, APIKey{Name: "Owned Method Routing Key", OwnerUserID: ordinary.ID, Status: StatusActive}, "thk_owned_method_routing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := NewWithConfig(store, config)
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+	app := server.Handler()
+	adminToken, _ := loginMethodRoutingAdmin(t, app, config.BootstrapAdminPassword)
+	return store, server, app, adminToken, ordinaryToken, teamLeaderToken, securityToken, target.ID, key.ID
+}
+
+func createAdminIdentityAPIKeyMethodSession(t *testing.T, store *GormStore, user AdminUser) (AdminUser, string) {
+	t.Helper()
+	created, err := store.CreateAdminUser(user, "identity-api-key-role-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, session, err := store.CreateAdminSession(created.ID, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return created, session.Token
+}
+
+func adminIdentityAPIKeyMethodModelCount(t *testing.T, store *GormStore, model any) int64 {
+	t.Helper()
+	var count int64
+	if err := store.db.Model(model).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	return count
+}

--- a/backend/internal/server/admin_operations_http.go
+++ b/backend/internal/server/admin_operations_http.go
@@ -202,6 +202,19 @@ func (s *Server) handleAdminProjectQuotaIncrease(w http.ResponseWriter, r *http.
 	writeJSON(w, http.StatusAccepted, map[string]any{"approval_required": true, "approval": approval})
 }
 
+func (s *Server) handleAdminProjectQuotaIncreasePost(w http.ResponseWriter, r *http.Request) {
+	projectID := r.PathValue("project_id")
+	if projectID == "" || strings.Contains(projectID, "/") {
+		s.handleAdminProjectNested(w, r)
+		return
+	}
+	user, ok := s.requireAdmin(w, r, "approval", r.Method)
+	if !ok {
+		return
+	}
+	s.handleAdminProjectQuotaIncrease(w, r, user, projectID)
+}
+
 func (s *Server) ensureDefaultMonitors() {
 	existing := s.store.ListResources("monitors")
 	existingIDs := map[string]bool{}

--- a/backend/internal/server/admin_projects_http.go
+++ b/backend/internal/server/admin_projects_http.go
@@ -69,43 +69,44 @@ func (s *Server) handleAdminOverview(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (s *Server) handleAdminProjects(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleAdminProjectsGet(w http.ResponseWriter, r *http.Request) {
 	user, ok := s.requireAdmin(w, r, "project", r.Method)
 	if !ok {
 		return
 	}
-	switch r.Method {
-	case http.MethodGet:
-		writeJSON(w, http.StatusOK, map[string]any{"data": s.filterProjectsForUser(user, s.store.ListProjects())})
-	case http.MethodPost:
-		var req Project
-		if err := s.decodeJSON(w, r, &req); err != nil {
-			writeError(w, r, err)
-			return
-		}
-		if normalizeAdminRole(user.Role) == "team_leader" {
-			if strings.TrimSpace(user.TeamID) == "" {
-				writeError(w, r, NewHTTPError(403, "team_required", "Team leader must belong to a team"))
-				return
-			}
-			req.TeamID = user.TeamID
-			if strings.TrimSpace(req.OwnerUserID) == "" {
-				req.OwnerUserID = user.ID
-			}
-		}
-		project, err := s.store.CreateProjectChecked(req)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "create", "project", project.ID, "", project)
-		if link, found := projectTeamByID(project.Teams, project.TeamID); found {
-			s.recordAdminAudit(r, user, "create", "project_team", projectTeamAuditID(project.ID, link.TeamID), nil, link)
-		}
-		writeJSON(w, http.StatusCreated, project)
-	default:
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
+	writeJSON(w, http.StatusOK, map[string]any{"data": s.filterProjectsForUser(user, s.store.ListProjects())})
+}
+
+func (s *Server) handleAdminProjectsPost(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAdmin(w, r, "project", r.Method)
+	if !ok {
+		return
 	}
+	var req Project
+	if err := s.decodeJSON(w, r, &req); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	if normalizeAdminRole(user.Role) == "team_leader" {
+		if strings.TrimSpace(user.TeamID) == "" {
+			writeError(w, r, NewHTTPError(403, "team_required", "Team leader must belong to a team"))
+			return
+		}
+		req.TeamID = user.TeamID
+		if strings.TrimSpace(req.OwnerUserID) == "" {
+			req.OwnerUserID = user.ID
+		}
+	}
+	project, err := s.store.CreateProjectChecked(req)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "create", "project", project.ID, "", project)
+	if link, found := projectTeamByID(project.Teams, project.TeamID); found {
+		s.recordAdminAudit(r, user, "create", "project_team", projectTeamAuditID(project.ID, link.TeamID), nil, link)
+	}
+	writeJSON(w, http.StatusCreated, project)
 }
 
 func (s *Server) handleAdminProjectNested(w http.ResponseWriter, r *http.Request) {
@@ -141,63 +142,9 @@ func (s *Server) handleAdminProjectNested(w http.ResponseWriter, r *http.Request
 	if len(parts) == 1 {
 		switch r.Method {
 		case http.MethodPatch:
-			beforeProject, _ := s.store.GetProject(projectID)
-			var req Project
-			if err := s.decodeJSON(w, r, &req); err != nil {
-				writeError(w, r, err)
-				return
-			}
-			if normalizeAdminRole(user.Role) == "team_leader" {
-				existing, err := s.findProject(projectID)
-				if err != nil {
-					writeError(w, r, err)
-					return
-				}
-				if !s.canManageProject(user, existing) {
-					writeError(w, r, NewHTTPError(403, "project_forbidden", "Project is not available for this user"))
-					return
-				}
-				req.TeamID = existing.TeamID
-				if strings.TrimSpace(req.OwnerUserID) == "" {
-					req.OwnerUserID = existing.OwnerUserID
-				}
-			}
-			project, err := s.store.UpdateProject(projectID, req)
-			if err != nil {
-				writeError(w, r, err)
-				return
-			}
-			s.recordAdminAudit(r, user, "update", "project", project.ID, beforeProject, project)
-			if project.TeamID != "" {
-				if _, existed := projectTeamByID(beforeProject.Teams, project.TeamID); !existed {
-					if link, found := projectTeamByID(project.Teams, project.TeamID); found {
-						s.recordAdminAudit(r, user, "create", "project_team", projectTeamAuditID(project.ID, link.TeamID), nil, link)
-					}
-				}
-			}
-			writeJSON(w, http.StatusOK, project)
+			s.serveAdminProjectPatch(w, r, user, projectID)
 		case http.MethodDelete:
-			beforeProject, _ := s.store.GetProject(projectID)
-			if normalizeAdminRole(user.Role) == "team_leader" {
-				existing, err := s.findProject(projectID)
-				if err != nil {
-					writeError(w, r, err)
-					return
-				}
-				if !s.canManageProject(user, existing) {
-					writeError(w, r, NewHTTPError(403, "project_forbidden", "Project is not available for this user"))
-					return
-				}
-			}
-			if err := s.store.DeleteProject(projectID); err != nil {
-				writeError(w, r, err)
-				return
-			}
-			s.recordAdminAudit(r, user, "delete", "project", projectID, "", nil)
-			for _, link := range beforeProject.Teams {
-				s.recordAdminAudit(r, user, "delete", "project_team", projectTeamAuditID(projectID, link.TeamID), link, nil)
-			}
-			w.WriteHeader(http.StatusNoContent)
+			s.serveAdminProjectDelete(w, r, user, projectID)
 		default:
 			writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
 		}
@@ -209,20 +156,327 @@ func (s *Server) handleAdminProjectNested(w http.ResponseWriter, r *http.Request
 	}
 	switch r.Method {
 	case http.MethodGet:
-		if !s.canUseProjectForAPIKey(user, projectID) {
-			writeError(w, r, NewHTTPError(403, "project_forbidden", "Project is not available for this user"))
-			return
-		}
-		writeJSON(w, http.StatusOK, map[string]any{"data": s.filterAPIKeysForUser(user, s.store.ListProjectKeys(projectID))})
+		s.serveAdminProjectKeysGet(w, r, user, projectID)
 	case http.MethodPost:
-		if !s.canUseProjectForAPIKey(user, projectID) {
-			writeError(w, r, NewHTTPError(403, "project_forbidden", "Project is not available for this user"))
-			return
-		}
-		s.handleAdminAPIKeyCreate(w, r, user, projectID)
+		s.serveAdminProjectKeysPost(w, r, user, projectID)
 	default:
 		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
 	}
+}
+
+func (s *Server) handleAdminProjectPatch(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminProjectItemRoute(w, r, "project", s.serveAdminProjectPatch)
+}
+
+func (s *Server) handleAdminProjectDelete(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminProjectItemRoute(w, r, "project", s.serveAdminProjectDelete)
+}
+
+func (s *Server) handleAdminProjectKeysGet(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminProjectItemRoute(w, r, "api_key", s.serveAdminProjectKeysGet)
+}
+
+func (s *Server) handleAdminProjectKeysPost(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminProjectItemRoute(w, r, "api_key", s.serveAdminProjectKeysPost)
+}
+
+func (s *Server) handleAdminProjectItemRoute(w http.ResponseWriter, r *http.Request, permission string, handler func(http.ResponseWriter, *http.Request, AdminUser, string)) {
+	projectID := r.PathValue("project_id")
+	if projectID == "" || strings.Contains(projectID, "/") {
+		s.handleAdminProjectNested(w, r)
+		return
+	}
+	user, ok := s.requireAdmin(w, r, permission, r.Method)
+	if !ok {
+		return
+	}
+	handler(w, r, user, projectID)
+}
+
+func (s *Server) adminProjectMethodNotAllowed(permission string, allowedMethods string) http.HandlerFunc {
+	reject := jsonMethodNotAllowed(allowedMethods)
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := r.PathValue("project_id")
+		if projectID == "" || strings.Contains(projectID, "/") {
+			s.handleAdminProjectNested(w, r)
+			return
+		}
+		if _, ok := s.requireAdmin(w, r, permission, r.Method); !ok {
+			return
+		}
+		reject(w, r)
+	}
+}
+
+func (s *Server) serveAdminProjectPatch(w http.ResponseWriter, r *http.Request, user AdminUser, projectID string) {
+	beforeProject, _ := s.store.GetProject(projectID)
+	var req Project
+	if err := s.decodeJSON(w, r, &req); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	if normalizeAdminRole(user.Role) == "team_leader" {
+		existing, err := s.findProject(projectID)
+		if err != nil {
+			writeError(w, r, err)
+			return
+		}
+		if !s.canManageProject(user, existing) {
+			writeError(w, r, NewHTTPError(403, "project_forbidden", "Project is not available for this user"))
+			return
+		}
+		req.TeamID = existing.TeamID
+		if strings.TrimSpace(req.OwnerUserID) == "" {
+			req.OwnerUserID = existing.OwnerUserID
+		}
+	}
+	project, err := s.store.UpdateProject(projectID, req)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "update", "project", project.ID, beforeProject, project)
+	if project.TeamID != "" {
+		if _, existed := projectTeamByID(beforeProject.Teams, project.TeamID); !existed {
+			if link, found := projectTeamByID(project.Teams, project.TeamID); found {
+				s.recordAdminAudit(r, user, "create", "project_team", projectTeamAuditID(project.ID, link.TeamID), nil, link)
+			}
+		}
+	}
+	writeJSON(w, http.StatusOK, project)
+}
+
+func (s *Server) serveAdminProjectDelete(w http.ResponseWriter, r *http.Request, user AdminUser, projectID string) {
+	beforeProject, _ := s.store.GetProject(projectID)
+	if normalizeAdminRole(user.Role) == "team_leader" {
+		existing, err := s.findProject(projectID)
+		if err != nil {
+			writeError(w, r, err)
+			return
+		}
+		if !s.canManageProject(user, existing) {
+			writeError(w, r, NewHTTPError(403, "project_forbidden", "Project is not available for this user"))
+			return
+		}
+	}
+	if err := s.store.DeleteProject(projectID); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "delete", "project", projectID, "", nil)
+	for _, link := range beforeProject.Teams {
+		s.recordAdminAudit(r, user, "delete", "project_team", projectTeamAuditID(projectID, link.TeamID), link, nil)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) serveAdminProjectKeysGet(w http.ResponseWriter, r *http.Request, user AdminUser, projectID string) {
+	if !s.canUseProjectForAPIKey(user, projectID) {
+		writeError(w, r, NewHTTPError(403, "project_forbidden", "Project is not available for this user"))
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"data": s.filterAPIKeysForUser(user, s.store.ListProjectKeys(projectID))})
+}
+
+func (s *Server) serveAdminProjectKeysPost(w http.ResponseWriter, r *http.Request, user AdminUser, projectID string) {
+	if !s.canUseProjectForAPIKey(user, projectID) {
+		writeError(w, r, NewHTTPError(403, "project_forbidden", "Project is not available for this user"))
+		return
+	}
+	s.handleAdminAPIKeyCreate(w, r, user, projectID)
+}
+
+func (s *Server) handleAdminProjectTeamsGet(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminProjectTeamRoute(w, r, false, s.serveAdminProjectTeamsGet)
+}
+
+func (s *Server) handleAdminProjectTeamsPost(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminProjectTeamRoute(w, r, true, s.serveAdminProjectTeamsPost)
+}
+
+func (s *Server) handleAdminProjectTeamPatch(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminProjectTeamItemRoute(w, r, s.serveAdminProjectTeamPatch)
+}
+
+func (s *Server) handleAdminProjectTeamDelete(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminProjectTeamItemRoute(w, r, s.serveAdminProjectTeamDelete)
+}
+
+func (s *Server) handleAdminProjectTeamRoute(w http.ResponseWriter, r *http.Request, manage bool, handler func(http.ResponseWriter, *http.Request, AdminUser, Project)) {
+	projectID := r.PathValue("project_id")
+	if projectID == "" || strings.Contains(projectID, "/") {
+		s.handleAdminProjectNested(w, r)
+		return
+	}
+	user, ok := s.requireAdmin(w, r, "project", r.Method)
+	if !ok {
+		return
+	}
+	project, ok := s.store.GetProject(projectID)
+	if !ok {
+		writeError(w, r, NewHTTPError(http.StatusNotFound, "project_not_found", "Project not found"))
+		return
+	}
+	if manage && !s.canManageProject(user, project) {
+		writeError(w, r, NewHTTPError(http.StatusForbidden, "project_forbidden", "Project management permission is required"))
+		return
+	}
+	if !manage && !s.canAccessProject(user, project) {
+		writeError(w, r, NewHTTPError(http.StatusForbidden, "project_forbidden", "Project is not available for this user"))
+		return
+	}
+	handler(w, r, user, project)
+}
+
+func (s *Server) handleAdminProjectTeamItemRoute(w http.ResponseWriter, r *http.Request, handler func(http.ResponseWriter, *http.Request, AdminUser, Project, string)) {
+	teamID := r.PathValue("team_id")
+	if teamID == "" || strings.Contains(teamID, "/") {
+		s.handleAdminProjectNested(w, r)
+		return
+	}
+	teamID = strings.TrimSpace(teamID)
+	s.handleAdminProjectTeamRoute(w, r, true, func(w http.ResponseWriter, r *http.Request, user AdminUser, project Project) {
+		handler(w, r, user, project, teamID)
+	})
+}
+
+func (s *Server) adminProjectTeamsMethodNotAllowed(allowedMethods string) http.HandlerFunc {
+	reject := jsonMethodNotAllowed(allowedMethods)
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := r.PathValue("project_id")
+		if projectID == "" || strings.Contains(projectID, "/") {
+			s.handleAdminProjectNested(w, r)
+			return
+		}
+		user, ok := s.requireAdmin(w, r, "project", r.Method)
+		if !ok {
+			return
+		}
+		project, ok := s.store.GetProject(projectID)
+		if !ok {
+			writeError(w, r, NewHTTPError(http.StatusNotFound, "project_not_found", "Project not found"))
+			return
+		}
+		if !s.canManageProject(user, project) {
+			writeError(w, r, NewHTTPError(http.StatusForbidden, "project_forbidden", "Project management permission is required"))
+			return
+		}
+		reject(w, r)
+	}
+}
+
+func (s *Server) adminProjectTeamMethodNotAllowed(allowedMethods string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		projectID := r.PathValue("project_id")
+		teamID := r.PathValue("team_id")
+		if projectID == "" || teamID == "" || strings.Contains(projectID, "/") || strings.Contains(teamID, "/") {
+			s.handleAdminProjectNested(w, r)
+			return
+		}
+		user, ok := s.requireAdmin(w, r, "project", r.Method)
+		if !ok {
+			return
+		}
+		project, ok := s.store.GetProject(projectID)
+		if !ok {
+			writeError(w, r, NewHTTPError(http.StatusNotFound, "project_not_found", "Project not found"))
+			return
+		}
+		if r.Method == http.MethodGet {
+			writeError(w, r, NewHTTPError(http.StatusForbidden, "project_forbidden", "Project is not available for this user"))
+			return
+		}
+		if !s.canManageProject(user, project) {
+			writeError(w, r, NewHTTPError(http.StatusForbidden, "project_forbidden", "Project management permission is required"))
+			return
+		}
+		jsonMethodNotAllowed(allowedMethods)(w, r)
+	}
+}
+
+func (s *Server) serveAdminProjectTeamsGet(w http.ResponseWriter, r *http.Request, _ AdminUser, project Project) {
+	limit := projectTeamPageValue(r.URL.Query().Get("limit"), 50, 1, 200)
+	offset := projectTeamPageValue(r.URL.Query().Get("offset"), 0, 0, math.MaxInt)
+	links, total, err := s.store.ListProjectTeams(project.ID, offset, limit)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"data": links, "total": total, "limit": limit, "offset": offset})
+}
+
+func (s *Server) serveAdminProjectTeamsPost(w http.ResponseWriter, r *http.Request, user AdminUser, project Project) {
+	var req struct {
+		TeamID string `json:"team_id"`
+		Role   string `json:"role"`
+	}
+	if err := s.decodeJSON(w, r, &req); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	req.TeamID = strings.TrimSpace(req.TeamID)
+	req.Role = normalizeProjectAccessRole(req.Role)
+	if req.TeamID == "" || !validProjectTeamRole(req.Role) {
+		writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_project_team", "team_id and a viewer, developer, or maintainer role are required"))
+		return
+	}
+	team, err := s.findResource("teams", req.TeamID)
+	if err != nil {
+		writeError(w, r, NewHTTPError(http.StatusNotFound, "team_not_found", "Team not found"))
+		return
+	}
+	if team.Status != "" && team.Status != StatusActive {
+		writeError(w, r, NewHTTPError(http.StatusBadRequest, "team_inactive", "Only an active team can be linked to a project"))
+		return
+	}
+	link, err := s.store.AddProjectTeam(ProjectTeam{ProjectID: project.ID, TeamID: req.TeamID, Role: req.Role})
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "create", "project_team", projectTeamAuditID(project.ID, req.TeamID), nil, link)
+	writeJSON(w, http.StatusCreated, link)
+}
+
+func (s *Server) serveAdminProjectTeamPatch(w http.ResponseWriter, r *http.Request, user AdminUser, project Project, teamID string) {
+	var req struct {
+		Role string `json:"role"`
+	}
+	if err := s.decodeJSON(w, r, &req); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	req.Role = normalizeProjectAccessRole(req.Role)
+	if teamID == "" || !validProjectTeamRole(req.Role) {
+		writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_project_team", "A viewer, developer, or maintainer role is required"))
+		return
+	}
+	before, found := projectTeamByID(project.Teams, teamID)
+	if !found {
+		writeError(w, r, NewHTTPError(http.StatusNotFound, "project_team_not_found", "Project team link not found"))
+		return
+	}
+	link, err := s.store.UpdateProjectTeam(project.ID, teamID, req.Role)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "update", "project_team", projectTeamAuditID(project.ID, teamID), before, link)
+	writeJSON(w, http.StatusOK, link)
+}
+
+func (s *Server) serveAdminProjectTeamDelete(w http.ResponseWriter, r *http.Request, user AdminUser, project Project, teamID string) {
+	before, found := projectTeamByID(project.Teams, teamID)
+	if !found {
+		writeError(w, r, NewHTTPError(http.StatusNotFound, "project_team_not_found", "Project team link not found"))
+		return
+	}
+	if err := s.store.RemoveProjectTeam(project.ID, teamID); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "delete", "project_team", projectTeamAuditID(project.ID, teamID), before, nil)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) handleAdminProjectTeams(w http.ResponseWriter, r *http.Request, user AdminUser, projectID string, parts []string) {
@@ -236,14 +490,7 @@ func (s *Server) handleAdminProjectTeams(w http.ResponseWriter, r *http.Request,
 			writeError(w, r, NewHTTPError(http.StatusForbidden, "project_forbidden", "Project is not available for this user"))
 			return
 		}
-		limit := projectTeamPageValue(r.URL.Query().Get("limit"), 50, 1, 200)
-		offset := projectTeamPageValue(r.URL.Query().Get("offset"), 0, 0, math.MaxInt)
-		links, total, err := s.store.ListProjectTeams(projectID, offset, limit)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		writeJSON(w, http.StatusOK, map[string]any{"data": links, "total": total, "limit": limit, "offset": offset})
+		s.serveAdminProjectTeamsGet(w, r, user, project)
 		return
 	}
 	if !s.canManageProject(user, project) {
@@ -253,75 +500,11 @@ func (s *Server) handleAdminProjectTeams(w http.ResponseWriter, r *http.Request,
 
 	switch {
 	case len(parts) == 2 && r.Method == http.MethodPost:
-		var req struct {
-			TeamID string `json:"team_id"`
-			Role   string `json:"role"`
-		}
-		if err := s.decodeJSON(w, r, &req); err != nil {
-			writeError(w, r, err)
-			return
-		}
-		req.TeamID = strings.TrimSpace(req.TeamID)
-		req.Role = normalizeProjectAccessRole(req.Role)
-		if req.TeamID == "" || !validProjectTeamRole(req.Role) {
-			writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_project_team", "team_id and a viewer, developer, or maintainer role are required"))
-			return
-		}
-		team, err := s.findResource("teams", req.TeamID)
-		if err != nil {
-			writeError(w, r, NewHTTPError(http.StatusNotFound, "team_not_found", "Team not found"))
-			return
-		}
-		if team.Status != "" && team.Status != StatusActive {
-			writeError(w, r, NewHTTPError(http.StatusBadRequest, "team_inactive", "Only an active team can be linked to a project"))
-			return
-		}
-		link, err := s.store.AddProjectTeam(ProjectTeam{ProjectID: projectID, TeamID: req.TeamID, Role: req.Role})
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "create", "project_team", projectTeamAuditID(projectID, req.TeamID), nil, link)
-		writeJSON(w, http.StatusCreated, link)
+		s.serveAdminProjectTeamsPost(w, r, user, project)
 	case len(parts) == 3 && r.Method == http.MethodPatch:
-		teamID := strings.TrimSpace(parts[2])
-		var req struct {
-			Role string `json:"role"`
-		}
-		if err := s.decodeJSON(w, r, &req); err != nil {
-			writeError(w, r, err)
-			return
-		}
-		req.Role = normalizeProjectAccessRole(req.Role)
-		if teamID == "" || !validProjectTeamRole(req.Role) {
-			writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_project_team", "A viewer, developer, or maintainer role is required"))
-			return
-		}
-		before, found := projectTeamByID(project.Teams, teamID)
-		if !found {
-			writeError(w, r, NewHTTPError(http.StatusNotFound, "project_team_not_found", "Project team link not found"))
-			return
-		}
-		link, err := s.store.UpdateProjectTeam(projectID, teamID, req.Role)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "update", "project_team", projectTeamAuditID(projectID, teamID), before, link)
-		writeJSON(w, http.StatusOK, link)
+		s.serveAdminProjectTeamPatch(w, r, user, project, strings.TrimSpace(parts[2]))
 	case len(parts) == 3 && r.Method == http.MethodDelete:
-		teamID := strings.TrimSpace(parts[2])
-		before, found := projectTeamByID(project.Teams, teamID)
-		if !found {
-			writeError(w, r, NewHTTPError(http.StatusNotFound, "project_team_not_found", "Project team link not found"))
-			return
-		}
-		if err := s.store.RemoveProjectTeam(projectID, teamID); err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "delete", "project_team", projectTeamAuditID(projectID, teamID), before, nil)
-		w.WriteHeader(http.StatusNoContent)
+		s.serveAdminProjectTeamDelete(w, r, user, project, strings.TrimSpace(parts[2]))
 	default:
 		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
 	}

--- a/backend/internal/server/admin_projects_http.go
+++ b/backend/internal/server/admin_projects_http.go
@@ -534,59 +534,60 @@ func projectTeamAuditID(projectID string, teamID string) string {
 	return strings.TrimSpace(projectID) + ":" + strings.TrimSpace(teamID)
 }
 
-func (s *Server) handleAdminUsers(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleAdminUsersGet(w http.ResponseWriter, r *http.Request) {
 	actor, ok := s.requireAdmin(w, r, "identity", r.Method)
 	if !ok {
 		return
 	}
-	switch r.Method {
-	case http.MethodGet:
-		writeJSON(w, http.StatusOK, map[string]any{"data": s.filterAdminUsersForUser(actor, s.store.ListAdminUsers())})
-	case http.MethodPost:
-		var req struct {
-			Username string   `json:"username"`
-			Name     string   `json:"name"`
-			Email    string   `json:"email"`
-			Role     string   `json:"role"`
-			TeamID   string   `json:"team_id"`
-			TeamIDs  []string `json:"team_ids"`
-			Status   string   `json:"status"`
-			Password string   `json:"password"`
-		}
-		if err := s.decodeJSON(w, r, &req); err != nil {
-			writeError(w, r, err)
-			return
-		}
-		if normalizeAdminRole(actor.Role) == "team_leader" {
-			if req.TeamID != "" && req.TeamID != actor.TeamID {
-				writeError(w, r, NewHTTPError(403, "team_forbidden", "Team leader can only manage own team"))
-				return
-			}
-			req.TeamID = actor.TeamID
-			req.TeamIDs = []string{actor.TeamID}
-			if normalizeAdminRole(req.Role) != "user" {
-				writeError(w, r, NewHTTPError(403, "role_forbidden", "Team leader can only create ordinary users"))
-				return
-			}
-		}
-		user, err := s.store.CreateAdminUser(AdminUser{
-			Username: req.Username,
-			Name:     req.Name,
-			Email:    req.Email,
-			Role:     req.Role,
-			TeamID:   req.TeamID,
-			TeamIDs:  req.TeamIDs,
-			Status:   req.Status,
-		}, req.Password)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, actor, "create", "admin_user", user.ID, "", user)
-		writeJSON(w, http.StatusCreated, user)
-	default:
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
+	writeJSON(w, http.StatusOK, map[string]any{"data": s.filterAdminUsersForUser(actor, s.store.ListAdminUsers())})
+}
+
+func (s *Server) handleAdminUsersPost(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.requireAdmin(w, r, "identity", r.Method)
+	if !ok {
+		return
 	}
+	var req struct {
+		Username string   `json:"username"`
+		Name     string   `json:"name"`
+		Email    string   `json:"email"`
+		Role     string   `json:"role"`
+		TeamID   string   `json:"team_id"`
+		TeamIDs  []string `json:"team_ids"`
+		Status   string   `json:"status"`
+		Password string   `json:"password"`
+	}
+	if err := s.decodeJSON(w, r, &req); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	if normalizeAdminRole(actor.Role) == "team_leader" {
+		if req.TeamID != "" && req.TeamID != actor.TeamID {
+			writeError(w, r, NewHTTPError(403, "team_forbidden", "Team leader can only manage own team"))
+			return
+		}
+		req.TeamID = actor.TeamID
+		req.TeamIDs = []string{actor.TeamID}
+		if normalizeAdminRole(req.Role) != "user" {
+			writeError(w, r, NewHTTPError(403, "role_forbidden", "Team leader can only create ordinary users"))
+			return
+		}
+	}
+	user, err := s.store.CreateAdminUser(AdminUser{
+		Username: req.Username,
+		Name:     req.Name,
+		Email:    req.Email,
+		Role:     req.Role,
+		TeamID:   req.TeamID,
+		TeamIDs:  req.TeamIDs,
+		Status:   req.Status,
+	}, req.Password)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, actor, "create", "admin_user", user.ID, "", user)
+	writeJSON(w, http.StatusCreated, user)
 }
 
 type adminUserImportItem struct {
@@ -598,13 +599,9 @@ type adminUserImportItem struct {
 	Status   string `json:"status"`
 }
 
-func (s *Server) handleAdminUsersImport(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleAdminUsersImportPost(w http.ResponseWriter, r *http.Request) {
 	actor, ok := s.requireAdmin(w, r, "identity", r.Method)
 	if !ok {
-		return
-	}
-	if r.Method != http.MethodPost {
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
 		return
 	}
 	var req struct {
@@ -880,10 +877,18 @@ func (s *Server) handleAdminUserItem(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, NewHTTPError(404, "not_found", "Not found"))
 		return
 	}
+	if r.URL.Path == "/api/admin/users/import" {
+		jsonMethodNotAllowed(http.MethodPost)(w, r)
+		return
+	}
 	userID := parts[0]
 	if len(parts) == 2 {
-		if parts[1] != "reset-password-email" || r.Method != http.MethodPost {
+		if parts[1] != "reset-password-email" {
 			writeError(w, r, NewHTTPError(404, "not_found", "Not found"))
+			return
+		}
+		if r.Method != http.MethodPost {
+			jsonMethodNotAllowed(http.MethodPost)(w, r)
 			return
 		}
 		s.handleAdminUserResetPasswordEmail(w, r, actor, userID)
@@ -891,74 +896,131 @@ func (s *Server) handleAdminUserItem(w http.ResponseWriter, r *http.Request) {
 	}
 	switch r.Method {
 	case http.MethodPatch:
-		var req struct {
-			Username string   `json:"username"`
-			Name     string   `json:"name"`
-			Email    string   `json:"email"`
-			Role     string   `json:"role"`
-			TeamID   string   `json:"team_id"`
-			TeamIDs  []string `json:"team_ids"`
-			Status   string   `json:"status"`
-			Password string   `json:"password"`
-		}
-		if err := s.decodeJSON(w, r, &req); err != nil {
-			writeError(w, r, err)
-			return
-		}
-		if normalizeAdminRole(actor.Role) == "team_leader" {
-			target, ok := s.findAdminUser(userID)
-			if !ok || !userHasTeam(target, actor.TeamID) || normalizeAdminRole(target.Role) != "user" {
-				writeError(w, r, NewHTTPError(403, "team_forbidden", "Team leader can only manage ordinary users in own team"))
-				return
-			}
-			if req.TeamID != "" && req.TeamID != actor.TeamID {
-				writeError(w, r, NewHTTPError(403, "team_forbidden", "Team leader can only manage own team"))
-				return
-			}
-			req.TeamID = actor.TeamID
-			req.TeamIDs = []string{actor.TeamID}
-			if req.Role != "" && normalizeAdminRole(req.Role) != "user" {
-				writeError(w, r, NewHTTPError(403, "role_forbidden", "Team leader cannot elevate user role"))
-				return
-			}
-			req.Role = "user"
-		}
-		updatedUser, err := s.store.UpdateAdminUser(userID, AdminUser{
-			Username: req.Username,
-			Name:     req.Name,
-			Email:    req.Email,
-			Role:     req.Role,
-			TeamID:   req.TeamID,
-			TeamIDs:  req.TeamIDs,
-			Status:   req.Status,
-		}, req.Password)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, actor, "update", "admin_user", userID, "", updatedUser)
-		writeJSON(w, http.StatusOK, updatedUser)
+		s.serveAdminUserPatch(w, r, actor, userID)
 	case http.MethodDelete:
-		if actor.ID == userID {
-			writeError(w, r, NewHTTPError(400, "cannot_delete_self", "You cannot delete your own account"))
-			return
-		}
-		if normalizeAdminRole(actor.Role) == "team_leader" {
-			target, ok := s.findAdminUser(userID)
-			if !ok || !userHasTeam(target, actor.TeamID) || normalizeAdminRole(target.Role) != "user" {
-				writeError(w, r, NewHTTPError(403, "team_forbidden", "Team leader can only delete ordinary users in own team"))
-				return
-			}
-		}
-		if err := s.store.DeleteAdminUser(userID); err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, actor, "delete", "admin_user", userID, "", nil)
-		w.WriteHeader(http.StatusNoContent)
+		s.serveAdminUserDelete(w, r, actor, userID)
 	default:
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
+		jsonMethodNotAllowed("PATCH, DELETE")(w, r)
 	}
+}
+
+func (s *Server) handleAdminUserPatch(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminUserRoute(w, r, s.serveAdminUserPatch)
+}
+
+func (s *Server) handleAdminUserDelete(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminUserRoute(w, r, s.serveAdminUserDelete)
+}
+
+func (s *Server) handleAdminUserRoute(w http.ResponseWriter, r *http.Request, handler func(http.ResponseWriter, *http.Request, AdminUser, string)) {
+	actor, ok := s.requireAdmin(w, r, "identity", r.Method)
+	if !ok {
+		return
+	}
+	userID := r.PathValue("user_id")
+	if userID == "" || strings.Contains(userID, "/") {
+		s.handleAdminUserItem(w, r)
+		return
+	}
+	handler(w, r, actor, userID)
+}
+
+func (s *Server) adminUserMethodNotAllowed(allowedMethods string) http.HandlerFunc {
+	reject := jsonMethodNotAllowed(allowedMethods)
+	return func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := s.requireAdmin(w, r, "identity", r.Method); !ok {
+			return
+		}
+		userID := r.PathValue("user_id")
+		if userID == "" || strings.Contains(userID, "/") {
+			s.handleAdminUserItem(w, r)
+			return
+		}
+		reject(w, r)
+	}
+}
+
+func (s *Server) serveAdminUserPatch(w http.ResponseWriter, r *http.Request, actor AdminUser, userID string) {
+	var req struct {
+		Username string   `json:"username"`
+		Name     string   `json:"name"`
+		Email    string   `json:"email"`
+		Role     string   `json:"role"`
+		TeamID   string   `json:"team_id"`
+		TeamIDs  []string `json:"team_ids"`
+		Status   string   `json:"status"`
+		Password string   `json:"password"`
+	}
+	if err := s.decodeJSON(w, r, &req); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	if normalizeAdminRole(actor.Role) == "team_leader" {
+		target, ok := s.findAdminUser(userID)
+		if !ok || !userHasTeam(target, actor.TeamID) || normalizeAdminRole(target.Role) != "user" {
+			writeError(w, r, NewHTTPError(403, "team_forbidden", "Team leader can only manage ordinary users in own team"))
+			return
+		}
+		if req.TeamID != "" && req.TeamID != actor.TeamID {
+			writeError(w, r, NewHTTPError(403, "team_forbidden", "Team leader can only manage own team"))
+			return
+		}
+		req.TeamID = actor.TeamID
+		req.TeamIDs = []string{actor.TeamID}
+		if req.Role != "" && normalizeAdminRole(req.Role) != "user" {
+			writeError(w, r, NewHTTPError(403, "role_forbidden", "Team leader cannot elevate user role"))
+			return
+		}
+		req.Role = "user"
+	}
+	updatedUser, err := s.store.UpdateAdminUser(userID, AdminUser{
+		Username: req.Username,
+		Name:     req.Name,
+		Email:    req.Email,
+		Role:     req.Role,
+		TeamID:   req.TeamID,
+		TeamIDs:  req.TeamIDs,
+		Status:   req.Status,
+	}, req.Password)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, actor, "update", "admin_user", userID, "", updatedUser)
+	writeJSON(w, http.StatusOK, updatedUser)
+}
+
+func (s *Server) serveAdminUserDelete(w http.ResponseWriter, r *http.Request, actor AdminUser, userID string) {
+	if actor.ID == userID {
+		writeError(w, r, NewHTTPError(400, "cannot_delete_self", "You cannot delete your own account"))
+		return
+	}
+	if normalizeAdminRole(actor.Role) == "team_leader" {
+		target, ok := s.findAdminUser(userID)
+		if !ok || !userHasTeam(target, actor.TeamID) || normalizeAdminRole(target.Role) != "user" {
+			writeError(w, r, NewHTTPError(403, "team_forbidden", "Team leader can only delete ordinary users in own team"))
+			return
+		}
+	}
+	if err := s.store.DeleteAdminUser(userID); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, actor, "delete", "admin_user", userID, "", nil)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleAdminUserResetPasswordEmailPost(w http.ResponseWriter, r *http.Request) {
+	actor, ok := s.requireAdmin(w, r, "identity", r.Method)
+	if !ok {
+		return
+	}
+	userID := r.PathValue("user_id")
+	if userID == "" || strings.Contains(userID, "/") {
+		s.handleAdminUserItem(w, r)
+		return
+	}
+	s.handleAdminUserResetPasswordEmail(w, r, actor, userID)
 }
 
 func (s *Server) handleAdminUserResetPasswordEmail(w http.ResponseWriter, r *http.Request, actor AdminUser, userID string) {
@@ -984,24 +1046,25 @@ func (s *Server) handleAdminUserResetPasswordEmail(w http.ResponseWriter, r *htt
 	writeJSON(w, http.StatusOK, map[string]any{"sent": true, "user": target})
 }
 
-func (s *Server) handleAdminAPIKeys(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleAdminAPIKeysGet(w http.ResponseWriter, r *http.Request) {
 	user, ok := s.requireAdmin(w, r, "api_key", r.Method)
 	if !ok {
 		return
 	}
-	switch r.Method {
-	case http.MethodGet:
-		writeJSON(w, http.StatusOK, map[string]any{"data": s.filterAPIKeysForUser(user, s.store.ListAPIKeys())})
-	case http.MethodPost:
-		project, err := s.personalAPIKeyProject(user)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.handleAdminAPIKeyCreate(w, r, user, project.ID)
-	default:
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
+	writeJSON(w, http.StatusOK, map[string]any{"data": s.filterAPIKeysForUser(user, s.store.ListAPIKeys())})
+}
+
+func (s *Server) handleAdminAPIKeysPost(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAdmin(w, r, "api_key", r.Method)
+	if !ok {
+		return
 	}
+	project, err := s.personalAPIKeyProject(user)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.handleAdminAPIKeyCreate(w, r, user, project.ID)
 }
 
 func (s *Server) personalAPIKeyProject(user AdminUser) (Project, error) {
@@ -1125,114 +1188,175 @@ func (s *Server) handleAdminAPIKeyItem(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if r.Method != http.MethodPost {
-			writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
+			jsonMethodNotAllowed(http.MethodPost)(w, r)
 			return
 		}
-		var req struct {
-			GraceUntil *time.Time `json:"grace_until"`
-		}
-		if r.Body != nil && r.ContentLength != 0 {
-			if err := s.decodeJSON(w, r, &req); err != nil {
-				writeError(w, r, err)
-				return
-			}
-		}
-		key, secret, err := s.store.RotateAPIKey(keyID, req.GraceUntil)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "rotate", "api_key", keyID, "", map[string]any{"new_key_id": key.ID})
-		for _, policyResource := range s.store.ListResources(routingPolicyResourceKind) {
-			policy := scopedRoutingPolicy(policyResource)
-			if policy.Scope == RoutingPolicyScopeAPIKey && policy.ScopeID == key.ID {
-				s.recordAdminAudit(r, user, "rotate_bind", routingPolicyResourceKind, policy.ID,
-					map[string]any{"rotated_from_key_id": keyID}, policyResource)
-				break
-			}
-		}
-		writeJSON(w, http.StatusCreated, map[string]any{
-			"id":                      key.ID,
-			"api_key":                 secret,
-			"name":                    key.Name,
-			"project_id":              key.ProjectID,
-			"owner_user_id":           key.OwnerUserID,
-			"rotated_from_id":         key.RotatedFromID,
-			"model_access_mode":       key.ModelAccessMode,
-			"allowed_models":          key.Allowed,
-			"plain_text_visible_once": true,
-		})
+		s.serveAdminAPIKeyRotate(w, r, user, keyID)
 		return
 	}
 	switch r.Method {
 	case http.MethodPatch:
-		var req struct {
-			Name            string             `json:"name"`
-			Group           string             `json:"group"`
-			OwnerUserID     *string            `json:"owner_user_id"`
-			AllowedModels   []string           `json:"allowed_models"`
-			ModelAccessMode string             `json:"model_access_mode"`
-			IPAllowlist     []string           `json:"ip_allowlist"`
-			Limits          *QuotaLimits       `json:"limits"`
-			RateLimitRPM    nullableInt64Patch `json:"rate_limit_rpm"`
-			TokenLimitTPM   nullableInt64Patch `json:"token_limit_tpm"`
-			Status          string             `json:"status"`
-			ExpiresAt       *time.Time         `json:"expires_at"`
+		s.serveAdminAPIKeyPatch(w, r, user, keyID)
+	case http.MethodDelete:
+		s.serveAdminAPIKeyDelete(w, r, user, keyID)
+	default:
+		jsonMethodNotAllowed("PATCH, DELETE")(w, r)
+	}
+}
+
+func (s *Server) handleAdminAPIKeyPatch(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminAPIKeyRoute(w, r, s.serveAdminAPIKeyPatch)
+}
+
+func (s *Server) handleAdminAPIKeyDelete(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminAPIKeyRoute(w, r, s.serveAdminAPIKeyDelete)
+}
+
+func (s *Server) handleAdminAPIKeyRotatePost(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminAPIKeyRoute(w, r, s.serveAdminAPIKeyRotate)
+}
+
+func (s *Server) handleAdminAPIKeyRoute(w http.ResponseWriter, r *http.Request, handler func(http.ResponseWriter, *http.Request, AdminUser, string)) {
+	user, ok := s.requireAdmin(w, r, "api_key", r.Method)
+	if !ok {
+		return
+	}
+	keyID := r.PathValue("key_id")
+	if keyID == "" || strings.Contains(keyID, "/") {
+		s.handleAdminAPIKeyItem(w, r)
+		return
+	}
+	if !s.canManageAPIKey(user, keyID) {
+		writeError(w, r, NewHTTPError(403, "api_key_forbidden", "API key is not available for this user"))
+		return
+	}
+	handler(w, r, user, keyID)
+}
+
+func (s *Server) adminAPIKeyMethodNotAllowed(allowedMethods string) http.HandlerFunc {
+	reject := jsonMethodNotAllowed(allowedMethods)
+	return func(w http.ResponseWriter, r *http.Request) {
+		user, ok := s.requireAdmin(w, r, "api_key", r.Method)
+		if !ok {
+			return
 		}
+		keyID := r.PathValue("key_id")
+		if keyID == "" || strings.Contains(keyID, "/") {
+			s.handleAdminAPIKeyItem(w, r)
+			return
+		}
+		if !s.canManageAPIKey(user, keyID) {
+			writeError(w, r, NewHTTPError(403, "api_key_forbidden", "API key is not available for this user"))
+			return
+		}
+		reject(w, r)
+	}
+}
+
+func (s *Server) serveAdminAPIKeyRotate(w http.ResponseWriter, r *http.Request, user AdminUser, keyID string) {
+	var req struct {
+		GraceUntil *time.Time `json:"grace_until"`
+	}
+	if r.Body != nil && r.ContentLength != 0 {
 		if err := s.decodeJSON(w, r, &req); err != nil {
 			writeError(w, r, err)
 			return
 		}
-		patch := APIKey{
-			Name:            req.Name,
-			Group:           req.Group,
-			Allowed:         req.AllowedModels,
-			ModelAccessMode: req.ModelAccessMode,
-			IPAllowlist:     req.IPAllowlist,
-			LimitsSet:       req.Limits != nil,
-			RateLimitRPM:    req.RateLimitRPM.Value,
-			RateLimitSet:    req.RateLimitRPM.Set,
-			TokenLimitTPM:   req.TokenLimitTPM.Value,
-			TokenLimitSet:   req.TokenLimitTPM.Set,
-			Status:          req.Status,
-			ExpiresAt:       req.ExpiresAt,
-		}
-		if req.Limits != nil {
-			patch.Limits = *req.Limits
-		}
-		if req.OwnerUserID != nil {
-			ownerUserID, err := s.resolveAPIKeyOwner(user, *req.OwnerUserID)
-			if err != nil {
-				writeError(w, r, err)
-				return
-			}
-			patch.OwnerUserID = ownerUserID
-		}
-		existing, err := s.findAPIKey(keyID)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		if approval, required := s.apiKeyUpdateApproval(user, existing, patch); required {
-			s.recordAdminAudit(r, user, "request_approval", "api_key", approval.ID, "", approval)
-			writeJSON(w, http.StatusAccepted, map[string]any{"approval_required": true, "approval": approval})
-			return
-		}
-		key, err := s.store.UpdateAPIKey(keyID, patch)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "update", "api_key", keyID, existing, key)
-		writeJSON(w, http.StatusOK, key)
-	case http.MethodDelete:
-		if err := s.store.DeleteAPIKey(keyID); err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "delete", "api_key", keyID, "", nil)
-		w.WriteHeader(http.StatusNoContent)
-	default:
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
 	}
+	key, secret, err := s.store.RotateAPIKey(keyID, req.GraceUntil)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "rotate", "api_key", keyID, "", map[string]any{"new_key_id": key.ID})
+	for _, policyResource := range s.store.ListResources(routingPolicyResourceKind) {
+		policy := scopedRoutingPolicy(policyResource)
+		if policy.Scope == RoutingPolicyScopeAPIKey && policy.ScopeID == key.ID {
+			s.recordAdminAudit(r, user, "rotate_bind", routingPolicyResourceKind, policy.ID,
+				map[string]any{"rotated_from_key_id": keyID}, policyResource)
+			break
+		}
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"id":                      key.ID,
+		"api_key":                 secret,
+		"name":                    key.Name,
+		"project_id":              key.ProjectID,
+		"owner_user_id":           key.OwnerUserID,
+		"rotated_from_id":         key.RotatedFromID,
+		"model_access_mode":       key.ModelAccessMode,
+		"allowed_models":          key.Allowed,
+		"plain_text_visible_once": true,
+	})
+}
+
+func (s *Server) serveAdminAPIKeyPatch(w http.ResponseWriter, r *http.Request, user AdminUser, keyID string) {
+	var req struct {
+		Name            string             `json:"name"`
+		Group           string             `json:"group"`
+		OwnerUserID     *string            `json:"owner_user_id"`
+		AllowedModels   []string           `json:"allowed_models"`
+		ModelAccessMode string             `json:"model_access_mode"`
+		IPAllowlist     []string           `json:"ip_allowlist"`
+		Limits          *QuotaLimits       `json:"limits"`
+		RateLimitRPM    nullableInt64Patch `json:"rate_limit_rpm"`
+		TokenLimitTPM   nullableInt64Patch `json:"token_limit_tpm"`
+		Status          string             `json:"status"`
+		ExpiresAt       *time.Time         `json:"expires_at"`
+	}
+	if err := s.decodeJSON(w, r, &req); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	patch := APIKey{
+		Name:            req.Name,
+		Group:           req.Group,
+		Allowed:         req.AllowedModels,
+		ModelAccessMode: req.ModelAccessMode,
+		IPAllowlist:     req.IPAllowlist,
+		LimitsSet:       req.Limits != nil,
+		RateLimitRPM:    req.RateLimitRPM.Value,
+		RateLimitSet:    req.RateLimitRPM.Set,
+		TokenLimitTPM:   req.TokenLimitTPM.Value,
+		TokenLimitSet:   req.TokenLimitTPM.Set,
+		Status:          req.Status,
+		ExpiresAt:       req.ExpiresAt,
+	}
+	if req.Limits != nil {
+		patch.Limits = *req.Limits
+	}
+	if req.OwnerUserID != nil {
+		ownerUserID, err := s.resolveAPIKeyOwner(user, *req.OwnerUserID)
+		if err != nil {
+			writeError(w, r, err)
+			return
+		}
+		patch.OwnerUserID = ownerUserID
+	}
+	existing, err := s.findAPIKey(keyID)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	if approval, required := s.apiKeyUpdateApproval(user, existing, patch); required {
+		s.recordAdminAudit(r, user, "request_approval", "api_key", approval.ID, "", approval)
+		writeJSON(w, http.StatusAccepted, map[string]any{"approval_required": true, "approval": approval})
+		return
+	}
+	key, err := s.store.UpdateAPIKey(keyID, patch)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "update", "api_key", keyID, existing, key)
+	writeJSON(w, http.StatusOK, key)
+}
+
+func (s *Server) serveAdminAPIKeyDelete(w http.ResponseWriter, r *http.Request, user AdminUser, keyID string) {
+	if err := s.store.DeleteAPIKey(keyID); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "delete", "api_key", keyID, "", nil)
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/server/admin_projects_method_routing_contract_test.go
+++ b/backend/internal/server/admin_projects_method_routing_contract_test.go
@@ -1,0 +1,494 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type adminProjectMethodRoute struct {
+	name         string
+	path         string
+	wrongMethod  string
+	allowed      []string
+	allow        string
+	userStatus   int
+	userCode     string
+	userHasAllow bool
+}
+
+func TestAdminProjectMethodRoutesPreserveAuthenticationAndAuthorizationOrder(t *testing.T) {
+	store, _, app, adminToken, userToken, projectID := newAdminProjectMethodRoutingServer(t)
+	routes := adminProjectMethodRoutes(projectID)
+	teamLeaderToken := createAdminProjectMethodSession(t, store, AdminUser{
+		Username: "project-method-team-leader",
+		Name:     "Project Method Team Leader",
+		Email:    "project-method-team-leader@tokenhub.local",
+		Role:     "team_leader",
+		TeamID:   "team_project_method",
+		Status:   StatusActive,
+	})
+	securityToken := createAdminProjectMethodSession(t, store, AdminUser{
+		Username: "project-method-security",
+		Name:     "Project Method Security",
+		Email:    "project-method-security@tokenhub.local",
+		Role:     "security_admin",
+		Status:   StatusActive,
+	})
+
+	projectsBefore := len(store.ListProjects())
+	keysBefore := len(store.ListAPIKeys())
+	approvalsBefore := len(store.ListApprovalRequests())
+	auditsBefore := len(store.ListAuditEvents())
+	linksBefore := adminProjectTeamCount(t, store, projectID)
+
+	for _, route := range routes {
+		t.Run(route.name+"/no_token", func(t *testing.T) {
+			response := methodRoutingRequest(app, route.wrongMethod, route.path, "")
+			assertJSONError(t, response, http.StatusUnauthorized, "invalid_admin_token")
+			assertAllowHeader(t, response, "")
+		})
+
+		t.Run(route.name+"/admin", func(t *testing.T) {
+			response := methodRoutingRequest(app, route.wrongMethod, route.path, adminToken)
+			assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+			assertAllowHeader(t, response, route.allow)
+		})
+
+		t.Run(route.name+"/ordinary_user", func(t *testing.T) {
+			response := methodRoutingRequest(app, route.wrongMethod, route.path, userToken)
+			assertJSONError(t, response, route.userStatus, route.userCode)
+			if route.userHasAllow {
+				assertAllowHeader(t, response, route.allow)
+			} else {
+				assertAllowHeader(t, response, "")
+			}
+		})
+
+		t.Run(route.name+"/team_leader", func(t *testing.T) {
+			response := methodRoutingRequest(app, route.wrongMethod, route.path, teamLeaderToken)
+			assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+			assertAllowHeader(t, response, route.allow)
+		})
+
+		t.Run(route.name+"/security_admin", func(t *testing.T) {
+			response := methodRoutingRequest(app, route.wrongMethod, route.path, securityToken)
+			if route.name == "quota increase" {
+				assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+				assertAllowHeader(t, response, route.allow)
+				return
+			}
+			assertJSONError(t, response, http.StatusForbidden, "admin_forbidden")
+			assertAllowHeader(t, response, "")
+		})
+	}
+
+	if got := len(store.ListProjects()); got != projectsBefore {
+		t.Fatalf("wrong methods changed projects: got %d, want %d", got, projectsBefore)
+	}
+	if got := len(store.ListAPIKeys()); got != keysBefore {
+		t.Fatalf("wrong methods changed API keys: got %d, want %d", got, keysBefore)
+	}
+	if got := len(store.ListApprovalRequests()); got != approvalsBefore {
+		t.Fatalf("wrong methods changed approvals: got %d, want %d", got, approvalsBefore)
+	}
+	if got := len(store.ListAuditEvents()); got != auditsBefore {
+		t.Fatalf("wrong methods changed audit events: got %d, want %d", got, auditsBefore)
+	}
+	if got := adminProjectTeamCount(t, store, projectID); got != linksBefore {
+		t.Fatalf("wrong methods changed project teams: got %d, want %d", got, linksBefore)
+	}
+}
+
+func TestAdminProjectMethodRoutesPreserveRoleChecksForReadAndWriteMethods(t *testing.T) {
+	store, _, app, _, userToken, projectID := newAdminProjectMethodRoutingServer(t)
+	teamLeaderToken := createAdminProjectMethodSession(t, store, AdminUser{
+		Username: "project-method-matrix-team-leader",
+		Name:     "Project Method Matrix Team Leader",
+		Email:    "project-method-matrix-team-leader@tokenhub.local",
+		Role:     "team_leader",
+		TeamID:   "team_project_method",
+		Status:   StatusActive,
+	})
+	securityToken := createAdminProjectMethodSession(t, store, AdminUser{
+		Username: "project-method-matrix-security",
+		Name:     "Project Method Matrix Security",
+		Email:    "project-method-matrix-security@tokenhub.local",
+		Role:     "security_admin",
+		Status:   StatusActive,
+	})
+
+	tests := []struct {
+		name       string
+		token      string
+		method     string
+		path       string
+		wantStatus int
+		wantCode   string
+		wantAllow  string
+	}{
+		{name: "user project item read", token: userToken, method: http.MethodGet, path: "/api/admin/projects/" + projectID, wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: "PATCH, DELETE"},
+		{name: "user project item write", token: userToken, method: http.MethodPost, path: "/api/admin/projects/" + projectID, wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+		{name: "team leader project item read", token: teamLeaderToken, method: http.MethodGet, path: "/api/admin/projects/" + projectID, wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: "PATCH, DELETE"},
+		{name: "team leader project item write", token: teamLeaderToken, method: http.MethodPost, path: "/api/admin/projects/" + projectID, wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: "PATCH, DELETE"},
+		{name: "security project item read", token: securityToken, method: http.MethodGet, path: "/api/admin/projects/" + projectID, wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+		{name: "security project item write", token: securityToken, method: http.MethodPost, path: "/api/admin/projects/" + projectID, wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+		{name: "user team item read", token: userToken, method: http.MethodGet, path: "/api/admin/projects/" + projectID + "/teams/team_shared", wantStatus: http.StatusForbidden, wantCode: "project_forbidden"},
+		{name: "user team item write", token: userToken, method: http.MethodPost, path: "/api/admin/projects/" + projectID + "/teams/team_shared", wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+		{name: "team leader team item read", token: teamLeaderToken, method: http.MethodGet, path: "/api/admin/projects/" + projectID + "/teams/team_shared", wantStatus: http.StatusForbidden, wantCode: "project_forbidden"},
+		{name: "team leader team item write", token: teamLeaderToken, method: http.MethodPost, path: "/api/admin/projects/" + projectID + "/teams/team_shared", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: "PATCH, DELETE"},
+		{name: "security team item read", token: securityToken, method: http.MethodGet, path: "/api/admin/projects/" + projectID + "/teams/team_shared", wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+		{name: "security team item write", token: securityToken, method: http.MethodPost, path: "/api/admin/projects/" + projectID + "/teams/team_shared", wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+		{name: "user quota read", token: userToken, method: http.MethodGet, path: "/api/admin/projects/" + projectID + "/quota-increase", wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+		{name: "user quota write", token: userToken, method: http.MethodPut, path: "/api/admin/projects/" + projectID + "/quota-increase", wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+		{name: "team leader quota read", token: teamLeaderToken, method: http.MethodGet, path: "/api/admin/projects/" + projectID + "/quota-increase", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: http.MethodPost},
+		{name: "team leader quota write", token: teamLeaderToken, method: http.MethodPut, path: "/api/admin/projects/" + projectID + "/quota-increase", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: http.MethodPost},
+		{name: "security quota read", token: securityToken, method: http.MethodGet, path: "/api/admin/projects/" + projectID + "/quota-increase", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: http.MethodPost},
+		{name: "security quota write", token: securityToken, method: http.MethodPut, path: "/api/admin/projects/" + projectID + "/quota-increase", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: http.MethodPost},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := methodRoutingRequest(app, test.method, test.path, test.token)
+			assertJSONError(t, response, test.wantStatus, test.wantCode)
+			assertAllowHeader(t, response, test.wantAllow)
+		})
+	}
+}
+
+func TestAdminProjectMethodRoutesRejectEveryUnsupportedMethod(t *testing.T) {
+	store, _, app, adminToken, _, projectID := newAdminProjectMethodRoutingServer(t)
+	projectsBefore := len(store.ListProjects())
+	keysBefore := len(store.ListAPIKeys())
+	approvalsBefore := len(store.ListApprovalRequests())
+	auditsBefore := len(store.ListAuditEvents())
+	linksBefore := adminProjectTeamCount(t, store, projectID)
+
+	for _, route := range adminProjectMethodRoutes(projectID) {
+		for _, method := range route.unsupportedMethods() {
+			t.Run(route.name+"/"+method, func(t *testing.T) {
+				response := methodRoutingRequest(app, method, route.path, adminToken)
+				wantStatus := http.StatusMethodNotAllowed
+				wantCode := "method_not_allowed"
+				wantAllow := route.allow
+				if route.name == "project team item" && method == http.MethodGet {
+					wantStatus = http.StatusForbidden
+					wantCode = "project_forbidden"
+					wantAllow = ""
+				}
+				assertJSONError(t, response, wantStatus, wantCode)
+				assertAllowHeader(t, response, wantAllow)
+			})
+		}
+	}
+
+	if got := len(store.ListProjects()); got != projectsBefore {
+		t.Fatalf("unsupported methods changed projects: got %d, want %d", got, projectsBefore)
+	}
+	if got := len(store.ListAPIKeys()); got != keysBefore {
+		t.Fatalf("unsupported methods changed API keys: got %d, want %d", got, keysBefore)
+	}
+	if got := len(store.ListApprovalRequests()); got != approvalsBefore {
+		t.Fatalf("unsupported methods changed approvals: got %d, want %d", got, approvalsBefore)
+	}
+	if got := len(store.ListAuditEvents()); got != auditsBefore {
+		t.Fatalf("unsupported methods changed audit events: got %d, want %d", got, auditsBefore)
+	}
+	if got := adminProjectTeamCount(t, store, projectID); got != linksBefore {
+		t.Fatalf("unsupported methods changed project teams: got %d, want %d", got, linksBefore)
+	}
+}
+
+func TestAdminProjectRoutesRejectRealHEADAfterAuthorization(t *testing.T) {
+	_, server, _, adminToken, userToken, projectID := newAdminProjectMethodRoutingServer(t)
+	httpServer := httptest.NewServer(server.Handler())
+	t.Cleanup(httpServer.Close)
+
+	tests := []struct {
+		name       string
+		path       string
+		allow      string
+		userStatus int
+		userAllow  string
+	}{
+		{name: "projects", path: "/api/admin/projects", allow: "GET, POST", userStatus: http.StatusForbidden},
+		{name: "project item", path: "/api/admin/projects/" + projectID, allow: "PATCH, DELETE", userStatus: http.StatusForbidden},
+		{name: "project keys", path: "/api/admin/projects/" + projectID + "/keys", allow: "GET, POST", userStatus: http.StatusMethodNotAllowed, userAllow: "GET, POST"},
+		{name: "project teams", path: "/api/admin/projects/" + projectID + "/teams", allow: "GET, POST", userStatus: http.StatusForbidden},
+		{name: "project team item", path: "/api/admin/projects/" + projectID + "/teams/team_shared", allow: "PATCH, DELETE", userStatus: http.StatusForbidden},
+		{name: "quota increase", path: "/api/admin/projects/" + projectID + "/quota-increase", allow: http.MethodPost, userStatus: http.StatusForbidden},
+	}
+
+	for _, test := range tests {
+		for _, credential := range []struct {
+			name       string
+			token      string
+			wantStatus int
+			wantAllow  string
+		}{
+			{name: "no_token", wantStatus: http.StatusUnauthorized},
+			{name: "admin", token: adminToken, wantStatus: http.StatusMethodNotAllowed, wantAllow: test.allow},
+			{name: "ordinary_user", token: userToken, wantStatus: test.userStatus, wantAllow: test.userAllow},
+		} {
+			t.Run(test.name+"/"+credential.name, func(t *testing.T) {
+				request, err := http.NewRequest(http.MethodHead, httpServer.URL+test.path, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if credential.token != "" {
+					request.Header.Set("authorization", "Bearer "+credential.token)
+				}
+				response, err := httpServer.Client().Do(request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer response.Body.Close()
+				assertRealHEADResponse(t, response, credential.wantStatus, credential.wantAllow, "application/json", true)
+			})
+		}
+	}
+}
+
+func TestAdminProjectMethodRoutesPreserveCORSPreflight(t *testing.T) {
+	_, _, app, _, _, projectID := newAdminProjectMethodRoutingServer(t)
+	for _, route := range adminProjectMethodRoutes(projectID) {
+		t.Run(route.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodOptions, route.path, nil)
+			request.Header.Set("origin", "https://console.example.com")
+			request.Header.Set("access-control-request-method", route.wrongMethod)
+			response := httptest.NewRecorder()
+
+			app.ServeHTTP(response, request)
+
+			if response.Code != http.StatusNoContent {
+				t.Fatalf("expected 204, got %d: %s", response.Code, response.Body.String())
+			}
+			if got := response.Header().Get("access-control-allow-methods"); got != "GET,POST,PUT,PATCH,DELETE,OPTIONS" {
+				t.Fatalf("access-control-allow-methods = %q", got)
+			}
+			assertAllowHeader(t, response, "")
+		})
+	}
+}
+
+func TestAdminProjectMethodRoutesPreservePathValidationOrder(t *testing.T) {
+	_, _, app, adminToken, _, projectID := newAdminProjectMethodRoutingServer(t)
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantStatus int
+		wantCode   string
+		wantAllow  string
+	}{
+		{name: "empty project id", method: http.MethodPost, path: "/api/admin/projects/", wantStatus: http.StatusBadRequest, wantCode: "project_required"},
+		{name: "project trailing slash", method: http.MethodPost, path: "/api/admin/projects/" + projectID + "/", wantStatus: http.StatusNotFound, wantCode: "not_found"},
+		{name: "unknown child", method: http.MethodPost, path: "/api/admin/projects/" + projectID + "/unknown", wantStatus: http.StatusNotFound, wantCode: "not_found"},
+		{name: "encoded project separator", method: http.MethodPost, path: "/api/admin/projects/" + projectID + "%2Funknown", wantStatus: http.StatusNotFound, wantCode: "not_found"},
+		{name: "missing teams project", method: http.MethodPut, path: "/api/admin/projects/missing/teams", wantStatus: http.StatusNotFound, wantCode: "project_not_found"},
+		{name: "team item GET keeps forbidden", method: http.MethodGet, path: "/api/admin/projects/" + projectID + "/teams/team_shared", wantStatus: http.StatusForbidden, wantCode: "project_forbidden"},
+		{name: "encoded team separator", method: http.MethodPatch, path: "/api/admin/projects/" + projectID + "/teams/team%2Fshared", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed"},
+		{name: "extra team segment", method: http.MethodPost, path: "/api/admin/projects/" + projectID + "/teams/team_shared/extra", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := methodRoutingRequest(app, test.method, test.path, adminToken)
+			assertJSONError(t, response, test.wantStatus, test.wantCode)
+			assertAllowHeader(t, response, test.wantAllow)
+		})
+	}
+}
+
+func TestAdminProjectMethodRoutesPreserveMissingProjectOrder(t *testing.T) {
+	_, _, app, adminToken, _, _ := newAdminProjectMethodRoutingServer(t)
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantStatus int
+		wantCode   string
+		wantAllow  string
+	}{
+		{name: "project item rejects method without lookup", method: http.MethodGet, path: "/api/admin/projects/missing", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: "PATCH, DELETE"},
+		{name: "project keys reject method without lookup", method: http.MethodDelete, path: "/api/admin/projects/missing/keys", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: "GET, POST"},
+		{name: "quota increase rejects method without lookup", method: http.MethodGet, path: "/api/admin/projects/missing/quota-increase", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: http.MethodPost},
+		{name: "project teams look up project before rejecting method", method: http.MethodPut, path: "/api/admin/projects/missing/teams", wantStatus: http.StatusNotFound, wantCode: "project_not_found"},
+		{name: "project team item write looks up project before rejecting method", method: http.MethodPost, path: "/api/admin/projects/missing/teams/team_shared", wantStatus: http.StatusNotFound, wantCode: "project_not_found"},
+		{name: "project team item read looks up project before special rejection", method: http.MethodGet, path: "/api/admin/projects/missing/teams/team_shared", wantStatus: http.StatusNotFound, wantCode: "project_not_found"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := methodRoutingRequest(app, test.method, test.path, adminToken)
+			assertJSONError(t, response, test.wantStatus, test.wantCode)
+			assertAllowHeader(t, response, test.wantAllow)
+		})
+	}
+}
+
+func TestAdminProjectTeamItemRoutesPreserveTrimmedTeamID(t *testing.T) {
+	store, _, app, adminToken, _, projectID := newAdminProjectMethodRoutingServer(t)
+	path := "/api/admin/projects/" + projectID + "/teams/%20team_shared%20"
+
+	updated := methodRoutingJSONRequest(t, app, http.MethodPatch, path, map[string]any{"role": "developer"}, adminToken)
+	if updated.Code != http.StatusOK {
+		t.Fatalf("team PATCH with surrounding spaces: expected 200, got %d: %s", updated.Code, updated.Body.String())
+	}
+	project, ok := store.GetProject(projectID)
+	if !ok {
+		t.Fatalf("project %s not found", projectID)
+	}
+	link, found := projectTeamByID(project.Teams, "team_shared")
+	if !found || link.Role != "developer" {
+		t.Fatalf("trimmed team link was not updated: %#v", project.Teams)
+	}
+
+	deleted := methodRoutingRequest(app, http.MethodDelete, path, adminToken)
+	if deleted.Code != http.StatusNoContent {
+		t.Fatalf("team DELETE with surrounding spaces: expected 204, got %d: %s", deleted.Code, deleted.Body.String())
+	}
+	project, ok = store.GetProject(projectID)
+	if !ok {
+		t.Fatalf("project %s not found after team deletion", projectID)
+	}
+	if _, found := projectTeamByID(project.Teams, "team_shared"); found {
+		t.Fatalf("trimmed team link still exists after DELETE: %#v", project.Teams)
+	}
+
+	blank := methodRoutingJSONRequest(t, app, http.MethodPatch, "/api/admin/projects/"+projectID+"/teams/%20", map[string]any{"role": "viewer"}, adminToken)
+	assertJSONError(t, blank, http.StatusBadRequest, "invalid_project_team")
+	assertAllowHeader(t, blank, "")
+}
+
+func TestAdminProjectMethodRoutesPreserveProjectItemAndKeySuccess(t *testing.T) {
+	store, _, app, adminToken, _, projectID := newAdminProjectMethodRoutingServer(t)
+
+	updated := methodRoutingJSONRequest(t, app, http.MethodPatch, "/api/admin/projects/"+projectID, map[string]any{
+		"name":   "Updated Method Routing Project",
+		"status": StatusActive,
+	}, adminToken)
+	if updated.Code != http.StatusOK {
+		t.Fatalf("project PATCH: expected 200, got %d: %s", updated.Code, updated.Body.String())
+	}
+	var project Project
+	if err := json.NewDecoder(updated.Body).Decode(&project); err != nil {
+		t.Fatal(err)
+	}
+	if project.ID != projectID || project.Name != "Updated Method Routing Project" {
+		t.Fatalf("unexpected updated project: %#v", project)
+	}
+
+	keys := methodRoutingRequest(app, http.MethodGet, "/api/admin/projects/"+projectID+"/keys", adminToken)
+	if keys.Code != http.StatusOK {
+		t.Fatalf("project keys GET: expected 200, got %d: %s", keys.Code, keys.Body.String())
+	}
+	assertAllowHeader(t, keys, "")
+
+	deletedProject := store.CreateProject(Project{Name: "Delete Method Routing Project", Status: StatusActive})
+	deleted := methodRoutingRequest(app, http.MethodDelete, "/api/admin/projects/"+deletedProject.ID, adminToken)
+	if deleted.Code != http.StatusNoContent {
+		t.Fatalf("project DELETE: expected 204, got %d: %s", deleted.Code, deleted.Body.String())
+	}
+	if _, ok := store.GetProject(deletedProject.ID); ok {
+		t.Fatalf("deleted project %s still exists", deletedProject.ID)
+	}
+
+	wantAudit := map[string]bool{"update": false, "delete": false}
+	for _, event := range store.ListAuditEvents() {
+		if event.ResourceType == "project" && (event.ResourceID == projectID || event.ResourceID == deletedProject.ID) {
+			wantAudit[event.Action] = true
+		}
+	}
+	for action, found := range wantAudit {
+		if !found {
+			t.Fatalf("missing project %s audit event", action)
+		}
+	}
+}
+
+func adminProjectMethodRoutes(projectID string) []adminProjectMethodRoute {
+	return []adminProjectMethodRoute{
+		{name: "projects", path: "/api/admin/projects", wrongMethod: http.MethodPut, allowed: []string{http.MethodGet, http.MethodPost}, allow: "GET, POST", userStatus: http.StatusForbidden, userCode: "admin_forbidden"},
+		{name: "project item", path: "/api/admin/projects/" + projectID, wrongMethod: http.MethodGet, allowed: []string{http.MethodPatch, http.MethodDelete}, allow: "PATCH, DELETE", userStatus: http.StatusMethodNotAllowed, userCode: "method_not_allowed", userHasAllow: true},
+		{name: "project keys", path: "/api/admin/projects/" + projectID + "/keys", wrongMethod: http.MethodDelete, allowed: []string{http.MethodGet, http.MethodPost}, allow: "GET, POST", userStatus: http.StatusMethodNotAllowed, userCode: "method_not_allowed", userHasAllow: true},
+		{name: "project teams", path: "/api/admin/projects/" + projectID + "/teams", wrongMethod: http.MethodPut, allowed: []string{http.MethodGet, http.MethodPost}, allow: "GET, POST", userStatus: http.StatusForbidden, userCode: "admin_forbidden"},
+		{name: "project team item", path: "/api/admin/projects/" + projectID + "/teams/team_shared", wrongMethod: http.MethodPost, allowed: []string{http.MethodPatch, http.MethodDelete}, allow: "PATCH, DELETE", userStatus: http.StatusForbidden, userCode: "admin_forbidden"},
+		{name: "quota increase", path: "/api/admin/projects/" + projectID + "/quota-increase", wrongMethod: http.MethodGet, allowed: []string{http.MethodPost}, allow: http.MethodPost, userStatus: http.StatusForbidden, userCode: "admin_forbidden"},
+	}
+}
+
+func (route adminProjectMethodRoute) unsupportedMethods() []string {
+	allowed := map[string]bool{}
+	for _, method := range route.allowed {
+		allowed[method] = true
+	}
+	methods := make([]string, 0, 5-len(allowed))
+	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		if !allowed[method] {
+			methods = append(methods, method)
+		}
+	}
+	return methods
+}
+
+func newAdminProjectMethodRoutingServer(t *testing.T) (*GormStore, *Server, http.Handler, string, string, string) {
+	t.Helper()
+	config := ConfigFromEnv()
+	config.AdminToken = "dev_admin_token"
+	config.BootstrapAdminPassword = "project-method-routing-password"
+	store := NewMemoryStoreWithConfig(config)
+	if err := BootstrapBaseDataWithConfig(store, config); err != nil {
+		t.Fatal(err)
+	}
+	store.CreateResource("teams", AdminResource{ID: "team_project_method", Name: "Project Method Team", Status: StatusActive})
+	store.CreateResource("teams", AdminResource{ID: "team_shared", Name: "Shared Method Team", Status: StatusActive})
+	project := store.CreateProject(Project{Name: "Method Routing Project", TeamID: "team_project_method", Status: StatusActive})
+	if _, err := store.AddProjectTeam(ProjectTeam{ProjectID: project.ID, TeamID: "team_shared", Role: "viewer"}); err != nil {
+		t.Fatal(err)
+	}
+	user, err := store.CreateAdminUser(AdminUser{
+		Username: "project-method-user",
+		Name:     "Project Method User",
+		Email:    "project-method-user@tokenhub.local",
+		Role:     "user",
+		Status:   StatusActive,
+	}, "project-method-user-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, userSession, err := store.CreateAdminSession(user.ID, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := NewWithConfig(store, config)
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+	app := server.Handler()
+	adminToken, _ := loginMethodRoutingAdmin(t, app, config.BootstrapAdminPassword)
+	return store, server, app, adminToken, userSession.Token, project.ID
+}
+
+func adminProjectTeamCount(t *testing.T, store *GormStore, projectID string) int64 {
+	t.Helper()
+	_, total, err := store.ListProjectTeams(projectID, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return total
+}
+
+func createAdminProjectMethodSession(t *testing.T, store *GormStore, user AdminUser) string {
+	t.Helper()
+	created, err := store.CreateAdminUser(user, "project-method-role-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, session, err := store.CreateAdminSession(created.ID, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return session.Token
+}

--- a/backend/internal/server/analytics_http.go
+++ b/backend/internal/server/analytics_http.go
@@ -50,51 +50,63 @@ type tokenCostCursorQuery struct {
 	GroupBy     []string `json:"group_by"`
 }
 
-func (s *Server) handleAdminAnalyticsCredentials(w http.ResponseWriter, r *http.Request) {
-	user, ok := s.requireAdmin(w, r, "analytics_credential", r.Method)
-	if !ok {
-		return
-	}
-	switch r.Method {
-	case http.MethodGet:
-		writeJSON(w, http.StatusOK, map[string]any{"data": s.store.ListAnalyticsCredentials()})
-	case http.MethodPost:
-		var request struct {
-			Name      string     `json:"name"`
-			ScopeType string     `json:"scope_type"`
-			ProjectID string     `json:"project_id"`
-			ExpiresAt *time.Time `json:"expires_at"`
-		}
-		if err := s.decodeJSON(w, r, &request); err != nil {
-			writeError(w, r, err)
-			return
-		}
-		credential, token, err := s.store.CreateAnalyticsCredential(AnalyticsCredential{
-			Name: request.Name, ScopeType: request.ScopeType, ProjectID: request.ProjectID,
-			ExpiresAt: request.ExpiresAt, CreatedBy: user.ID,
-		}, "")
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "create", "analytics_credential", credential.ID, nil, credential)
-		w.Header().Set("cache-control", "no-store")
-		writeJSON(w, http.StatusCreated, map[string]any{"credential": credential, "token": token})
-	default:
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
-	}
+func (s *Server) registerAdminAnalyticsCredentialRoutes() {
+	s.registerMethodRoutes("/api/admin/analytics/credentials", func(allowedMethods string) http.HandlerFunc {
+		return s.adminMethodNotAllowed("analytics_credential", allowedMethods)
+	},
+		methodRoute{Method: http.MethodGet, Handler: s.handleAdminAnalyticsCredentialsGet},
+		methodRoute{Method: http.MethodPost, Handler: s.handleAdminAnalyticsCredentialsPost},
+	)
+	s.registerSingleMethodRoute(
+		http.MethodDelete,
+		"/api/admin/analytics/credentials/{credential_id}",
+		s.handleAdminAnalyticsCredentialDelete,
+		s.adminMethodNotAllowed("analytics_credential", http.MethodDelete),
+	)
+	s.mux.HandleFunc("/api/admin/analytics/credentials/", s.handleAdminAnalyticsCredentialNested)
 }
 
-func (s *Server) handleAdminAnalyticsCredentialItem(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleAdminAnalyticsCredentialsGet(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r, "analytics_credential", r.Method); !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"data": s.store.ListAnalyticsCredentials()})
+}
+
+func (s *Server) handleAdminAnalyticsCredentialsPost(w http.ResponseWriter, r *http.Request) {
 	user, ok := s.requireAdmin(w, r, "analytics_credential", r.Method)
 	if !ok {
 		return
 	}
-	if r.Method != http.MethodDelete {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+	var request struct {
+		Name      string     `json:"name"`
+		ScopeType string     `json:"scope_type"`
+		ProjectID string     `json:"project_id"`
+		ExpiresAt *time.Time `json:"expires_at"`
+	}
+	if err := s.decodeJSON(w, r, &request); err != nil {
+		writeError(w, r, err)
 		return
 	}
-	id := strings.TrimPrefix(r.URL.Path, "/api/admin/analytics/credentials/")
+	credential, token, err := s.store.CreateAnalyticsCredential(AnalyticsCredential{
+		Name: request.Name, ScopeType: request.ScopeType, ProjectID: request.ProjectID,
+		ExpiresAt: request.ExpiresAt, CreatedBy: user.ID,
+	}, "")
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "create", "analytics_credential", credential.ID, nil, credential)
+	w.Header().Set("cache-control", "no-store")
+	writeJSON(w, http.StatusCreated, map[string]any{"credential": credential, "token": token})
+}
+
+func (s *Server) handleAdminAnalyticsCredentialDelete(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAdmin(w, r, "analytics_credential", r.Method)
+	if !ok {
+		return
+	}
+	id := r.PathValue("credential_id")
 	if id == "" || strings.Contains(id, "/") {
 		writeError(w, r, NewHTTPError(http.StatusNotFound, "analytics_credential_not_found", "Analytics credential not found"))
 		return
@@ -106,6 +118,17 @@ func (s *Server) handleAdminAnalyticsCredentialItem(w http.ResponseWriter, r *ht
 	}
 	s.recordAdminAudit(r, user, "revoke", "analytics_credential", credential.ID, nil, credential)
 	writeJSON(w, http.StatusOK, credential)
+}
+
+func (s *Server) handleAdminAnalyticsCredentialNested(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r, "analytics_credential", r.Method); !ok {
+		return
+	}
+	if r.Method != http.MethodDelete {
+		jsonMethodNotAllowed(http.MethodDelete)(w, r)
+		return
+	}
+	writeError(w, r, NewHTTPError(http.StatusNotFound, "analytics_credential_not_found", "Analytics credential not found"))
 }
 
 func (s *Server) handleTokenCostAnalytics(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/server/method_routes.go
+++ b/backend/internal/server/method_routes.go
@@ -1,6 +1,16 @@
 package server
 
-import "net/http"
+import (
+	"net/http"
+	"strings"
+)
+
+type methodRoute struct {
+	Method  string
+	Handler http.HandlerFunc
+}
+
+type methodNotAllowedFactory func(allowedMethods string) http.HandlerFunc
 
 // registerSingleMethodRoute must only be called once for a path. Multi-method
 // resources need one shared fallback with the complete Allow value.
@@ -10,6 +20,24 @@ func (s *Server) registerSingleMethodRoute(method string, pattern string, handle
 		s.mux.HandleFunc(http.MethodHead+" "+pattern, methodNotAllowed)
 	}
 	s.mux.HandleFunc(pattern, methodNotAllowed)
+}
+
+// registerMethodRoutes registers every allowed method for one path and one
+// shared fallback. The Allow value comes from the same route list so the two
+// cannot drift apart.
+func (s *Server) registerMethodRoutes(pattern string, methodNotAllowed methodNotAllowedFactory, routes ...methodRoute) {
+	allowedMethods := make([]string, 0, len(routes))
+	hasGET := false
+	for _, route := range routes {
+		allowedMethods = append(allowedMethods, route.Method)
+		hasGET = hasGET || route.Method == http.MethodGet
+		s.mux.HandleFunc(route.Method+" "+pattern, route.Handler)
+	}
+	fallback := methodNotAllowed(strings.Join(allowedMethods, ", "))
+	if hasGET {
+		s.mux.HandleFunc(http.MethodHead+" "+pattern, fallback)
+	}
+	s.mux.HandleFunc(pattern, fallback)
 }
 
 // registerDynamicGETRoute rejects the HEAD requests that a GET pattern matches

--- a/backend/internal/server/method_routes.go
+++ b/backend/internal/server/method_routes.go
@@ -26,18 +26,24 @@ func (s *Server) registerSingleMethodRoute(method string, pattern string, handle
 // shared fallback. The Allow value comes from the same route list so the two
 // cannot drift apart.
 func (s *Server) registerMethodRoutes(pattern string, methodNotAllowed methodNotAllowedFactory, routes ...methodRoute) {
-	allowedMethods := make([]string, 0, len(routes))
 	hasGET := false
 	for _, route := range routes {
-		allowedMethods = append(allowedMethods, route.Method)
 		hasGET = hasGET || route.Method == http.MethodGet
 		s.mux.HandleFunc(route.Method+" "+pattern, route.Handler)
 	}
-	fallback := methodNotAllowed(strings.Join(allowedMethods, ", "))
+	fallback := methodNotAllowed(methodRoutesAllow(routes))
 	if hasGET {
 		s.mux.HandleFunc(http.MethodHead+" "+pattern, fallback)
 	}
 	s.mux.HandleFunc(pattern, fallback)
+}
+
+func methodRoutesAllow(routes []methodRoute) string {
+	allowedMethods := make([]string, 0, len(routes))
+	for _, route := range routes {
+		allowedMethods = append(allowedMethods, route.Method)
+	}
+	return strings.Join(allowedMethods, ", ")
 }
 
 // registerDynamicGETRoute rejects the HEAD requests that a GET pattern matches

--- a/backend/internal/server/provider_account_oauth.go
+++ b/backend/internal/server/provider_account_oauth.go
@@ -249,11 +249,7 @@ func (s *Server) handleAdminOpenAIAccountOAuthGenerateAuthURL(w http.ResponseWri
 	})
 }
 
-func (s *Server) handleOpenAIAccountOAuthCallback(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeError(w, r, NewHTTPError(405, "method_not_allowed", "Method not allowed"))
-		return
-	}
+func (s *Server) handleOpenAIAccountOAuthCallbackGet(w http.ResponseWriter, r *http.Request) {
 	state := strings.TrimSpace(r.URL.Query().Get("state"))
 	session, ok, err := s.store.GetProviderAccountOAuthSessionByState(state)
 	if err != nil {

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -47,7 +47,33 @@ func (s *Server) routes() {
 	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/overview", s.handleAdminOverview, s.adminMethodNotAllowed("overview", http.MethodGet))
 	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/playground/chat", s.handleAdminPlaygroundChat, s.adminMethodNotAllowed("playground", http.MethodPost))
 	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/playground/chat/stream", s.handleAdminPlaygroundChatStream, s.adminMethodNotAllowed("playground", http.MethodPost))
-	s.mux.HandleFunc("/api/admin/projects", s.handleAdminProjects)
+	s.registerMethodRoutes("/api/admin/projects", func(allowedMethods string) http.HandlerFunc {
+		return s.adminMethodNotAllowed("project", allowedMethods)
+	},
+		methodRoute{Method: http.MethodGet, Handler: s.handleAdminProjectsGet},
+		methodRoute{Method: http.MethodPost, Handler: s.handleAdminProjectsPost},
+	)
+	s.registerMethodRoutes("/api/admin/projects/{project_id}", func(allowedMethods string) http.HandlerFunc {
+		return s.adminProjectMethodNotAllowed("project", allowedMethods)
+	},
+		methodRoute{Method: http.MethodPatch, Handler: s.handleAdminProjectPatch},
+		methodRoute{Method: http.MethodDelete, Handler: s.handleAdminProjectDelete},
+	)
+	s.registerMethodRoutes("/api/admin/projects/{project_id}/keys", func(allowedMethods string) http.HandlerFunc {
+		return s.adminProjectMethodNotAllowed("api_key", allowedMethods)
+	},
+		methodRoute{Method: http.MethodGet, Handler: s.handleAdminProjectKeysGet},
+		methodRoute{Method: http.MethodPost, Handler: s.handleAdminProjectKeysPost},
+	)
+	s.registerMethodRoutes("/api/admin/projects/{project_id}/teams", s.adminProjectTeamsMethodNotAllowed,
+		methodRoute{Method: http.MethodGet, Handler: s.handleAdminProjectTeamsGet},
+		methodRoute{Method: http.MethodPost, Handler: s.handleAdminProjectTeamsPost},
+	)
+	s.registerMethodRoutes("/api/admin/projects/{project_id}/teams/{team_id}", s.adminProjectTeamMethodNotAllowed,
+		methodRoute{Method: http.MethodPatch, Handler: s.handleAdminProjectTeamPatch},
+		methodRoute{Method: http.MethodDelete, Handler: s.handleAdminProjectTeamDelete},
+	)
+	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/projects/{project_id}/quota-increase", s.handleAdminProjectQuotaIncreasePost, s.adminProjectMethodNotAllowed("approval", http.MethodPost))
 	s.mux.HandleFunc("/api/admin/projects/", s.handleAdminProjectNested)
 	s.mux.HandleFunc("/api/admin/guardrail-policies", s.handleAdminGuardrailPolicies)
 	s.mux.HandleFunc("/api/admin/guardrail-policies/test", s.handleAdminGuardrailPolicyTest)

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -95,7 +95,7 @@ func (s *Server) routes() {
 	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/provider-adapters", s.handleAdminProviderAdapters, s.adminMethodNotAllowed("providers", http.MethodGet))
 	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/provider-account-oauth/openai/generate-auth-url", s.handleAdminOpenAIAccountOAuthGenerateAuthURL, s.adminMethodNotAllowed("provider", http.MethodPost))
 	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/provider-account-oauth/openai/exchange-code", s.handleAdminOpenAIAccountOAuthExchangeCode, s.adminMethodNotAllowed("provider", http.MethodPost))
-	s.mux.HandleFunc("/api/admin/provider-account-oauth/openai/oauth/callback", s.handleOpenAIAccountOAuthCallback)
+	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/provider-account-oauth/openai/oauth/callback", s.handleOpenAIAccountOAuthCallbackGet, jsonMethodNotAllowed(http.MethodGet))
 	s.registerMethodRoutes("/api/admin/api-keys", func(allowedMethods string) http.HandlerFunc {
 		return s.adminMethodNotAllowed("api_key", allowedMethods)
 	},
@@ -108,8 +108,7 @@ func (s *Server) routes() {
 	)
 	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/api-keys/{key_id}/rotate", s.handleAdminAPIKeyRotatePost, s.adminAPIKeyMethodNotAllowed(http.MethodPost))
 	s.mux.HandleFunc("/api/admin/api-keys/", s.handleAdminAPIKeyItem)
-	s.mux.HandleFunc("/api/admin/analytics/credentials", s.handleAdminAnalyticsCredentials)
-	s.mux.HandleFunc("/api/admin/analytics/credentials/", s.handleAdminAnalyticsCredentialItem)
+	s.registerAdminAnalyticsCredentialRoutes()
 	s.mux.HandleFunc("/api/admin/providers", s.handleAdminProviders)
 	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/providers/monitoring", s.handleAdminProviderMonitoring, s.adminMethodNotAllowed("provider", http.MethodGet))
 	s.mux.HandleFunc("/api/admin/providers/", s.handleAdminProviderNested)

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -75,9 +75,7 @@ func (s *Server) routes() {
 	)
 	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/projects/{project_id}/quota-increase", s.handleAdminProjectQuotaIncreasePost, s.adminProjectMethodNotAllowed("approval", http.MethodPost))
 	s.mux.HandleFunc("/api/admin/projects/", s.handleAdminProjectNested)
-	s.mux.HandleFunc("/api/admin/guardrail-policies", s.handleAdminGuardrailPolicies)
-	s.mux.HandleFunc("/api/admin/guardrail-policies/test", s.handleAdminGuardrailPolicyTest)
-	s.mux.HandleFunc("/api/admin/guardrail-policies/", s.handleAdminGuardrailPolicyItem)
+	s.registerAdminGuardrailPolicyRoutes()
 	s.registerMethodRoutes("/api/admin/users", func(allowedMethods string) http.HandlerFunc {
 		return s.adminMethodNotAllowed("identity", allowedMethods)
 	},

--- a/backend/internal/server/routes.go
+++ b/backend/internal/server/routes.go
@@ -78,8 +78,19 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("/api/admin/guardrail-policies", s.handleAdminGuardrailPolicies)
 	s.mux.HandleFunc("/api/admin/guardrail-policies/test", s.handleAdminGuardrailPolicyTest)
 	s.mux.HandleFunc("/api/admin/guardrail-policies/", s.handleAdminGuardrailPolicyItem)
-	s.mux.HandleFunc("/api/admin/users", s.handleAdminUsers)
-	s.mux.HandleFunc("/api/admin/users/import", s.handleAdminUsersImport)
+	s.registerMethodRoutes("/api/admin/users", func(allowedMethods string) http.HandlerFunc {
+		return s.adminMethodNotAllowed("identity", allowedMethods)
+	},
+		methodRoute{Method: http.MethodGet, Handler: s.handleAdminUsersGet},
+		methodRoute{Method: http.MethodPost, Handler: s.handleAdminUsersPost},
+	)
+	userImportMethodNotAllowed := s.adminMethodNotAllowed("identity", http.MethodPost)
+	s.mux.HandleFunc(http.MethodPost+" /api/admin/users/import", s.handleAdminUsersImportPost)
+	s.mux.HandleFunc(http.MethodPatch+" /api/admin/users/import", userImportMethodNotAllowed)
+	s.mux.HandleFunc(http.MethodDelete+" /api/admin/users/import", userImportMethodNotAllowed)
+	s.registerDynamicMethodRoute(http.MethodPatch, "/api/admin/users/{user_id}", s.handleAdminUserPatch)
+	s.registerDynamicMethodRoute(http.MethodDelete, "/api/admin/users/{user_id}", s.handleAdminUserDelete)
+	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/users/{user_id}/reset-password-email", s.handleAdminUserResetPasswordEmailPost, s.adminUserMethodNotAllowed(http.MethodPost))
 	s.mux.HandleFunc("/api/admin/users/", s.handleAdminUserItem)
 	s.mux.HandleFunc("/api/admin/provider-catalog", s.handleAdminProviderCatalog)
 	s.mux.HandleFunc("/api/admin/provider-catalog/", s.handleAdminProviderCatalogItem)
@@ -87,7 +98,17 @@ func (s *Server) routes() {
 	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/provider-account-oauth/openai/generate-auth-url", s.handleAdminOpenAIAccountOAuthGenerateAuthURL, s.adminMethodNotAllowed("provider", http.MethodPost))
 	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/provider-account-oauth/openai/exchange-code", s.handleAdminOpenAIAccountOAuthExchangeCode, s.adminMethodNotAllowed("provider", http.MethodPost))
 	s.mux.HandleFunc("/api/admin/provider-account-oauth/openai/oauth/callback", s.handleOpenAIAccountOAuthCallback)
-	s.mux.HandleFunc("/api/admin/api-keys", s.handleAdminAPIKeys)
+	s.registerMethodRoutes("/api/admin/api-keys", func(allowedMethods string) http.HandlerFunc {
+		return s.adminMethodNotAllowed("api_key", allowedMethods)
+	},
+		methodRoute{Method: http.MethodGet, Handler: s.handleAdminAPIKeysGet},
+		methodRoute{Method: http.MethodPost, Handler: s.handleAdminAPIKeysPost},
+	)
+	s.registerMethodRoutes("/api/admin/api-keys/{key_id}", s.adminAPIKeyMethodNotAllowed,
+		methodRoute{Method: http.MethodPatch, Handler: s.handleAdminAPIKeyPatch},
+		methodRoute{Method: http.MethodDelete, Handler: s.handleAdminAPIKeyDelete},
+	)
+	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/api-keys/{key_id}/rotate", s.handleAdminAPIKeyRotatePost, s.adminAPIKeyMethodNotAllowed(http.MethodPost))
 	s.mux.HandleFunc("/api/admin/api-keys/", s.handleAdminAPIKeyItem)
 	s.mux.HandleFunc("/api/admin/analytics/credentials", s.handleAdminAnalyticsCredentials)
 	s.mux.HandleFunc("/api/admin/analytics/credentials/", s.handleAdminAnalyticsCredentialItem)


### PR DESCRIPTION
## Summary

Moves method checks for the admin governance routes into ServeMux registration. Existing authentication, RBAC, resource checks, response formats, and business ordering stay in place, while wrong-method responses now include endpoint-specific `Allow` headers.

## Related Issue

Related #145 

## Changes

**Project and membership APIs**

- `GET|POST /api/admin/projects`
- `PATCH|DELETE /api/admin/projects/{project_id}`
- `GET|POST /api/admin/projects/{project_id}/keys`
- `GET|POST /api/admin/projects/{project_id}/teams`
- `PATCH|DELETE /api/admin/projects/{project_id}/teams/{team_id}`
- `POST /api/admin/projects/{project_id}/quota-increase`

**Identity and API Key APIs**

- `GET|POST /api/admin/users`
- `POST /api/admin/users/import`
- `PATCH|DELETE /api/admin/users/{user_id}`
- `POST /api/admin/users/{user_id}/reset-password-email`
- `GET|POST /api/admin/api-keys`
- `PATCH|DELETE /api/admin/api-keys/{key_id}`
- `POST /api/admin/api-keys/{key_id}/rotate`

**Guardrail policy APIs**

- `GET|POST /api/admin/guardrail-policies`
- `POST /api/admin/guardrail-policies/test`
- `GET|PUT|DELETE /api/admin/guardrail-policies/{policy_id}`

**Analytics credential and OAuth APIs**

- `GET|POST /api/admin/analytics/credentials`
- `DELETE /api/admin/analytics/credentials/{credential_id}`
- `GET /api/admin/provider-account-oauth/openai/oauth/callback`

The route families retain compatibility handlers where static actions overlap dynamic IDs or malformed paths need the previous 404 and authentication ordering.

Regression coverage includes allowed and unsupported methods, authentication and resource authorization order, `Allow`, real HEAD responses, CORS preflight, encoded IDs, trailing slashes, successful write paths, audit side effects, and OAuth callback redirects.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...
- `go vet ./...
- `node --test tools/*.test.mjs
- `node tools/check-ui-translations.mjs
- `node tools/check-env-contract.mjs
- `node tools/check-source-lines.mjs

## Compatibility, Security, and Operations

Successful responses, authentication and RBAC decisions, JSON error formats, and request ordering remain unchanged. Wrong-method responses now add endpoint-specific `Allow` headers. HEAD remains rejected and OPTIONS remains handled by the existing CORS middleware.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.