### PR TITLE
fix(providers): support configurable synthetic DNS ranges

### DIFF
--- a/backend/internal/server/admin_operations_http.go
+++ b/backend/internal/server/admin_operations_http.go
@@ -53,6 +53,14 @@ func (s *Server) handleAdminResources(w http.ResponseWriter, r *http.Request) {
 				writeError(w, r, err)
 				return
 			}
+			if kind == "settings" && req.ID == gatewaySettingsID {
+				s.syntheticDNSSetting.Lock()
+				defer s.syntheticDNSSetting.Unlock()
+				if err := validateProviderSyntheticDNSSettings(req); err != nil {
+					writeError(w, r, err)
+					return
+				}
+			}
 			if approval, required := s.adminResourceApproval(user, kind, "", req); required {
 				s.recordAdminAudit(r, user, "request_approval", kind, approval.ID, "", approval)
 				writeJSON(w, http.StatusAccepted, map[string]any{"approval_required": true, "approval": approval})
@@ -68,6 +76,9 @@ func (s *Server) handleAdminResources(w http.ResponseWriter, r *http.Request) {
 				}
 			} else {
 				resource = s.store.CreateResource(kind, req)
+			}
+			if kind == "settings" && resource.ID == gatewaySettingsID {
+				s.syntheticDNSPolicy.applySetting(&resource)
 			}
 			s.recordAdminAudit(r, user, "create", kind, resource.ID, "", resource)
 			writeJSON(w, http.StatusCreated, resource)
@@ -88,6 +99,10 @@ func (s *Server) handleAdminResources(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, NewHTTPError(404, "not_found", "Not found"))
 		return
 	}
+	if kind == "settings" && parts[1] == gatewaySettingsID && (r.Method == http.MethodPatch || r.Method == http.MethodDelete) {
+		s.syntheticDNSSetting.Lock()
+		defer s.syntheticDNSSetting.Unlock()
+	}
 	switch r.Method {
 	case http.MethodPatch:
 		if normalizeAdminRole(user.Role) == "team_leader" && kind == "teams" && parts[1] != user.TeamID {
@@ -103,6 +118,13 @@ func (s *Server) handleAdminResources(w http.ResponseWriter, r *http.Request) {
 			writeError(w, r, err)
 			return
 		}
+		if kind == "settings" && parts[1] == gatewaySettingsID {
+			req.ID = parts[1]
+			if err := validateProviderSyntheticDNSSettings(req); err != nil {
+				writeError(w, r, err)
+				return
+			}
+		}
 		if approval, required := s.adminResourceApproval(user, kind, parts[1], req); required {
 			s.recordAdminAudit(r, user, "request_approval", kind, approval.ID, "", approval)
 			writeJSON(w, http.StatusAccepted, map[string]any{"approval_required": true, "approval": approval})
@@ -112,6 +134,9 @@ func (s *Server) handleAdminResources(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			writeError(w, r, err)
 			return
+		}
+		if kind == "settings" && parts[1] == gatewaySettingsID {
+			s.syntheticDNSPolicy.applySetting(&resource)
 		}
 		s.recordAdminAudit(r, user, "update", kind, parts[1], "", resource)
 		writeJSON(w, http.StatusOK, resource)
@@ -132,6 +157,9 @@ func (s *Server) handleAdminResources(w http.ResponseWriter, r *http.Request) {
 		if err := s.store.DeleteResource(kind, parts[1]); err != nil {
 			writeError(w, r, err)
 			return
+		}
+		if kind == "settings" && parts[1] == gatewaySettingsID {
+			s.syntheticDNSPolicy.applySetting(nil)
 		}
 		s.recordAdminAudit(r, user, "delete", kind, parts[1], "", nil)
 		w.WriteHeader(http.StatusNoContent)

--- a/backend/internal/server/admin_operations_http.go
+++ b/backend/internal/server/admin_operations_http.go
@@ -67,15 +67,15 @@ func (s *Server) handleAdminResources(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			var resource AdminResource
+			var err error
 			if kind == routingPolicyResourceKind {
-				var err error
 				resource, err = s.store.CreateRoutingPolicy(req)
-				if err != nil {
-					writeError(w, r, err)
-					return
-				}
 			} else {
-				resource = s.store.CreateResource(kind, req)
+				resource, err = s.store.CreateResourceChecked(kind, req)
+			}
+			if err != nil {
+				writeError(w, r, err)
+				return
 			}
 			if kind == "settings" && resource.ID == gatewaySettingsID {
 				s.syntheticDNSPolicy.applySetting(&resource)

--- a/backend/internal/server/admin_providers_http.go
+++ b/backend/internal/server/admin_providers_http.go
@@ -180,7 +180,7 @@ func (s *Server) handleAdminProviderCatalogItem(w http.ResponseWriter, r *http.R
 		var entry ProviderCatalogEntry
 		var err error
 		for _, candidate := range catalogRequests {
-			entry, err = CustomProviderCatalogFromUpstream(r.Context(), http.DefaultClient, candidate)
+			entry, err = CustomProviderCatalogFromUpstream(r.Context(), s.upstreamClient, candidate)
 			if err == nil {
 				break
 			}
@@ -581,10 +581,10 @@ func (s *Server) serveAdminProviderTestConnection(w http.ResponseWriter, r *http
 		result, healthErr := adapter.Health(ctx, provider)
 		health, err = &result, healthErr
 		if err == nil {
-			catalog, err = KronkProviderCatalogFromUpstream(ctx, http.DefaultClient, req)
+			catalog, err = KronkProviderCatalogFromUpstream(ctx, s.upstreamClient, req)
 		}
 	} else {
-		catalog, err = CustomProviderCatalogFromUpstream(ctx, http.DefaultClient, req)
+		catalog, err = CustomProviderCatalogFromUpstream(ctx, s.upstreamClient, req)
 	}
 	if err != nil {
 		writeError(w, r, err)

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -46,6 +46,9 @@ type Server struct {
 	responseInstanceID  string
 	versions            *versionService
 	guardrailEngine     *guardrails.Engine
+	upstreamClient      *http.Client
+	syntheticDNSPolicy  *providerSyntheticDNSPolicy
+	syntheticDNSSetting sync.Mutex
 }
 
 func New(store Store) *Server {
@@ -93,7 +96,8 @@ func NewWithConfig(store Store, config Config) *Server {
 	}
 	imageContext, imageCancel := context.WithCancel(context.Background())
 	responseContext, responseCancel := context.WithCancel(context.Background())
-	client, streamClient, streamIdleTimeout := newUpstreamClients(config)
+	syntheticDNSPolicy := newProviderSyntheticDNSPolicy(store)
+	client, streamClient, streamIdleTimeout := newUpstreamClients(config, syntheticDNSPolicy)
 	allowedProviderUpstreams := allowedProviderUpstreamCIDRs()
 	openai := OpenAICompatibleAdapter{Client: client, StreamClient: streamClient, StreamIdleTimeout: streamIdleTimeout}
 	kronk := KronkAdapter{OpenAICompatibleAdapter: openai}
@@ -105,7 +109,7 @@ func NewWithConfig(store Store, config Config) *Server {
 			// credential-bearing responses/compact/probe/image calls into
 			// the internal network. No Client.Timeout: streaming stays
 			// bounded by StreamIdleTimeout, exactly as before.
-			Transport:     guardProviderUpstreamRequests(ssrfGuardedProviderTransport(allowedProviderUpstreams), allowedProviderUpstreams),
+			Transport:     guardProviderUpstreamRequests(rotatingProviderUpstreamTransport(allowedProviderUpstreams, syntheticDNSPolicy, nil), allowedProviderUpstreams),
 			CheckRedirect: strictProviderUpstreamRedirect,
 		},
 		StreamIdleTimeout:  streamIdleTimeout,
@@ -138,7 +142,7 @@ func NewWithConfig(store Store, config Config) *Server {
 	s := &Server{
 		store:              store,
 		adapterRegistry:    registry,
-		integrations:       NewIntegrationService(store, registry),
+		integrations:       NewIntegrationService(store, registry, client),
 		codexSubscription:  codexSubscription,
 		providerCatalog:    newProviderCatalogService(store, config.ProviderCatalogFile),
 		billing:            newBillingService(store),
@@ -161,6 +165,8 @@ func NewWithConfig(store Store, config Config) *Server {
 			Model:   config.GuardrailModelName,
 			Timeout: time.Duration(config.GuardrailModelTimeoutSeconds) * time.Second,
 		})),
+		upstreamClient:     client,
+		syntheticDNSPolicy: syntheticDNSPolicy,
 	}
 	if jobs, err := store.FailUnfinishedImageJobs("image_worker_restarted", "Image generation stopped because the server restarted"); err != nil {
 		log.Printf("[tokenhub] failed to mark unfinished image jobs after startup: %v", err)

--- a/backend/internal/server/integration_service.go
+++ b/backend/internal/server/integration_service.go
@@ -10,6 +10,7 @@ import (
 type IntegrationService struct {
 	store    Store
 	registry *AdapterRegistry
+	client   *http.Client
 }
 
 type ProviderProbeBatchResult struct {
@@ -21,8 +22,12 @@ type ProviderProbeBatchResult struct {
 	Errors     []string              `json:"errors,omitempty"`
 }
 
-func NewIntegrationService(store Store, registry *AdapterRegistry) *IntegrationService {
-	return &IntegrationService{store: store, registry: registry}
+func NewIntegrationService(store Store, registry *AdapterRegistry, clients ...*http.Client) *IntegrationService {
+	client := http.DefaultClient
+	if len(clients) > 0 && clients[0] != nil {
+		client = clients[0]
+	}
+	return &IntegrationService{store: store, registry: registry, client: client}
 }
 
 func (s *IntegrationService) TestProviderResource(ctx context.Context, resourceID string, request *ProviderProbeRequest) (any, error) {
@@ -60,7 +65,7 @@ func (s *IntegrationService) TestProviderResource(ctx context.Context, resourceI
 		effective := effectiveProviderResourceConfig(provider, &resource)
 		if len(effective.Headers) > 0 {
 			startedAt := time.Now()
-			_, probeErr := CustomProviderCatalogFromUpstream(ctx, http.DefaultClient, ProviderCreateRequest{
+			_, probeErr := CustomProviderCatalogFromUpstream(ctx, s.client, ProviderCreateRequest{
 				Type: effective.Type, BaseURL: effective.BaseURL, APIKey: effective.APIKey,
 				Headers: effective.Headers, SensitiveHeaders: effective.SensitiveHeaders, Options: effective.Options,
 			})
@@ -132,7 +137,7 @@ func (s *IntegrationService) TestProvider(ctx context.Context, providerID string
 			if firstResourceErr != nil {
 				return nil, firstResourceErr
 			}
-			_, probeErr := CustomProviderCatalogFromUpstream(ctx, http.DefaultClient, ProviderCreateRequest{
+			_, probeErr := CustomProviderCatalogFromUpstream(ctx, s.client, ProviderCreateRequest{
 				Type: effectiveProvider.Type, BaseURL: effectiveProvider.BaseURL, APIKey: effectiveProvider.APIKey,
 				Headers: effectiveProvider.Headers, SensitiveHeaders: effectiveProvider.SensitiveHeaders, Options: effectiveProvider.Options,
 			})

--- a/backend/internal/server/provider_catalog_ssrf_test.go
+++ b/backend/internal/server/provider_catalog_ssrf_test.go
@@ -771,7 +771,7 @@ func TestDialGuardedUpstreamFallbackAfterSlowLookup(t *testing.T) {
 	}
 
 	started := time.Now()
-	conn, err := dialGuardedUpstream(context.Background(), "tcp", "provider.example:443", nil, budget, lookup, dial)
+	conn, err := dialGuardedUpstream(context.Background(), "tcp", "provider.example:443", nil, nil, budget, lookup, dial)
 	if err != nil {
 		t.Fatalf("expected fallback to reach the healthy candidate, got %v (dialed: %v)", err, dialed)
 	}

--- a/backend/internal/server/provider_kronk.go
+++ b/backend/internal/server/provider_kronk.go
@@ -215,7 +215,7 @@ func (s *Server) discoverKronkCatalog(ctx context.Context, req ProviderCreateReq
 		}
 		req.Options = mergedStringMap(provider.Options, req.Options)
 	}
-	entry, err := KronkProviderCatalogFromUpstream(ctx, http.DefaultClient, req)
+	entry, err := KronkProviderCatalogFromUpstream(ctx, s.upstreamClient, req)
 	if err != nil {
 		return ProviderCatalogEntry{}, err
 	}

--- a/backend/internal/server/provider_stream_timeout.go
+++ b/backend/internal/server/provider_stream_timeout.go
@@ -44,28 +44,37 @@ var errProviderStreamIdle = NewHTTPError(
 // through the SSRF guard, and follow the strict redirect policy. Save-time
 // validation alone cannot protect old records or later DNS rebinding, and a
 // redirect must never bounce inference traffic into the internal network.
-func newUpstreamClients(config Config) (*http.Client, *http.Client, time.Duration) {
+func newUpstreamClients(config Config, syntheticDNS ...*providerSyntheticDNSPolicy) (*http.Client, *http.Client, time.Duration) {
 	idleTimeout := upstreamTimeout(config.UpstreamStreamIdleTimeoutSeconds, defaultUpstreamStreamIdleTimeoutSeconds)
 	allowedPrivate := allowedProviderUpstreamCIDRs()
+	var syntheticDNSPolicy *providerSyntheticDNSPolicy
+	if len(syntheticDNS) > 0 {
+		syntheticDNSPolicy = syntheticDNS[0]
+	}
 	client := &http.Client{
 		Timeout:       upstreamTimeout(config.UpstreamNonStreamTimeoutSeconds, defaultUpstreamNonStreamTimeoutSeconds),
-		Transport:     guardProviderUpstreamRequests(ssrfGuardedProviderTransport(allowedPrivate), allowedPrivate),
+		Transport:     guardProviderUpstreamRequests(rotatingProviderUpstreamTransport(allowedPrivate, syntheticDNSPolicy, nil), allowedPrivate),
 		CheckRedirect: strictProviderUpstreamRedirect,
 	}
-	return client, newUpstreamStreamClient(idleTimeout), idleTimeout
+	return client, newUpstreamStreamClient(idleTimeout, syntheticDNS...), idleTimeout
 }
 
 // newUpstreamStreamClient returns the client used for streaming upstream calls:
 // no total deadline, and a header timeout matching the idle budget so a stream
 // that never starts fails on the same terms as one that stops. It dials through
 // the same SSRF-guarded transport as the non-streaming client.
-func newUpstreamStreamClient(idleTimeout time.Duration) *http.Client {
-	// ssrfGuardedProviderTransport already clones the default transport (never
-	// mutates the process-global one) and installs the guarded DialContext with
-	// proxying disabled; only the header timeout is added here.
+func newUpstreamStreamClient(idleTimeout time.Duration, syntheticDNS ...*providerSyntheticDNSPolicy) *http.Client {
+	// Each transport generation clones the default transport (never mutates the
+	// process-global one), installs the guarded DialContext with proxying disabled,
+	// and adds the streaming response-header timeout.
 	allowedPrivate := allowedProviderUpstreamCIDRs()
-	transport := ssrfGuardedProviderTransport(allowedPrivate)
-	transport.ResponseHeaderTimeout = idleTimeout
+	var syntheticDNSPolicy *providerSyntheticDNSPolicy
+	if len(syntheticDNS) > 0 {
+		syntheticDNSPolicy = syntheticDNS[0]
+	}
+	transport := rotatingProviderUpstreamTransport(allowedPrivate, syntheticDNSPolicy, func(transport *http.Transport) {
+		transport.ResponseHeaderTimeout = idleTimeout
+	})
 	return &http.Client{Transport: guardProviderUpstreamRequests(transport, allowedPrivate), CheckRedirect: strictProviderUpstreamRedirect}
 }
 

--- a/backend/internal/server/provider_upstream_review_test.go
+++ b/backend/internal/server/provider_upstream_review_test.go
@@ -149,7 +149,7 @@ func TestProviderUpstreamLoopbackRequiresExplicitOptIn(t *testing.T) {
 
 	dialed := false
 	_, err := dialGuardedUpstream(
-		context.Background(), "tcp", "127.0.0.1:11434", nil, time.Second,
+		context.Background(), "tcp", "127.0.0.1:11434", nil, nil, time.Second,
 		nil,
 		func(context.Context, string, string) (net.Conn, error) {
 			dialed = true
@@ -169,7 +169,7 @@ func TestProviderUpstreamLoopbackExplicitOptIn(t *testing.T) {
 
 	dialed := false
 	_, err := dialGuardedUpstream(
-		context.Background(), "tcp", "127.0.0.1:11434", nil, time.Second,
+		context.Background(), "tcp", "127.0.0.1:11434", nil, nil, time.Second,
 		nil,
 		func(context.Context, string, string) (net.Conn, error) {
 			dialed = true

--- a/backend/internal/server/provider_upstream_ssrf.go
+++ b/backend/internal/server/provider_upstream_ssrf.go
@@ -257,8 +257,8 @@ func checkProviderUpstreamLiteralDial(ip net.IP, allowedPrivate []*net.IPNet) er
 //  2. Redirect following: http clients follow 3xx by default, so a public URL
 //     that returns a redirect to a private target would bypass validation.
 //
-// Trade-off: when the caller passes nil or http.DefaultClient (the production
-// call sites) we build a dedicated Transport whose DialContext resolves the
+// When the caller passes nil or http.DefaultClient, we build a dedicated
+// Transport whose DialContext resolves the
 // hostname, drops any private or link-local candidates, and refuses to connect
 // when none are allowed; otherwise it dials one of the validated addresses
 // directly, so the checked IP is the one actually connected to. When the
@@ -308,7 +308,7 @@ type upstreamDialFunc func(ctx context.Context, network, addr string) (net.Conn,
 // a slow lookup followed by a silently black-holing first address must not
 // starve the healthy candidates behind it (the Happy Eyeballs fallback the
 // default transport would have provided).
-func dialGuardedUpstream(ctx context.Context, network string, addr string, allowedPrivate []*net.IPNet, budget time.Duration, lookup upstreamLookupFunc, dial upstreamDialFunc) (net.Conn, error) {
+func dialGuardedUpstream(ctx context.Context, network string, addr string, allowedPrivate []*net.IPNet, syntheticDNS *providerSyntheticDNSPolicy, budget time.Duration, lookup upstreamLookupFunc, dial upstreamDialFunc) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return nil, err
@@ -334,7 +334,7 @@ func dialGuardedUpstream(ctx context.Context, network string, addr string, allow
 	}
 	var allowed []net.IPAddr
 	for _, ip := range ips {
-		if !isDisallowedProviderUpstreamIP(ip.IP) {
+		if !isDisallowedProviderUpstreamIP(ip.IP) || syntheticDNS.allowsResolvedIPContext(dialCtx, ip.IP) {
 			allowed = append(allowed, ip)
 		}
 	}
@@ -467,16 +467,16 @@ func raceValidatedUpstreamCandidates(ctx context.Context, network, port string, 
 // validated candidate is dialed in turn, so the checked IP is the one actually
 // connected to and a single unreachable address does not fail the request.
 //
-// The private-range allowlist only applies to literal IPs (allowedPrivate): a
-// hostname that resolves to private addresses is still refused, even when the
-// resolved range is allowlisted, because resolution results cannot be trusted
-// the way an administrator-typed literal can (DNS rebinding).
+// The private-range allowlist only applies to literal IPs (allowedPrivate).
+// Hostname results remain denied by default and may pass only through the
+// separately configured synthetic-DNS policy, which is intended for Fake-IP
+// pools intercepted by a transparent proxy.
 //
 // Proxying is disabled on purpose: with an HTTP(S)_PROXY configured, DialContext
 // would receive the proxy address and the guard would validate the proxy rather
 // than the request target, letting the proxy's own DNS resolution bypass the
 // check. Provider catalog fetches therefore always connect directly.
-func ssrfGuardedProviderTransport(allowedPrivate []*net.IPNet) *http.Transport {
+func ssrfGuardedProviderTransport(allowedPrivate []*net.IPNet, syntheticDNS ...*providerSyntheticDNSPolicy) *http.Transport {
 	base, ok := http.DefaultTransport.(*http.Transport)
 	var transport *http.Transport
 	if ok {
@@ -490,8 +490,12 @@ func ssrfGuardedProviderTransport(allowedPrivate []*net.IPNet) *http.Transport {
 		KeepAlive: 30 * time.Second,
 	}
 	resolver := net.DefaultResolver
+	var syntheticDNSPolicy *providerSyntheticDNSPolicy
+	if len(syntheticDNS) > 0 {
+		syntheticDNSPolicy = syntheticDNS[0]
+	}
 	transport.DialContext = func(ctx context.Context, network string, addr string) (net.Conn, error) {
-		return dialGuardedUpstream(ctx, network, addr, allowedPrivate, dialer.Timeout, resolver.LookupIPAddr, dialer.DialContext)
+		return dialGuardedUpstream(ctx, network, addr, allowedPrivate, syntheticDNSPolicy, dialer.Timeout, resolver.LookupIPAddr, dialer.DialContext)
 	}
 	return transport
 }

--- a/backend/internal/server/provider_upstream_ssrf.go
+++ b/backend/internal/server/provider_upstream_ssrf.go
@@ -294,6 +294,10 @@ type upstreamLookupFunc func(ctx context.Context, host string) ([]net.IPAddr, er
 // upstreamDialFunc dials an address, matching net.Dialer.DialContext.
 type upstreamDialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
 
+type providerSyntheticDNSResolver interface {
+	allowsResolvedIPContext(context.Context, net.IP) bool
+}
+
 // dialGuardedUpstream dials addr while enforcing the SSRF classification:
 // loopback identifiers pass only after explicit operator opt-in, literal IPs
 // are checked directly, and hostnames resolve to validated dial candidates,
@@ -308,7 +312,7 @@ type upstreamDialFunc func(ctx context.Context, network, addr string) (net.Conn,
 // a slow lookup followed by a silently black-holing first address must not
 // starve the healthy candidates behind it (the Happy Eyeballs fallback the
 // default transport would have provided).
-func dialGuardedUpstream(ctx context.Context, network string, addr string, allowedPrivate []*net.IPNet, syntheticDNS *providerSyntheticDNSPolicy, budget time.Duration, lookup upstreamLookupFunc, dial upstreamDialFunc) (net.Conn, error) {
+func dialGuardedUpstream(ctx context.Context, network string, addr string, allowedPrivate []*net.IPNet, syntheticDNS providerSyntheticDNSResolver, budget time.Duration, lookup upstreamLookupFunc, dial upstreamDialFunc) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return nil, err
@@ -334,7 +338,7 @@ func dialGuardedUpstream(ctx context.Context, network string, addr string, allow
 	}
 	var allowed []net.IPAddr
 	for _, ip := range ips {
-		if !isDisallowedProviderUpstreamIP(ip.IP) || syntheticDNS.allowsResolvedIPContext(dialCtx, ip.IP) {
+		if !isDisallowedProviderUpstreamIP(ip.IP) || syntheticDNS != nil && syntheticDNS.allowsResolvedIPContext(dialCtx, ip.IP) {
 			allowed = append(allowed, ip)
 		}
 	}
@@ -476,7 +480,7 @@ func raceValidatedUpstreamCandidates(ctx context.Context, network, port string, 
 // would receive the proxy address and the guard would validate the proxy rather
 // than the request target, letting the proxy's own DNS resolution bypass the
 // check. Provider catalog fetches therefore always connect directly.
-func ssrfGuardedProviderTransport(allowedPrivate []*net.IPNet, syntheticDNS ...*providerSyntheticDNSPolicy) *http.Transport {
+func ssrfGuardedProviderTransport(allowedPrivate []*net.IPNet, syntheticDNS ...providerSyntheticDNSResolver) *http.Transport {
 	base, ok := http.DefaultTransport.(*http.Transport)
 	var transport *http.Transport
 	if ok {
@@ -490,7 +494,7 @@ func ssrfGuardedProviderTransport(allowedPrivate []*net.IPNet, syntheticDNS ...*
 		KeepAlive: 30 * time.Second,
 	}
 	resolver := net.DefaultResolver
-	var syntheticDNSPolicy *providerSyntheticDNSPolicy
+	var syntheticDNSPolicy providerSyntheticDNSResolver
 	if len(syntheticDNS) > 0 {
 		syntheticDNSPolicy = syntheticDNS[0]
 	}

--- a/backend/internal/server/provider_upstream_synthetic_dns.go
+++ b/backend/internal/server/provider_upstream_synthetic_dns.go
@@ -1,0 +1,349 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	gatewaySettingsID                 = "cfg_gateway"
+	syntheticDNSEnabledField          = "provider_synthetic_dns_enabled"
+	syntheticDNSCIDRsField            = "provider_synthetic_dns_cidrs"
+	defaultSyntheticDNSCIDRs          = "198.18.0.0/15"
+	syntheticDNSPolicyRefreshInterval = 5 * time.Second
+	syntheticDNSPolicyRefreshTimeout  = 2 * time.Second
+	maxProviderSyntheticDNSCIDRCount  = 16
+)
+
+// providerSyntheticDNSPolicy is the deliberately narrow exception for proxy
+// clients that replace real DNS answers with synthetic addresses. It applies
+// only after a hostname lookup; literal-IP provider URLs never consult it.
+// The short cache avoids a database read for every new TCP connection while
+// still converging settings across replicas without a restart.
+type providerSyntheticDNSPolicy struct {
+	store Store
+
+	mu          sync.Mutex
+	loadedAt    time.Time
+	blocks      []*net.IPNet
+	refreshDone chan struct{}
+	revision    uint64
+
+	transportsMu sync.Mutex
+	transports   []*providerUpstreamTransportPool
+}
+
+func newProviderSyntheticDNSPolicy(store Store) *providerSyntheticDNSPolicy {
+	policy := &providerSyntheticDNSPolicy{store: store}
+	policy.refresh(context.Background())
+	return policy
+}
+
+func (policy *providerSyntheticDNSPolicy) allowsResolvedIP(ip net.IP) bool {
+	return policy.allowsResolvedIPContext(context.Background(), ip)
+}
+
+func (policy *providerSyntheticDNSPolicy) allowsResolvedIPContext(ctx context.Context, ip net.IP) bool {
+	if policy == nil || ip == nil || isNonBypassableProviderSyntheticDNSIP(ip) {
+		return false
+	}
+	for _, block := range policy.configuredBlocks(ctx) {
+		if block.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+type providerSyntheticDNSContextStore interface {
+	ListResourcesContext(context.Context, string) ([]AdminResource, error)
+}
+
+func (policy *providerSyntheticDNSPolicy) configuredBlocks(ctx context.Context) []*net.IPNet {
+	if policy == nil || policy.store == nil {
+		return nil
+	}
+	policy.mu.Lock()
+	if !policy.loadedAt.IsZero() && time.Since(policy.loadedAt) < syntheticDNSPolicyRefreshInterval {
+		blocks := policy.blocks
+		policy.mu.Unlock()
+		return blocks
+	}
+	if policy.refreshDone != nil {
+		done := policy.refreshDone
+		policy.mu.Unlock()
+		select {
+		case <-done:
+		case <-ctx.Done():
+		}
+		policy.mu.Lock()
+		blocks := policy.blocks
+		policy.mu.Unlock()
+		return blocks
+	}
+	policy.refreshDone = make(chan struct{})
+	done := policy.refreshDone
+	revision := policy.revision
+	policy.mu.Unlock()
+
+	refreshCtx, cancel := context.WithTimeout(ctx, syntheticDNSPolicyRefreshTimeout)
+	defer cancel()
+	settings, err := policy.listSettings(refreshCtx)
+	var blocks []*net.IPNet
+	if err == nil {
+		blocks = providerSyntheticDNSBlocksFromSettings(settings)
+	}
+
+	policy.mu.Lock()
+	changed := false
+	staleRefresh := policy.revision != revision
+	if err == nil && !staleRefresh {
+		changed = !providerSyntheticDNSBlocksEqual(policy.blocks, blocks)
+		policy.blocks = blocks
+	} else if err != nil && !staleRefresh {
+		log.Printf("[tokenhub] failed to refresh Provider synthetic DNS settings: %v", err)
+	}
+	if !staleRefresh {
+		policy.loadedAt = time.Now()
+	}
+	policy.refreshDone = nil
+	close(done)
+	current := policy.blocks
+	policy.mu.Unlock()
+	if changed {
+		policy.rotateTransports()
+	}
+	return current
+}
+
+func (policy *providerSyntheticDNSPolicy) refresh(ctx context.Context) {
+	if policy == nil {
+		return
+	}
+	_ = policy.configuredBlocks(ctx)
+}
+
+func (policy *providerSyntheticDNSPolicy) listSettings(ctx context.Context) ([]AdminResource, error) {
+	if store, ok := policy.store.(providerSyntheticDNSContextStore); ok {
+		return store.ListResourcesContext(ctx, "settings")
+	}
+	return policy.store.ListResources("settings"), nil
+}
+
+func providerSyntheticDNSBlocksFromSettings(settings []AdminResource) []*net.IPNet {
+	for _, setting := range settings {
+		if setting.ID != gatewaySettingsID || setting.Status != StatusActive || !truthyField(setting.Fields, syntheticDNSEnabledField) {
+			continue
+		}
+		blocks, err := parseProviderSyntheticDNSCIDRs(stringField(setting.Fields, syntheticDNSCIDRsField))
+		if err == nil {
+			return blocks
+		}
+		return nil
+	}
+	return nil
+}
+
+func (policy *providerSyntheticDNSPolicy) invalidate() {
+	if policy == nil {
+		return
+	}
+	policy.mu.Lock()
+	policy.revision++
+	policy.loadedAt = time.Time{}
+	policy.mu.Unlock()
+	policy.rotateTransports()
+}
+
+func (policy *providerSyntheticDNSPolicy) applySetting(setting *AdminResource) {
+	if policy == nil {
+		return
+	}
+	var blocks []*net.IPNet
+	if setting != nil {
+		blocks = providerSyntheticDNSBlocksFromSettings([]AdminResource{*setting})
+	}
+	policy.mu.Lock()
+	changed := !providerSyntheticDNSBlocksEqual(policy.blocks, blocks)
+	policy.revision++
+	policy.blocks = blocks
+	policy.loadedAt = time.Now()
+	policy.mu.Unlock()
+	if changed {
+		policy.rotateTransports()
+	}
+}
+
+func providerSyntheticDNSBlocksEqual(left, right []*net.IPNet) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index].String() != right[index].String() {
+			return false
+		}
+	}
+	return true
+}
+
+func (policy *providerSyntheticDNSPolicy) registerTransport(transport *providerUpstreamTransportPool) {
+	if policy == nil || transport == nil {
+		return
+	}
+	policy.transportsMu.Lock()
+	policy.transports = append(policy.transports, transport)
+	policy.transportsMu.Unlock()
+}
+
+func (policy *providerSyntheticDNSPolicy) rotateTransports() {
+	if policy == nil {
+		return
+	}
+	policy.transportsMu.Lock()
+	transports := append([]*providerUpstreamTransportPool(nil), policy.transports...)
+	policy.transportsMu.Unlock()
+	for _, transport := range transports {
+		transport.rotate()
+	}
+}
+
+func parseProviderSyntheticDNSCIDRs(raw string) ([]*net.IPNet, error) {
+	entries := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\r' || r == '\t' || r == ' '
+	})
+	if len(entries) == 0 {
+		return nil, NewHTTPError(http.StatusBadRequest, "provider_synthetic_dns_cidrs_required", "At least one synthetic DNS CIDR is required when the exception is enabled")
+	}
+	if len(entries) > maxProviderSyntheticDNSCIDRCount {
+		return nil, NewHTTPError(http.StatusBadRequest, "provider_synthetic_dns_cidrs_invalid", fmt.Sprintf("At most %d synthetic DNS CIDRs are allowed", maxProviderSyntheticDNSCIDRCount))
+	}
+	blocks := make([]*net.IPNet, 0, len(entries))
+	for _, entry := range entries {
+		_, block, err := net.ParseCIDR(entry)
+		if err != nil {
+			return nil, NewHTTPError(http.StatusBadRequest, "provider_synthetic_dns_cidrs_invalid", fmt.Sprintf("Invalid synthetic DNS CIDR %q", entry))
+		}
+		prefix, bits := block.Mask.Size()
+		if (bits == 32 && prefix < 8) || (bits == 128 && prefix < 18) {
+			return nil, NewHTTPError(http.StatusBadRequest, "provider_synthetic_dns_cidrs_too_broad", fmt.Sprintf("Synthetic DNS CIDR %q is too broad", entry))
+		}
+		if providerSyntheticDNSCIDRContainsNonBypassableAddress(block) {
+			return nil, NewHTTPError(http.StatusBadRequest, "provider_synthetic_dns_cidrs_not_allowed", fmt.Sprintf("Synthetic DNS CIDR %q overlaps a protected address range", entry))
+		}
+		blocks = append(blocks, block)
+	}
+	return blocks, nil
+}
+
+// These ranges remain denied even when a synthetic-DNS exception is enabled.
+// Private/ULA, benchmarking, and documentation ranges are intentionally not
+// here: proxy products can use them as configurable synthetic pools. The
+// exception is still constrained to hostname resolution results.
+var nonBypassableProviderSyntheticDNSCIDRs = mustProviderUpstreamCIDRs([]string{
+	"0.0.0.0/8",
+	"127.0.0.0/8",
+	"100.64.0.0/10",
+	"169.254.0.0/16",
+	"192.0.0.0/24",
+	"192.88.99.0/24",
+	"224.0.0.0/4",
+	"240.0.0.0/4",
+	"::/128",
+	"::1/128",
+	"100::/64",
+	"100:0:0:1::/64",
+	"2001:2::/48",
+	"5f00::/16",
+	"64:ff9b::/96",
+	"64:ff9b:1::/48",
+	"fe80::/10",
+	"ff00::/8",
+	"fec0::/10",
+	"fd00:ec2::254/128",
+})
+
+func mustProviderUpstreamCIDRs(cidrs []string) []*net.IPNet {
+	blocks := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, block, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(err)
+		}
+		blocks = append(blocks, block)
+	}
+	return blocks
+}
+
+func isNonBypassableProviderSyntheticDNSIP(ip net.IP) bool {
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsMulticast() {
+		return true
+	}
+	if _, translated := providerUpstreamEmbeddedNAT64IPv4(ip); translated || nat64LocalUsePrefix.Contains(ip) {
+		return true
+	}
+	for _, block := range nonBypassableProviderSyntheticDNSCIDRs {
+		if block.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func providerSyntheticDNSCIDRContainsNonBypassableAddress(candidate *net.IPNet) bool {
+	if candidate == nil {
+		return true
+	}
+	for _, protected := range nonBypassableProviderSyntheticDNSCIDRs {
+		if candidate.Contains(protected.IP) || protected.Contains(candidate.IP) {
+			return true
+		}
+	}
+	if protected, _ := configuredProviderUpstreamNAT64Prefix(); protected != nil && (candidate.Contains(protected.IP) || protected.Contains(candidate.IP)) {
+		return true
+	}
+	return false
+}
+
+func validateProviderSyntheticDNSSettings(resource AdminResource) error {
+	if resource.ID != "" && resource.ID != gatewaySettingsID {
+		return nil
+	}
+	if !truthyField(resource.Fields, syntheticDNSEnabledField) {
+		return nil
+	}
+	_, err := parseProviderSyntheticDNSCIDRs(stringField(resource.Fields, syntheticDNSCIDRsField))
+	return err
+}
+
+func ensureProviderSyntheticDNSSettings(store Store) error {
+	for _, setting := range store.ListResources("settings") {
+		if setting.ID != gatewaySettingsID {
+			continue
+		}
+		if setting.Fields == nil {
+			setting.Fields = map[string]any{}
+		}
+		changed := false
+		if _, ok := setting.Fields[syntheticDNSEnabledField]; !ok {
+			setting.Fields[syntheticDNSEnabledField] = false
+			changed = true
+		}
+		if _, ok := setting.Fields[syntheticDNSCIDRsField]; !ok {
+			setting.Fields[syntheticDNSCIDRsField] = defaultSyntheticDNSCIDRs
+			changed = true
+		}
+		if changed {
+			if _, err := store.UpdateResource("settings", setting.ID, setting); err != nil {
+				return fmt.Errorf("backfill Provider synthetic DNS settings: %w", err)
+			}
+		}
+		return nil
+	}
+	return nil
+}

--- a/backend/internal/server/provider_upstream_synthetic_dns.go
+++ b/backend/internal/server/provider_upstream_synthetic_dns.go
@@ -15,6 +15,7 @@ const (
 	gatewaySettingsID                 = "cfg_gateway"
 	syntheticDNSEnabledField          = "provider_synthetic_dns_enabled"
 	syntheticDNSCIDRsField            = "provider_synthetic_dns_cidrs"
+	syntheticDNSAllowPrivateField     = "provider_synthetic_dns_allow_private_ranges"
 	defaultSyntheticDNSCIDRs          = "198.18.0.0/15"
 	syntheticDNSPolicyRefreshInterval = 5 * time.Second
 	syntheticDNSPolicyRefreshTimeout  = 2 * time.Second
@@ -31,12 +32,35 @@ type providerSyntheticDNSPolicy struct {
 
 	mu          sync.Mutex
 	loadedAt    time.Time
-	blocks      []*net.IPNet
+	snapshot    providerSyntheticDNSSnapshot
 	refreshDone chan struct{}
 	revision    uint64
 
 	transportsMu sync.Mutex
 	transports   []*providerUpstreamTransportPool
+}
+
+// providerSyntheticDNSSnapshot is immutable after construction. Each
+// transport generation captures one snapshot so a settings change cannot
+// alter the SSRF decision of a request that already selected that generation.
+type providerSyntheticDNSSnapshot struct {
+	blocks             []*net.IPNet
+	allowPrivateRanges bool
+}
+
+func (snapshot providerSyntheticDNSSnapshot) allowsResolvedIPContext(_ context.Context, ip net.IP) bool {
+	if ip == nil || isNonBypassableProviderSyntheticDNSIP(ip) {
+		return false
+	}
+	if ip.IsPrivate() && !snapshot.allowPrivateRanges {
+		return false
+	}
+	for _, block := range snapshot.blocks {
+		if block.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 func newProviderSyntheticDNSPolicy(store Store) *providerSyntheticDNSPolicy {
@@ -50,30 +74,25 @@ func (policy *providerSyntheticDNSPolicy) allowsResolvedIP(ip net.IP) bool {
 }
 
 func (policy *providerSyntheticDNSPolicy) allowsResolvedIPContext(ctx context.Context, ip net.IP) bool {
-	if policy == nil || ip == nil || isNonBypassableProviderSyntheticDNSIP(ip) {
+	if policy == nil {
 		return false
 	}
-	for _, block := range policy.configuredBlocks(ctx) {
-		if block.Contains(ip) {
-			return true
-		}
-	}
-	return false
+	return policy.configuredSnapshot(ctx).allowsResolvedIPContext(ctx, ip)
 }
 
 type providerSyntheticDNSContextStore interface {
 	ListResourcesContext(context.Context, string) ([]AdminResource, error)
 }
 
-func (policy *providerSyntheticDNSPolicy) configuredBlocks(ctx context.Context) []*net.IPNet {
+func (policy *providerSyntheticDNSPolicy) configuredSnapshot(ctx context.Context) providerSyntheticDNSSnapshot {
 	if policy == nil || policy.store == nil {
-		return nil
+		return providerSyntheticDNSSnapshot{}
 	}
 	policy.mu.Lock()
 	if !policy.loadedAt.IsZero() && time.Since(policy.loadedAt) < syntheticDNSPolicyRefreshInterval {
-		blocks := policy.blocks
+		snapshot := policy.snapshot
 		policy.mu.Unlock()
-		return blocks
+		return snapshot
 	}
 	if policy.refreshDone != nil {
 		done := policy.refreshDone
@@ -83,9 +102,9 @@ func (policy *providerSyntheticDNSPolicy) configuredBlocks(ctx context.Context) 
 		case <-ctx.Done():
 		}
 		policy.mu.Lock()
-		blocks := policy.blocks
+		snapshot := policy.snapshot
 		policy.mu.Unlock()
-		return blocks
+		return snapshot
 	}
 	policy.refreshDone = make(chan struct{})
 	done := policy.refreshDone
@@ -95,17 +114,17 @@ func (policy *providerSyntheticDNSPolicy) configuredBlocks(ctx context.Context) 
 	refreshCtx, cancel := context.WithTimeout(ctx, syntheticDNSPolicyRefreshTimeout)
 	defer cancel()
 	settings, err := policy.listSettings(refreshCtx)
-	var blocks []*net.IPNet
+	var snapshot providerSyntheticDNSSnapshot
 	if err == nil {
-		blocks = providerSyntheticDNSBlocksFromSettings(settings)
+		snapshot = providerSyntheticDNSSnapshotFromSettings(settings)
 	}
 
 	policy.mu.Lock()
 	changed := false
 	staleRefresh := policy.revision != revision
 	if err == nil && !staleRefresh {
-		changed = !providerSyntheticDNSBlocksEqual(policy.blocks, blocks)
-		policy.blocks = blocks
+		changed = !providerSyntheticDNSSnapshotsEqual(policy.snapshot, snapshot)
+		policy.snapshot = snapshot
 	} else if err != nil && !staleRefresh {
 		log.Printf("[tokenhub] failed to refresh Provider synthetic DNS settings: %v", err)
 	}
@@ -114,10 +133,10 @@ func (policy *providerSyntheticDNSPolicy) configuredBlocks(ctx context.Context) 
 	}
 	policy.refreshDone = nil
 	close(done)
-	current := policy.blocks
+	current := policy.snapshot
 	policy.mu.Unlock()
 	if changed {
-		policy.rotateTransports()
+		policy.rotateTransports(current)
 	}
 	return current
 }
@@ -126,7 +145,7 @@ func (policy *providerSyntheticDNSPolicy) refresh(ctx context.Context) {
 	if policy == nil {
 		return
 	}
-	_ = policy.configuredBlocks(ctx)
+	_ = policy.configuredSnapshot(ctx)
 }
 
 func (policy *providerSyntheticDNSPolicy) listSettings(ctx context.Context) ([]AdminResource, error) {
@@ -136,56 +155,46 @@ func (policy *providerSyntheticDNSPolicy) listSettings(ctx context.Context) ([]A
 	return policy.store.ListResources("settings"), nil
 }
 
-func providerSyntheticDNSBlocksFromSettings(settings []AdminResource) []*net.IPNet {
+func providerSyntheticDNSSnapshotFromSettings(settings []AdminResource) providerSyntheticDNSSnapshot {
 	for _, setting := range settings {
 		if setting.ID != gatewaySettingsID || setting.Status != StatusActive || !truthyField(setting.Fields, syntheticDNSEnabledField) {
 			continue
 		}
-		blocks, err := parseProviderSyntheticDNSCIDRs(stringField(setting.Fields, syntheticDNSCIDRsField))
+		allowPrivate := truthyField(setting.Fields, syntheticDNSAllowPrivateField)
+		blocks, err := parseProviderSyntheticDNSCIDRs(stringField(setting.Fields, syntheticDNSCIDRsField), allowPrivate)
 		if err == nil {
-			return blocks
+			return providerSyntheticDNSSnapshot{blocks: blocks, allowPrivateRanges: allowPrivate}
 		}
-		return nil
+		return providerSyntheticDNSSnapshot{}
 	}
-	return nil
-}
-
-func (policy *providerSyntheticDNSPolicy) invalidate() {
-	if policy == nil {
-		return
-	}
-	policy.mu.Lock()
-	policy.revision++
-	policy.loadedAt = time.Time{}
-	policy.mu.Unlock()
-	policy.rotateTransports()
+	return providerSyntheticDNSSnapshot{}
 }
 
 func (policy *providerSyntheticDNSPolicy) applySetting(setting *AdminResource) {
 	if policy == nil {
 		return
 	}
-	var blocks []*net.IPNet
+	var snapshot providerSyntheticDNSSnapshot
 	if setting != nil {
-		blocks = providerSyntheticDNSBlocksFromSettings([]AdminResource{*setting})
+		snapshot = providerSyntheticDNSSnapshotFromSettings([]AdminResource{*setting})
 	}
 	policy.mu.Lock()
-	changed := !providerSyntheticDNSBlocksEqual(policy.blocks, blocks)
+	changed := !providerSyntheticDNSSnapshotsEqual(policy.snapshot, snapshot)
 	policy.revision++
-	policy.blocks = blocks
+	policy.snapshot = snapshot
 	policy.loadedAt = time.Now()
 	policy.mu.Unlock()
 	if changed {
-		policy.rotateTransports()
+		policy.rotateTransports(snapshot)
 	}
 }
 
-func providerSyntheticDNSBlocksEqual(left, right []*net.IPNet) bool {
-	if len(left) != len(right) {
+func providerSyntheticDNSSnapshotsEqual(left, right providerSyntheticDNSSnapshot) bool {
+	if left.allowPrivateRanges != right.allowPrivateRanges || len(left.blocks) != len(right.blocks) {
 		return false
 	}
-	for index := range left {
-		if left[index].String() != right[index].String() {
+	for index := range left.blocks {
+		if left.blocks[index].String() != right.blocks[index].String() {
 			return false
 		}
 	}
@@ -201,7 +210,7 @@ func (policy *providerSyntheticDNSPolicy) registerTransport(transport *providerU
 	policy.transportsMu.Unlock()
 }
 
-func (policy *providerSyntheticDNSPolicy) rotateTransports() {
+func (policy *providerSyntheticDNSPolicy) rotateTransports(snapshot providerSyntheticDNSSnapshot) {
 	if policy == nil {
 		return
 	}
@@ -209,11 +218,11 @@ func (policy *providerSyntheticDNSPolicy) rotateTransports() {
 	transports := append([]*providerUpstreamTransportPool(nil), policy.transports...)
 	policy.transportsMu.Unlock()
 	for _, transport := range transports {
-		transport.rotate()
+		transport.rotate(snapshot)
 	}
 }
 
-func parseProviderSyntheticDNSCIDRs(raw string) ([]*net.IPNet, error) {
+func parseProviderSyntheticDNSCIDRs(raw string, allowPrivate bool) ([]*net.IPNet, error) {
 	entries := strings.FieldsFunc(raw, func(r rune) bool {
 		return r == ',' || r == ';' || r == '\n' || r == '\r' || r == '\t' || r == ' '
 	})
@@ -236,15 +245,38 @@ func parseProviderSyntheticDNSCIDRs(raw string) ([]*net.IPNet, error) {
 		if providerSyntheticDNSCIDRContainsNonBypassableAddress(block) {
 			return nil, NewHTTPError(http.StatusBadRequest, "provider_synthetic_dns_cidrs_not_allowed", fmt.Sprintf("Synthetic DNS CIDR %q overlaps a protected address range", entry))
 		}
+		if !allowPrivate && providerSyntheticDNSCIDRContainsPrivateAddress(block) {
+			return nil, NewHTTPError(http.StatusBadRequest, "provider_synthetic_dns_private_cidr_requires_unsafe_mode", fmt.Sprintf("Synthetic DNS CIDR %q overlaps a private address range; enable unsafe private-range trust explicitly", entry))
+		}
 		blocks = append(blocks, block)
 	}
 	return blocks, nil
 }
 
+var providerSyntheticDNSPrivateCIDRs = mustProviderUpstreamCIDRs([]string{
+	"10.0.0.0/8",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+	"fc00::/7",
+})
+
+func providerSyntheticDNSCIDRContainsPrivateAddress(candidate *net.IPNet) bool {
+	if candidate == nil {
+		return true
+	}
+	for _, private := range providerSyntheticDNSPrivateCIDRs {
+		if candidate.Contains(private.IP) || private.Contains(candidate.IP) {
+			return true
+		}
+	}
+	return false
+}
+
 // These ranges remain denied even when a synthetic-DNS exception is enabled.
-// Private/ULA, benchmarking, and documentation ranges are intentionally not
-// here: proxy products can use them as configurable synthetic pools. The
-// exception is still constrained to hostname resolution results.
+// Private/ULA ranges are gated separately by the explicit high-risk trust
+// setting. Benchmarking and documentation ranges are intentionally not here:
+// proxy products can use them as configurable synthetic pools. The exception
+// is still constrained to hostname resolution results.
 var nonBypassableProviderSyntheticDNSCIDRs = mustProviderUpstreamCIDRs([]string{
 	"0.0.0.0/8",
 	"127.0.0.0/8",
@@ -317,12 +349,17 @@ func validateProviderSyntheticDNSSettings(resource AdminResource) error {
 	if !truthyField(resource.Fields, syntheticDNSEnabledField) {
 		return nil
 	}
-	_, err := parseProviderSyntheticDNSCIDRs(stringField(resource.Fields, syntheticDNSCIDRsField))
+	allowPrivate := truthyField(resource.Fields, syntheticDNSAllowPrivateField)
+	_, err := parseProviderSyntheticDNSCIDRs(stringField(resource.Fields, syntheticDNSCIDRsField), allowPrivate)
 	return err
 }
 
 func ensureProviderSyntheticDNSSettings(store Store) error {
-	for _, setting := range store.ListResources("settings") {
+	settings, err := store.ListResourcesChecked("settings")
+	if err != nil {
+		return fmt.Errorf("read Provider synthetic DNS settings for backfill: %w", err)
+	}
+	for _, setting := range settings {
 		if setting.ID != gatewaySettingsID {
 			continue
 		}
@@ -336,6 +373,10 @@ func ensureProviderSyntheticDNSSettings(store Store) error {
 		}
 		if _, ok := setting.Fields[syntheticDNSCIDRsField]; !ok {
 			setting.Fields[syntheticDNSCIDRsField] = defaultSyntheticDNSCIDRs
+			changed = true
+		}
+		if _, ok := setting.Fields[syntheticDNSAllowPrivateField]; !ok {
+			setting.Fields[syntheticDNSAllowPrivateField] = false
 			changed = true
 		}
 		if changed {

--- a/backend/internal/server/provider_upstream_synthetic_dns_test.go
+++ b/backend/internal/server/provider_upstream_synthetic_dns_test.go
@@ -1,0 +1,394 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func syntheticDNSSettings(enabled bool, cidrs string) AdminResource {
+	return AdminResource{
+		ID:     gatewaySettingsID,
+		Name:   "Gateway Base Settings",
+		Status: StatusActive,
+		Fields: map[string]any{
+			syntheticDNSEnabledField: enabled,
+			syntheticDNSCIDRsField:   cidrs,
+		},
+	}
+}
+
+func TestProviderSyntheticDNSPolicyAllowsOnlyConfiguredResolvedAddresses(t *testing.T) {
+	store := NewMemoryStore()
+	store.CreateResource("settings", syntheticDNSSettings(true, "198.18.0.0/15\nfc00::/18"))
+	policy := newProviderSyntheticDNSPolicy(store)
+
+	for _, candidate := range []string{"198.18.0.1", "198.19.255.254", "fc00::1"} {
+		if !policy.allowsResolvedIP(net.ParseIP(candidate)) {
+			t.Fatalf("expected configured synthetic address %s to pass", candidate)
+		}
+	}
+	for _, candidate := range []string{"10.0.0.1", "169.254.169.254", "127.0.0.1", "64:ff9b::a9fe:a9fe"} {
+		if policy.allowsResolvedIP(net.ParseIP(candidate)) {
+			t.Fatalf("expected unconfigured or protected address %s to stay blocked", candidate)
+		}
+	}
+	if err := checkProviderUpstreamLiteralDial(net.ParseIP("198.18.0.1"), nil); !errors.Is(err, errProviderUpstreamDialDisallowed) {
+		t.Fatalf("expected literal synthetic IP to stay rejected, got %v", err)
+	}
+}
+
+func TestProviderSyntheticDNSPolicyUpdatesAfterInvalidation(t *testing.T) {
+	store := NewMemoryStore()
+	setting := store.CreateResource("settings", syntheticDNSSettings(false, defaultSyntheticDNSCIDRs))
+	policy := newProviderSyntheticDNSPolicy(store)
+	if policy.allowsResolvedIP(net.ParseIP("198.18.0.1")) {
+		t.Fatal("expected disabled policy to reject the synthetic address")
+	}
+	setting.Fields[syntheticDNSEnabledField] = true
+	if _, err := store.UpdateResource("settings", gatewaySettingsID, setting); err != nil {
+		t.Fatal(err)
+	}
+	policy.invalidate()
+	if !policy.allowsResolvedIP(net.ParseIP("198.18.0.1")) {
+		t.Fatal("expected the enabled policy to apply without restarting")
+	}
+}
+
+func TestProviderSyntheticDNSPolicyRefreshesExpiredSnapshotWithoutInvalidation(t *testing.T) {
+	store := NewMemoryStore()
+	setting := store.CreateResource("settings", syntheticDNSSettings(false, defaultSyntheticDNSCIDRs))
+	policy := newProviderSyntheticDNSPolicy(store)
+	address := net.ParseIP("198.18.0.1")
+	if policy.allowsResolvedIP(address) {
+		t.Fatal("expected disabled policy to reject the synthetic address")
+	}
+	setting.Fields[syntheticDNSEnabledField] = true
+	if _, err := store.UpdateResource("settings", gatewaySettingsID, setting); err != nil {
+		t.Fatal(err)
+	}
+	policy.mu.Lock()
+	policy.loadedAt = time.Now().Add(-syntheticDNSPolicyRefreshInterval)
+	policy.mu.Unlock()
+	if !policy.allowsResolvedIP(address) {
+		t.Fatal("expected an expired snapshot to refresh from the shared store")
+	}
+}
+
+type timeoutSyntheticDNSStore struct {
+	Store
+	calls int
+}
+
+func (store *timeoutSyntheticDNSStore) ListResourcesContext(ctx context.Context, kind string) ([]AdminResource, error) {
+	store.calls++
+	if store.calls == 1 {
+		return store.Store.ListResources(kind), nil
+	}
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestProviderSyntheticDNSPolicyBoundsSlowRefreshAndKeepsLastSnapshot(t *testing.T) {
+	base := NewMemoryStore()
+	base.CreateResource("settings", syntheticDNSSettings(true, defaultSyntheticDNSCIDRs))
+	store := &timeoutSyntheticDNSStore{Store: base}
+	policy := newProviderSyntheticDNSPolicy(store)
+	policy.mu.Lock()
+	policy.loadedAt = time.Now().Add(-syntheticDNSPolicyRefreshInterval)
+	policy.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	if !policy.allowsResolvedIPContext(ctx, net.ParseIP("198.18.0.1")) {
+		t.Fatal("expected a failed refresh to retain the last valid policy snapshot")
+	}
+	if elapsed := time.Since(started); elapsed > 250*time.Millisecond {
+		t.Fatalf("expected the refresh to obey its context, took %s", elapsed)
+	}
+}
+
+type controlledSyntheticDNSRefreshStore struct {
+	Store
+	calls   atomic.Int32
+	started chan struct{}
+	release chan struct{}
+}
+
+func (store *controlledSyntheticDNSRefreshStore) ListResourcesContext(ctx context.Context, kind string) ([]AdminResource, error) {
+	if store.calls.Add(1) == 1 {
+		return store.Store.ListResources(kind), nil
+	}
+	snapshot := store.Store.ListResources(kind)
+	close(store.started)
+	select {
+	case <-store.release:
+		return snapshot, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func TestProviderSyntheticDNSPolicyDoesNotOverwriteLocalUpdateWithStaleRefresh(t *testing.T) {
+	base := NewMemoryStore()
+	setting := base.CreateResource("settings", syntheticDNSSettings(false, defaultSyntheticDNSCIDRs))
+	store := &controlledSyntheticDNSRefreshStore{
+		Store:   base,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	policy := newProviderSyntheticDNSPolicy(store)
+	policy.mu.Lock()
+	policy.loadedAt = time.Now().Add(-syntheticDNSPolicyRefreshInterval)
+	policy.mu.Unlock()
+
+	refreshed := make(chan struct{})
+	go func() {
+		policy.refresh(context.Background())
+		close(refreshed)
+	}()
+	select {
+	case <-store.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the stale refresh")
+	}
+	setting.Fields[syntheticDNSEnabledField] = true
+	if _, err := base.UpdateResource("settings", gatewaySettingsID, setting); err != nil {
+		t.Fatal(err)
+	}
+	policy.applySetting(&setting)
+	close(store.release)
+	select {
+	case <-refreshed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the stale refresh to finish")
+	}
+	if !policy.allowsResolvedIP(net.ParseIP("198.18.0.1")) {
+		t.Fatal("expected the newer local update to win over the stale refresh result")
+	}
+}
+
+func TestDialGuardedUpstreamUsesSyntheticDNSOnlyForHostnameResults(t *testing.T) {
+	store := NewMemoryStore()
+	store.CreateResource("settings", syntheticDNSSettings(true, defaultSyntheticDNSCIDRs))
+	policy := newProviderSyntheticDNSPolicy(store)
+	lookup := func(context.Context, string) ([]net.IPAddr, error) {
+		return []net.IPAddr{{IP: net.ParseIP("198.18.0.1")}}, nil
+	}
+	dialed := ""
+	dial := func(_ context.Context, _, addr string) (net.Conn, error) {
+		dialed = addr
+		return nil, errors.New("dial reached")
+	}
+	_, err := dialGuardedUpstream(context.Background(), "tcp", "provider.example:443", nil, policy, time.Second, lookup, dial)
+	if err == nil || !strings.Contains(err.Error(), "dial reached") || dialed != "198.18.0.1:443" {
+		t.Fatalf("expected configured hostname result to reach the dialer, got addr=%q err=%v", dialed, err)
+	}
+
+	dialed = ""
+	_, err = dialGuardedUpstream(context.Background(), "tcp", "198.18.0.1:443", nil, policy, time.Second, lookup, dial)
+	if !errors.Is(err, errProviderUpstreamDialDisallowed) || dialed != "" {
+		t.Fatalf("expected literal address to fail before dialing, got addr=%q err=%v", dialed, err)
+	}
+}
+
+func TestValidateProviderSyntheticDNSSettingsRejectsUnsafeCIDRs(t *testing.T) {
+	for _, test := range []struct {
+		cidrs string
+		code  string
+	}{
+		{"", "provider_synthetic_dns_cidrs_required"},
+		{"not-a-cidr", "provider_synthetic_dns_cidrs_invalid"},
+		{"0.0.0.0/0", "provider_synthetic_dns_cidrs_too_broad"},
+		{"169.254.0.0/16", "provider_synthetic_dns_cidrs_not_allowed"},
+		{"fc00::/7", "provider_synthetic_dns_cidrs_too_broad"},
+	} {
+		err := validateProviderSyntheticDNSSettings(syntheticDNSSettings(true, test.cidrs))
+		if code := AsHTTPError(err).Code; code != test.code {
+			t.Fatalf("expected %q to fail with %s, got %s (%v)", test.cidrs, test.code, code, err)
+		}
+	}
+	for _, cidrs := range []string{"198.18.0.0/15", "28.0.0.0/8", "fc00::/18", "10.0.0.0/8"} {
+		if err := validateProviderSyntheticDNSSettings(syntheticDNSSettings(true, cidrs)); err != nil {
+			t.Fatalf("expected explicit synthetic range %q to be accepted, got %v", cidrs, err)
+		}
+	}
+	t.Setenv(providerUpstreamNAT64PrefixEnv, "fd00:64::/64")
+	err := validateProviderSyntheticDNSSettings(syntheticDNSSettings(true, "fd00:64::/64"))
+	if code := AsHTTPError(err).Code; code != "provider_synthetic_dns_cidrs_not_allowed" {
+		t.Fatalf("expected the configured NAT64 prefix to stay protected, got %s (%v)", code, err)
+	}
+}
+
+func TestAdminSettingsRejectInvalidSyntheticDNSCIDR(t *testing.T) {
+	store := NewMemoryStore()
+	if err := BootstrapBaseData(store); err != nil {
+		t.Fatal(err)
+	}
+	setting := store.ListResources("settings")[0]
+	setting.Fields[syntheticDNSEnabledField] = true
+	setting.Fields[syntheticDNSCIDRsField] = "169.254.0.0/16"
+	response := doJSON(t, New(store).Handler(), http.MethodPatch, "/api/admin/resources/settings/"+gatewaySettingsID, setting, "")
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body, "provider_synthetic_dns_cidrs_not_allowed") {
+		t.Fatalf("expected invalid synthetic range to be rejected, got %d: %s", response.Code, response.Body)
+	}
+}
+
+func TestAdminSettingsApplySyntheticDNSPolicyWithoutRestart(t *testing.T) {
+	store := NewMemoryStore()
+	if err := BootstrapBaseData(store); err != nil {
+		t.Fatal(err)
+	}
+	server := New(store)
+	address := net.ParseIP("198.18.0.1")
+	if server.syntheticDNSPolicy.allowsResolvedIP(address) {
+		t.Fatal("expected the seeded policy to start disabled")
+	}
+	setting := store.ListResources("settings")[0]
+	setting.Fields[syntheticDNSEnabledField] = true
+	response := doJSON(t, server.Handler(), http.MethodPatch, "/api/admin/resources/settings/"+gatewaySettingsID, setting, "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected valid setting update, got %d: %s", response.Code, response.Body)
+	}
+	if !server.syntheticDNSPolicy.allowsResolvedIP(address) {
+		t.Fatal("expected the saved setting to affect new dials without a restart")
+	}
+}
+
+func TestAdminSettingsPostValidatesSyntheticDNSCIDR(t *testing.T) {
+	store := NewMemoryStore()
+	if err := BootstrapBaseData(store); err != nil {
+		t.Fatal(err)
+	}
+	server := New(store)
+	setting := syntheticDNSSettings(true, "169.254.0.0/16")
+	response := doJSON(t, server.Handler(), http.MethodPost, "/api/admin/resources/settings", setting, "")
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body, "provider_synthetic_dns_cidrs_not_allowed") {
+		t.Fatalf("expected POST upsert to enforce the same validation as PATCH, got %d: %s", response.Code, response.Body)
+	}
+}
+
+func TestAdminSettingsDeleteDisablesSyntheticDNSPolicyImmediately(t *testing.T) {
+	store := NewMemoryStore()
+	if err := BootstrapBaseData(store); err != nil {
+		t.Fatal(err)
+	}
+	setting := store.ListResources("settings")[0]
+	setting.Fields[syntheticDNSEnabledField] = true
+	if _, err := store.UpdateResource("settings", gatewaySettingsID, setting); err != nil {
+		t.Fatal(err)
+	}
+	server := New(store)
+	address := net.ParseIP("198.18.0.1")
+	if !server.syntheticDNSPolicy.allowsResolvedIP(address) {
+		t.Fatal("expected the policy to start enabled")
+	}
+	response := doJSON(t, server.Handler(), http.MethodDelete, "/api/admin/resources/settings/"+gatewaySettingsID, nil, "")
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("expected settings deletion to succeed, got %d: %s", response.Code, response.Body)
+	}
+	if server.syntheticDNSPolicy.allowsResolvedIP(address) {
+		t.Fatal("expected deleting the gateway settings to disable the policy immediately")
+	}
+}
+
+type delayedSyntheticDNSUpdateStore struct {
+	Store
+	committed chan struct{}
+	release   chan struct{}
+}
+
+func (store *delayedSyntheticDNSUpdateStore) UpdateResource(kind string, id string, patch AdminResource) (AdminResource, error) {
+	resource, err := store.Store.UpdateResource(kind, id, patch)
+	if err == nil && kind == "settings" && id == gatewaySettingsID && truthyField(patch.Fields, syntheticDNSEnabledField) {
+		close(store.committed)
+		<-store.release
+	}
+	return resource, err
+}
+
+func TestConcurrentAdminSettingsMutationsApplyInCommitOrder(t *testing.T) {
+	base := NewMemoryStore()
+	if err := BootstrapBaseData(base); err != nil {
+		t.Fatal(err)
+	}
+	store := &delayedSyntheticDNSUpdateStore{
+		Store:     base,
+		committed: make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+	server := New(store)
+	responses := make(chan responseBody, 2)
+	go func() {
+		responses <- doJSON(t, server.Handler(), http.MethodPatch, "/api/admin/resources/settings/"+gatewaySettingsID, syntheticDNSSettings(true, defaultSyntheticDNSCIDRs), "")
+	}()
+	select {
+	case <-store.committed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the first settings commit")
+	}
+	go func() {
+		responses <- doJSON(t, server.Handler(), http.MethodPatch, "/api/admin/resources/settings/"+gatewaySettingsID, syntheticDNSSettings(false, defaultSyntheticDNSCIDRs), "")
+	}()
+	close(store.release)
+	for range 2 {
+		select {
+		case response := <-responses:
+			if response.Code != http.StatusOK {
+				t.Fatalf("expected concurrent settings update to succeed, got %d: %s", response.Code, response.Body)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for concurrent settings updates")
+		}
+	}
+	if server.syntheticDNSPolicy.allowsResolvedIP(net.ParseIP("198.18.0.1")) {
+		t.Fatal("expected the later disabled setting to win in memory as well as in the store")
+	}
+}
+
+func TestBootstrapBackfillsProviderSyntheticDNSSettings(t *testing.T) {
+	store := NewMemoryStore()
+	store.CreateResource("settings", AdminResource{
+		ID: gatewaySettingsID, Name: "Existing settings", Status: StatusActive,
+		Fields: map[string]any{"public_base_url": "https://gateway.example.com"},
+	})
+	if err := BootstrapBaseData(store); err != nil {
+		t.Fatal(err)
+	}
+	setting := store.ListResources("settings")[0]
+	if _, ok := setting.Fields[syntheticDNSEnabledField]; !ok {
+		t.Fatalf("expected enabled flag to be backfilled: %+v", setting.Fields)
+	}
+	if got := stringField(setting.Fields, syntheticDNSCIDRsField); got != defaultSyntheticDNSCIDRs {
+		t.Fatalf("expected default CIDR to be backfilled, got %q", got)
+	}
+}
+
+type failingSyntheticDNSBackfillStore struct {
+	Store
+}
+
+func (store failingSyntheticDNSBackfillStore) UpdateResource(kind string, id string, patch AdminResource) (AdminResource, error) {
+	if kind == "settings" && id == gatewaySettingsID {
+		return AdminResource{}, errors.New("backfill failed")
+	}
+	return store.Store.UpdateResource(kind, id, patch)
+}
+
+func TestBootstrapReportsProviderSyntheticDNSBackfillFailure(t *testing.T) {
+	store := NewMemoryStore()
+	store.CreateResource("settings", AdminResource{
+		ID: gatewaySettingsID, Name: "Existing settings", Status: StatusActive,
+		Fields: map[string]any{"public_base_url": "https://gateway.example.com"},
+	})
+	err := BootstrapBaseData(failingSyntheticDNSBackfillStore{Store: store})
+	if err == nil || !strings.Contains(err.Error(), "backfill Provider synthetic DNS settings") {
+		t.Fatalf("expected bootstrap to report the backfill failure, got %v", err)
+	}
+}

--- a/backend/internal/server/provider_upstream_synthetic_dns_test.go
+++ b/backend/internal/server/provider_upstream_synthetic_dns_test.go
@@ -17,23 +17,30 @@ func syntheticDNSSettings(enabled bool, cidrs string) AdminResource {
 		Name:   "Gateway Base Settings",
 		Status: StatusActive,
 		Fields: map[string]any{
-			syntheticDNSEnabledField: enabled,
-			syntheticDNSCIDRsField:   cidrs,
+			syntheticDNSEnabledField:      enabled,
+			syntheticDNSCIDRsField:        cidrs,
+			syntheticDNSAllowPrivateField: false,
 		},
 	}
 }
 
+func syntheticDNSSettingsWithPrivateTrust(enabled bool, cidrs string) AdminResource {
+	setting := syntheticDNSSettings(enabled, cidrs)
+	setting.Fields[syntheticDNSAllowPrivateField] = true
+	return setting
+}
+
 func TestProviderSyntheticDNSPolicyAllowsOnlyConfiguredResolvedAddresses(t *testing.T) {
 	store := NewMemoryStore()
-	store.CreateResource("settings", syntheticDNSSettings(true, "198.18.0.0/15\nfc00::/18"))
+	store.CreateResource("settings", syntheticDNSSettings(true, "198.18.0.0/15"))
 	policy := newProviderSyntheticDNSPolicy(store)
 
-	for _, candidate := range []string{"198.18.0.1", "198.19.255.254", "fc00::1"} {
+	for _, candidate := range []string{"198.18.0.1", "198.19.255.254"} {
 		if !policy.allowsResolvedIP(net.ParseIP(candidate)) {
 			t.Fatalf("expected configured synthetic address %s to pass", candidate)
 		}
 	}
-	for _, candidate := range []string{"10.0.0.1", "169.254.169.254", "127.0.0.1", "64:ff9b::a9fe:a9fe"} {
+	for _, candidate := range []string{"10.0.0.1", "fc00::1", "169.254.169.254", "127.0.0.1", "64:ff9b::a9fe:a9fe"} {
 		if policy.allowsResolvedIP(net.ParseIP(candidate)) {
 			t.Fatalf("expected unconfigured or protected address %s to stay blocked", candidate)
 		}
@@ -43,20 +50,30 @@ func TestProviderSyntheticDNSPolicyAllowsOnlyConfiguredResolvedAddresses(t *test
 	}
 }
 
-func TestProviderSyntheticDNSPolicyUpdatesAfterInvalidation(t *testing.T) {
-	store := NewMemoryStore()
-	setting := store.CreateResource("settings", syntheticDNSSettings(false, defaultSyntheticDNSCIDRs))
-	policy := newProviderSyntheticDNSPolicy(store)
-	if policy.allowsResolvedIP(net.ParseIP("198.18.0.1")) {
-		t.Fatal("expected disabled policy to reject the synthetic address")
+func TestProviderSyntheticDNSPrivateRangesRequireUnsafeTrust(t *testing.T) {
+	for _, cidr := range []string{"10.0.0.0/8", "fc00::/18"} {
+		err := validateProviderSyntheticDNSSettings(syntheticDNSSettings(true, cidr))
+		if code := AsHTTPError(err).Code; code != "provider_synthetic_dns_private_cidr_requires_unsafe_mode" {
+			t.Fatalf("expected %q to require unsafe private-range trust, got %s (%v)", cidr, code, err)
+		}
+		if err := validateProviderSyntheticDNSSettings(syntheticDNSSettingsWithPrivateTrust(true, cidr)); err != nil {
+			t.Fatalf("expected unsafe private-range trust to accept %q, got %v", cidr, err)
+		}
 	}
-	setting.Fields[syntheticDNSEnabledField] = true
+
+	store := NewMemoryStore()
+	setting := store.CreateResource("settings", syntheticDNSSettings(true, "10.0.0.0/8"))
+	policy := newProviderSyntheticDNSPolicy(store)
+	if policy.allowsResolvedIP(net.ParseIP("10.0.0.1")) {
+		t.Fatal("expected ordinary synthetic DNS mode to keep RFC1918 blocked")
+	}
+	setting.Fields[syntheticDNSAllowPrivateField] = true
 	if _, err := store.UpdateResource("settings", gatewaySettingsID, setting); err != nil {
 		t.Fatal(err)
 	}
-	policy.invalidate()
-	if !policy.allowsResolvedIP(net.ParseIP("198.18.0.1")) {
-		t.Fatal("expected the enabled policy to apply without restarting")
+	policy.applySetting(&setting)
+	if !policy.allowsResolvedIP(net.ParseIP("10.0.0.1")) {
+		t.Fatal("expected explicitly enabled unsafe private-range trust to allow RFC1918")
 	}
 }
 
@@ -208,19 +225,21 @@ func TestValidateProviderSyntheticDNSSettingsRejectsUnsafeCIDRs(t *testing.T) {
 		{"0.0.0.0/0", "provider_synthetic_dns_cidrs_too_broad"},
 		{"169.254.0.0/16", "provider_synthetic_dns_cidrs_not_allowed"},
 		{"fc00::/7", "provider_synthetic_dns_cidrs_too_broad"},
+		{"10.0.0.0/8", "provider_synthetic_dns_private_cidr_requires_unsafe_mode"},
+		{"fc00::/18", "provider_synthetic_dns_private_cidr_requires_unsafe_mode"},
 	} {
 		err := validateProviderSyntheticDNSSettings(syntheticDNSSettings(true, test.cidrs))
 		if code := AsHTTPError(err).Code; code != test.code {
 			t.Fatalf("expected %q to fail with %s, got %s (%v)", test.cidrs, test.code, code, err)
 		}
 	}
-	for _, cidrs := range []string{"198.18.0.0/15", "28.0.0.0/8", "fc00::/18", "10.0.0.0/8"} {
+	for _, cidrs := range []string{"198.18.0.0/15", "28.0.0.0/8"} {
 		if err := validateProviderSyntheticDNSSettings(syntheticDNSSettings(true, cidrs)); err != nil {
 			t.Fatalf("expected explicit synthetic range %q to be accepted, got %v", cidrs, err)
 		}
 	}
 	t.Setenv(providerUpstreamNAT64PrefixEnv, "fd00:64::/64")
-	err := validateProviderSyntheticDNSSettings(syntheticDNSSettings(true, "fd00:64::/64"))
+	err := validateProviderSyntheticDNSSettings(syntheticDNSSettingsWithPrivateTrust(true, "fd00:64::/64"))
 	if code := AsHTTPError(err).Code; code != "provider_synthetic_dns_cidrs_not_allowed" {
 		t.Fatalf("expected the configured NAT64 prefix to stay protected, got %s (%v)", code, err)
 	}
@@ -237,6 +256,31 @@ func TestAdminSettingsRejectInvalidSyntheticDNSCIDR(t *testing.T) {
 	response := doJSON(t, New(store).Handler(), http.MethodPatch, "/api/admin/resources/settings/"+gatewaySettingsID, setting, "")
 	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body, "provider_synthetic_dns_cidrs_not_allowed") {
 		t.Fatalf("expected invalid synthetic range to be rejected, got %d: %s", response.Code, response.Body)
+	}
+}
+
+func TestAdminSettingsRequireUnsafeTrustForPrivateSyntheticDNSCIDR(t *testing.T) {
+	store := NewMemoryStore()
+	if err := BootstrapBaseData(store); err != nil {
+		t.Fatal(err)
+	}
+	server := New(store)
+	setting := store.ListResources("settings")[0]
+	setting.Fields[syntheticDNSEnabledField] = true
+	setting.Fields[syntheticDNSCIDRsField] = "10.0.0.0/8"
+
+	response := doJSON(t, server.Handler(), http.MethodPatch, "/api/admin/resources/settings/"+gatewaySettingsID, setting, "")
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body, "provider_synthetic_dns_private_cidr_requires_unsafe_mode") {
+		t.Fatalf("expected ordinary mode to reject the private range, got %d: %s", response.Code, response.Body)
+	}
+
+	setting.Fields[syntheticDNSAllowPrivateField] = true
+	response = doJSON(t, server.Handler(), http.MethodPatch, "/api/admin/resources/settings/"+gatewaySettingsID, setting, "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected explicit unsafe trust to accept the private range, got %d: %s", response.Code, response.Body)
+	}
+	if !server.syntheticDNSPolicy.allowsResolvedIP(net.ParseIP("10.0.0.1")) {
+		t.Fatal("expected the saved unsafe setting to apply to the runtime policy")
 	}
 }
 
@@ -271,6 +315,33 @@ func TestAdminSettingsPostValidatesSyntheticDNSCIDR(t *testing.T) {
 	response := doJSON(t, server.Handler(), http.MethodPost, "/api/admin/resources/settings", setting, "")
 	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body, "provider_synthetic_dns_cidrs_not_allowed") {
 		t.Fatalf("expected POST upsert to enforce the same validation as PATCH, got %d: %s", response.Code, response.Body)
+	}
+}
+
+type failingSyntheticDNSCreateStore struct {
+	Store
+}
+
+func (store failingSyntheticDNSCreateStore) CreateResourceChecked(kind string, resource AdminResource) (AdminResource, error) {
+	if kind == "settings" && resource.ID == gatewaySettingsID {
+		return AdminResource{}, errors.New("synthetic DNS settings write failed")
+	}
+	return store.Store.CreateResourceChecked(kind, resource)
+}
+
+func TestAdminSettingsPostDoesNotApplySyntheticDNSPolicyWhenPersistenceFails(t *testing.T) {
+	base := NewMemoryStore()
+	if err := BootstrapBaseData(base); err != nil {
+		t.Fatal(err)
+	}
+	server := New(failingSyntheticDNSCreateStore{Store: base})
+	address := net.ParseIP("198.18.0.1")
+	response := doJSON(t, server.Handler(), http.MethodPost, "/api/admin/resources/settings", syntheticDNSSettings(true, defaultSyntheticDNSCIDRs), "")
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("expected failed persistence to return 500, got %d: %s", response.Code, response.Body)
+	}
+	if server.syntheticDNSPolicy.allowsResolvedIP(address) {
+		t.Fatal("expected failed persistence to leave the runtime policy disabled")
 	}
 }
 
@@ -368,6 +439,34 @@ func TestBootstrapBackfillsProviderSyntheticDNSSettings(t *testing.T) {
 	if got := stringField(setting.Fields, syntheticDNSCIDRsField); got != defaultSyntheticDNSCIDRs {
 		t.Fatalf("expected default CIDR to be backfilled, got %q", got)
 	}
+	if truthyField(setting.Fields, syntheticDNSAllowPrivateField) {
+		t.Fatal("expected unsafe private-range trust to be backfilled as disabled")
+	}
+}
+
+func TestSeedDemoDataPersistsPrivateSyntheticDNSSettingAsDisabled(t *testing.T) {
+	store := NewMemoryStore()
+	if err := SeedDemoData(store); err != nil {
+		t.Fatal(err)
+	}
+	settings := store.ListResources("settings")
+	var gatewaySetting *AdminResource
+	for index := range settings {
+		if settings[index].ID == gatewaySettingsID {
+			gatewaySetting = &settings[index]
+			break
+		}
+	}
+	if gatewaySetting == nil {
+		t.Fatal("expected demo seed to persist gateway settings")
+	}
+	value, ok := gatewaySetting.Fields[syntheticDNSAllowPrivateField]
+	if !ok {
+		t.Fatalf("expected demo seed to persist %q explicitly", syntheticDNSAllowPrivateField)
+	}
+	if truthyField(map[string]any{syntheticDNSAllowPrivateField: value}, syntheticDNSAllowPrivateField) {
+		t.Fatal("expected demo seed to keep private-range trust disabled")
+	}
 }
 
 type failingSyntheticDNSBackfillStore struct {
@@ -390,5 +489,34 @@ func TestBootstrapReportsProviderSyntheticDNSBackfillFailure(t *testing.T) {
 	err := BootstrapBaseData(failingSyntheticDNSBackfillStore{Store: store})
 	if err == nil || !strings.Contains(err.Error(), "backfill Provider synthetic DNS settings") {
 		t.Fatalf("expected bootstrap to report the backfill failure, got %v", err)
+	}
+}
+
+type failingSyntheticDNSBackfillReadStore struct {
+	Store
+}
+
+func (store failingSyntheticDNSBackfillReadStore) ListResourcesChecked(kind string) ([]AdminResource, error) {
+	if kind == "settings" {
+		return nil, errors.New("settings read failed")
+	}
+	return store.Store.ListResourcesChecked(kind)
+}
+
+func TestBootstrapReportsProviderSyntheticDNSBackfillReadFailure(t *testing.T) {
+	store := NewMemoryStore()
+	err := BootstrapBaseData(failingSyntheticDNSBackfillReadStore{Store: store})
+	if err == nil || !strings.Contains(err.Error(), "read Provider synthetic DNS settings for backfill") {
+		t.Fatalf("expected bootstrap to report the settings read failure, got %v", err)
+	}
+}
+
+func TestListResourcesCheckedPreservesStoreContext(t *testing.T) {
+	store := NewMemoryStore()
+	ctx, cancel := context.WithCancel(context.Background())
+	contextual := store.WithContext(ctx)
+	cancel()
+	if _, err := contextual.ListResourcesChecked("settings"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected the checked read to preserve the canceled store context, got %v", err)
 	}
 }

--- a/backend/internal/server/provider_upstream_synthetic_dns_test.go
+++ b/backend/internal/server/provider_upstream_synthetic_dns_test.go
@@ -469,8 +469,61 @@ func TestSeedDemoDataPersistsPrivateSyntheticDNSSettingAsDisabled(t *testing.T) 
 	}
 }
 
+func TestSeedDemoDataPreservesExistingProviderSyntheticDNSSettings(t *testing.T) {
+	store := NewMemoryStore()
+	if err := BootstrapBaseData(store); err != nil {
+		t.Fatal(err)
+	}
+	findGatewaySetting := func() AdminResource {
+		t.Helper()
+		for _, setting := range store.ListResources("settings") {
+			if setting.ID == gatewaySettingsID {
+				return setting
+			}
+		}
+		t.Fatal("expected gateway settings")
+		return AdminResource{}
+	}
+	setting := findGatewaySetting()
+	setting.Fields[syntheticDNSEnabledField] = true
+	setting.Fields[syntheticDNSCIDRsField] = "28.0.0.0/8"
+	if _, err := store.UpdateResource("settings", gatewaySettingsID, setting); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SeedDemoData(store); err != nil {
+		t.Fatal(err)
+	}
+	setting = findGatewaySetting()
+	if !truthyField(setting.Fields, syntheticDNSEnabledField) {
+		t.Fatalf("expected demo seed to preserve the enabled setting, got %+v", setting.Fields)
+	}
+	if got := stringField(setting.Fields, syntheticDNSCIDRsField); got != "28.0.0.0/8" {
+		t.Fatalf("expected demo seed to preserve the custom CIDR, got %q", got)
+	}
+}
+
 type failingSyntheticDNSBackfillStore struct {
 	Store
+}
+
+type failingSyntheticDNSSeedCreateStore struct {
+	Store
+}
+
+func (store failingSyntheticDNSSeedCreateStore) CreateResourceChecked(kind string, resource AdminResource) (AdminResource, error) {
+	if kind == "settings" && resource.ID == gatewaySettingsID {
+		return AdminResource{}, errors.New("gateway settings create failed")
+	}
+	return store.Store.CreateResourceChecked(kind, resource)
+}
+
+func TestBootstrapReportsProviderSyntheticDNSSeedCreateFailure(t *testing.T) {
+	store := NewMemoryStore()
+	err := BootstrapBaseData(failingSyntheticDNSSeedCreateStore{Store: store})
+	if err == nil || !strings.Contains(err.Error(), "seed gateway settings") {
+		t.Fatalf("expected bootstrap to report the gateway settings create failure, got %v", err)
+	}
 }
 
 func (store failingSyntheticDNSBackfillStore) UpdateResource(kind string, id string, patch AdminResource) (AdminResource, error) {
@@ -492,22 +545,30 @@ func TestBootstrapReportsProviderSyntheticDNSBackfillFailure(t *testing.T) {
 	}
 }
 
-type failingSyntheticDNSBackfillReadStore struct {
+type failingSyntheticDNSSettingsReadStore struct {
 	Store
 }
 
-func (store failingSyntheticDNSBackfillReadStore) ListResourcesChecked(kind string) ([]AdminResource, error) {
+func (store failingSyntheticDNSSettingsReadStore) ListResourcesChecked(kind string) ([]AdminResource, error) {
 	if kind == "settings" {
 		return nil, errors.New("settings read failed")
 	}
 	return store.Store.ListResourcesChecked(kind)
 }
 
-func TestBootstrapReportsProviderSyntheticDNSBackfillReadFailure(t *testing.T) {
+func TestBootstrapReportsProviderSyntheticDNSSeedReadFailure(t *testing.T) {
 	store := NewMemoryStore()
-	err := BootstrapBaseData(failingSyntheticDNSBackfillReadStore{Store: store})
+	err := BootstrapBaseData(failingSyntheticDNSSettingsReadStore{Store: store})
+	if err == nil || !strings.Contains(err.Error(), "seed gateway settings") {
+		t.Fatalf("expected bootstrap to report the gateway settings read failure, got %v", err)
+	}
+}
+
+func TestEnsureProviderSyntheticDNSSettingsReportsBackfillReadFailure(t *testing.T) {
+	store := NewMemoryStore()
+	err := ensureProviderSyntheticDNSSettings(failingSyntheticDNSSettingsReadStore{Store: store})
 	if err == nil || !strings.Contains(err.Error(), "read Provider synthetic DNS settings for backfill") {
-		t.Fatalf("expected bootstrap to report the settings read failure, got %v", err)
+		t.Fatalf("expected the backfill to report the settings read failure, got %v", err)
 	}
 }
 

--- a/backend/internal/server/provider_upstream_transport_pool.go
+++ b/backend/internal/server/provider_upstream_transport_pool.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"net"
+	"net/http"
+	"sync"
+)
+
+// providerUpstreamTransportPool swaps the underlying connection pool whenever
+// the synthetic-DNS policy changes. New requests immediately use the new pool;
+// requests already in flight keep their original transport and may finish
+// normally. Closing the retired pool's idle connections prevents a revoked
+// synthetic range from being reused by a later request.
+type providerUpstreamTransportPool struct {
+	mu      sync.RWMutex
+	current *http.Transport
+	factory func() *http.Transport
+	policy  *providerSyntheticDNSPolicy
+}
+
+func newProviderUpstreamTransportPool(policy *providerSyntheticDNSPolicy, factory func() *http.Transport) *providerUpstreamTransportPool {
+	pool := &providerUpstreamTransportPool{
+		current: factory(),
+		factory: factory,
+		policy:  policy,
+	}
+	policy.registerTransport(pool)
+	return pool
+}
+
+func (pool *providerUpstreamTransportPool) RoundTrip(request *http.Request) (*http.Response, error) {
+	if pool.policy != nil && request != nil {
+		pool.policy.refresh(request.Context())
+	}
+	pool.mu.RLock()
+	transport := pool.current
+	pool.mu.RUnlock()
+	return transport.RoundTrip(request)
+}
+
+func (pool *providerUpstreamTransportPool) CloseIdleConnections() {
+	pool.mu.RLock()
+	transport := pool.current
+	pool.mu.RUnlock()
+	transport.CloseIdleConnections()
+}
+
+func (pool *providerUpstreamTransportPool) rotate() {
+	if pool == nil || pool.factory == nil {
+		return
+	}
+	replacement := pool.factory()
+	pool.mu.Lock()
+	retired := pool.current
+	pool.current = replacement
+	pool.mu.Unlock()
+	if retired != nil {
+		retired.CloseIdleConnections()
+	}
+}
+
+func rotatingProviderUpstreamTransport(allowedPrivate []*net.IPNet, policy *providerSyntheticDNSPolicy, configure func(*http.Transport)) http.RoundTripper {
+	factory := func() *http.Transport {
+		transport := ssrfGuardedProviderTransport(allowedPrivate, policy)
+		if configure != nil {
+			configure(transport)
+		}
+		return transport
+	}
+	if policy == nil {
+		return factory()
+	}
+	return newProviderUpstreamTransportPool(policy, factory)
+}

--- a/backend/internal/server/provider_upstream_transport_pool.go
+++ b/backend/internal/server/provider_upstream_transport_pool.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"sync"
@@ -14,13 +15,14 @@ import (
 type providerUpstreamTransportPool struct {
 	mu      sync.RWMutex
 	current *http.Transport
-	factory func() *http.Transport
+	factory func(providerSyntheticDNSSnapshot) *http.Transport
 	policy  *providerSyntheticDNSPolicy
 }
 
-func newProviderUpstreamTransportPool(policy *providerSyntheticDNSPolicy, factory func() *http.Transport) *providerUpstreamTransportPool {
+func newProviderUpstreamTransportPool(policy *providerSyntheticDNSPolicy, factory func(providerSyntheticDNSSnapshot) *http.Transport) *providerUpstreamTransportPool {
+	snapshot := policy.configuredSnapshot(context.Background())
 	pool := &providerUpstreamTransportPool{
-		current: factory(),
+		current: factory(snapshot),
 		factory: factory,
 		policy:  policy,
 	}
@@ -45,11 +47,11 @@ func (pool *providerUpstreamTransportPool) CloseIdleConnections() {
 	transport.CloseIdleConnections()
 }
 
-func (pool *providerUpstreamTransportPool) rotate() {
+func (pool *providerUpstreamTransportPool) rotate(snapshot providerSyntheticDNSSnapshot) {
 	if pool == nil || pool.factory == nil {
 		return
 	}
-	replacement := pool.factory()
+	replacement := pool.factory(snapshot)
 	pool.mu.Lock()
 	retired := pool.current
 	pool.current = replacement
@@ -60,15 +62,15 @@ func (pool *providerUpstreamTransportPool) rotate() {
 }
 
 func rotatingProviderUpstreamTransport(allowedPrivate []*net.IPNet, policy *providerSyntheticDNSPolicy, configure func(*http.Transport)) http.RoundTripper {
-	factory := func() *http.Transport {
-		transport := ssrfGuardedProviderTransport(allowedPrivate, policy)
+	factory := func(snapshot providerSyntheticDNSSnapshot) *http.Transport {
+		transport := ssrfGuardedProviderTransport(allowedPrivate, snapshot)
 		if configure != nil {
 			configure(transport)
 		}
 		return transport
 	}
 	if policy == nil {
-		return factory()
+		return factory(providerSyntheticDNSSnapshot{})
 	}
 	return newProviderUpstreamTransportPool(policy, factory)
 }

--- a/backend/internal/server/provider_upstream_transport_pool_test.go
+++ b/backend/internal/server/provider_upstream_transport_pool_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestProviderUpstreamTransportRotationUsesNewPoolWithoutInterruptingInflightRequest(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/slow" {
+			close(started)
+			<-release
+		}
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	var dials atomic.Int32
+	factory := func() *http.Transport {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		dialer := &net.Dialer{Timeout: time.Second}
+		transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+			dials.Add(1)
+			return dialer.DialContext(ctx, network, address)
+		}
+		return transport
+	}
+	store := NewMemoryStore()
+	store.CreateResource("settings", syntheticDNSSettings(false, defaultSyntheticDNSCIDRs))
+	policy := newProviderSyntheticDNSPolicy(store)
+	pool := newProviderUpstreamTransportPool(policy, factory)
+	client := &http.Client{Transport: pool}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		response, err := client.Get(upstream.URL + "/slow")
+		if err == nil {
+			_, _ = io.Copy(io.Discard, response.Body)
+			err = response.Body.Close()
+		}
+		firstDone <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the in-flight request")
+	}
+
+	enabled := syntheticDNSSettings(true, defaultSyntheticDNSCIDRs)
+	policy.applySetting(&enabled)
+	response, err := client.Get(upstream.URL + "/fast")
+	if err != nil {
+		t.Fatalf("new generation request failed: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
+	close(release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("rotation interrupted the in-flight request: %v", err)
+	}
+	if got := dials.Load(); got != 2 {
+		t.Fatalf("expected each transport generation to dial once, got %d dials", got)
+	}
+}

--- a/backend/internal/server/provider_upstream_transport_pool_test.go
+++ b/backend/internal/server/provider_upstream_transport_pool_test.go
@@ -2,10 +2,12 @@ package server
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -25,7 +27,7 @@ func TestProviderUpstreamTransportRotationUsesNewPoolWithoutInterruptingInflight
 	defer upstream.Close()
 
 	var dials atomic.Int32
-	factory := func() *http.Transport {
+	factory := func(providerSyntheticDNSSnapshot) *http.Transport {
 		transport := http.DefaultTransport.(*http.Transport).Clone()
 		dialer := &net.Dialer{Timeout: time.Second}
 		transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
@@ -69,5 +71,66 @@ func TestProviderUpstreamTransportRotationUsesNewPoolWithoutInterruptingInflight
 	}
 	if got := dials.Load(); got != 2 {
 		t.Fatalf("expected each transport generation to dial once, got %d dials", got)
+	}
+}
+
+func TestProviderUpstreamTransportRotationKeepsPreDialRequestPolicySnapshot(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	oldDialStarted := make(chan struct{})
+	releaseOldDial := make(chan struct{})
+	var generations atomic.Int32
+	factory := func(snapshot providerSyntheticDNSSnapshot) *http.Transport {
+		generation := generations.Add(1)
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		dialer := &net.Dialer{Timeout: time.Second}
+		transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+			if generation == 1 {
+				close(oldDialStarted)
+				select {
+				case <-releaseOldDial:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			}
+			if !snapshot.allowsResolvedIPContext(ctx, net.ParseIP("198.18.0.1")) {
+				return nil, errors.New("synthetic DNS policy snapshot rejected dial")
+			}
+			return dialer.DialContext(ctx, network, address)
+		}
+		return transport
+	}
+	store := NewMemoryStore()
+	store.CreateResource("settings", syntheticDNSSettings(true, defaultSyntheticDNSCIDRs))
+	policy := newProviderSyntheticDNSPolicy(store)
+	client := &http.Client{Transport: newProviderUpstreamTransportPool(policy, factory)}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		response, err := client.Get(upstream.URL)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, response.Body)
+			err = response.Body.Close()
+		}
+		firstDone <- err
+	}()
+	select {
+	case <-oldDialStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the old request before dial completion")
+	}
+
+	disabled := syntheticDNSSettings(false, defaultSyntheticDNSCIDRs)
+	policy.applySetting(&disabled)
+	close(releaseOldDial)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("expected the pre-dial request to retain its original policy snapshot: %v", err)
+	}
+	if _, err := client.Get(upstream.URL); err == nil || !strings.Contains(err.Error(), "policy snapshot rejected dial") {
+		t.Fatalf("expected a new request to use the disabled policy generation, got %v", err)
 	}
 }

--- a/backend/internal/server/seed.go
+++ b/backend/internal/server/seed.go
@@ -130,7 +130,9 @@ func SeedDemoDataWithConfig(store Store, config Config) error {
 		Status:             StatusActive,
 	})
 
-	seedAdminResources(store)
+	if err := seedAdminResources(store); err != nil {
+		return err
+	}
 
 	if err := seedMockData(store); err != nil {
 		return err
@@ -144,7 +146,9 @@ func BootstrapBaseData(store Store) error {
 }
 
 func BootstrapBaseDataWithConfig(store Store, config Config) error {
-	seedDefaultOrgResources(store)
+	if err := seedDefaultOrgResources(store); err != nil {
+		return err
+	}
 	if err := seedBootstrapAdmin(store, config.BootstrapAdminPassword); err != nil {
 		return err
 	}
@@ -225,7 +229,7 @@ func seedDefaultModelCatalog(store Store, catalogFile string) error {
 	return nil
 }
 
-func seedDefaultOrgResources(store Store) {
+func seedDefaultOrgResources(store Store) error {
 	seedResourceIfMissing(store, "teams", AdminResource{
 		ID:          "team_platform",
 		Name:        "Platform Engineering Team",
@@ -265,13 +269,18 @@ func seedDefaultOrgResources(store Store) {
 		Description: "Public model API address, request timeout, and audit retention period.",
 		Status:      StatusActive,
 		Fields: map[string]any{
-			"public_base_url":       "http://localhost:8080",
-			"default_timeout":       "120s",
-			"audit_retention":       "180d",
-			"api_key_prefix":        DefaultAPIKeyPrefix,
-			"api_key_random_length": DefaultAPIKeyRandomLength,
+			"public_base_url":        "http://localhost:8080",
+			"default_timeout":        "120s",
+			"audit_retention":        "180d",
+			"api_key_prefix":         DefaultAPIKeyPrefix,
+			"api_key_random_length":  DefaultAPIKeyRandomLength,
+			syntheticDNSEnabledField: false,
+			syntheticDNSCIDRsField:   defaultSyntheticDNSCIDRs,
 		},
 	})
+	if err := ensureProviderSyntheticDNSSettings(store); err != nil {
+		return err
+	}
 	seedResourceIfMissing(store, "identity-providers", AdminResource{
 		ID:          "idp_oidc_template",
 		Name:        "Enterprise OIDC/OAuth Identity Source",
@@ -293,6 +302,7 @@ func seedDefaultOrgResources(store Store) {
 		},
 	})
 	seedDefaultRoleConfigs(store)
+	return nil
 }
 
 func seedDefaultRoleConfigs(store Store) {
@@ -348,8 +358,10 @@ func seedResourceIfMissing(store Store, kind string, resource AdminResource) {
 	store.CreateResource(kind, resource)
 }
 
-func seedAdminResources(store Store) {
-	seedDefaultOrgResources(store)
+func seedAdminResources(store Store) error {
+	if err := seedDefaultOrgResources(store); err != nil {
+		return err
+	}
 	store.CreateResource("monitors", AdminResource{
 		ID:          "mon_gateway",
 		Name:        "Core Chat Model Heartbeat",
@@ -390,11 +402,13 @@ func seedAdminResources(store Store) {
 		Description: "Default OpenAI-compatible gateway configuration.",
 		Status:      StatusActive,
 		Fields: map[string]any{
-			"public_base_url":       "http://localhost:8080",
-			"default_timeout":       "120s",
-			"audit_retention":       "180d",
-			"api_key_prefix":        DefaultAPIKeyPrefix,
-			"api_key_random_length": DefaultAPIKeyRandomLength,
+			"public_base_url":        "http://localhost:8080",
+			"default_timeout":        "120s",
+			"audit_retention":        "180d",
+			"api_key_prefix":         DefaultAPIKeyPrefix,
+			"api_key_random_length":  DefaultAPIKeyRandomLength,
+			syntheticDNSEnabledField: false,
+			syntheticDNSCIDRsField:   defaultSyntheticDNSCIDRs,
 		},
 	})
 	store.CreateResource("security-policies", AdminResource{
@@ -484,6 +498,7 @@ func seedAdminResources(store Store) {
 			"recipients": "finance@example.com",
 		},
 	})
+	return nil
 }
 
 func seedMockData(store Store) error {

--- a/backend/internal/server/seed.go
+++ b/backend/internal/server/seed.go
@@ -263,7 +263,7 @@ func seedDefaultOrgResources(store Store) error {
 			"error_passthrough": "sanitized",
 		},
 	})
-	seedResourceIfMissing(store, "settings", AdminResource{
+	if err := seedResourceIfMissingChecked(store, "settings", AdminResource{
 		ID:          "cfg_gateway",
 		Name:        "Gateway Base Settings",
 		Description: "Public model API address, request timeout, and audit retention period.",
@@ -278,7 +278,9 @@ func seedDefaultOrgResources(store Store) error {
 			syntheticDNSCIDRsField:        defaultSyntheticDNSCIDRs,
 			syntheticDNSAllowPrivateField: false,
 		},
-	})
+	}); err != nil {
+		return fmt.Errorf("seed gateway settings: %w", err)
+	}
 	if err := ensureProviderSyntheticDNSSettings(store); err != nil {
 		return err
 	}
@@ -359,6 +361,20 @@ func seedResourceIfMissing(store Store, kind string, resource AdminResource) {
 	store.CreateResource(kind, resource)
 }
 
+func seedResourceIfMissingChecked(store Store, kind string, resource AdminResource) error {
+	resources, err := store.ListResourcesChecked(kind)
+	if err != nil {
+		return err
+	}
+	for _, existing := range resources {
+		if existing.ID == resource.ID {
+			return nil
+		}
+	}
+	_, err = store.CreateResourceChecked(kind, resource)
+	return err
+}
+
 func seedAdminResources(store Store) error {
 	if err := seedDefaultOrgResources(store); err != nil {
 		return err
@@ -395,22 +411,6 @@ func seedAdminResources(store Store) error {
 		Fields: map[string]any{
 			"notify_mode": "silent",
 			"target":      "all_admins",
-		},
-	})
-	store.CreateResource("settings", AdminResource{
-		ID:          "cfg_gateway",
-		Name:        "Gateway Base Settings",
-		Description: "Default OpenAI-compatible gateway configuration.",
-		Status:      StatusActive,
-		Fields: map[string]any{
-			"public_base_url":             "http://localhost:8080",
-			"default_timeout":             "120s",
-			"audit_retention":             "180d",
-			"api_key_prefix":              DefaultAPIKeyPrefix,
-			"api_key_random_length":       DefaultAPIKeyRandomLength,
-			syntheticDNSEnabledField:      false,
-			syntheticDNSCIDRsField:        defaultSyntheticDNSCIDRs,
-			syntheticDNSAllowPrivateField: false,
 		},
 	})
 	store.CreateResource("security-policies", AdminResource{

--- a/backend/internal/server/seed.go
+++ b/backend/internal/server/seed.go
@@ -269,13 +269,14 @@ func seedDefaultOrgResources(store Store) error {
 		Description: "Public model API address, request timeout, and audit retention period.",
 		Status:      StatusActive,
 		Fields: map[string]any{
-			"public_base_url":        "http://localhost:8080",
-			"default_timeout":        "120s",
-			"audit_retention":        "180d",
-			"api_key_prefix":         DefaultAPIKeyPrefix,
-			"api_key_random_length":  DefaultAPIKeyRandomLength,
-			syntheticDNSEnabledField: false,
-			syntheticDNSCIDRsField:   defaultSyntheticDNSCIDRs,
+			"public_base_url":             "http://localhost:8080",
+			"default_timeout":             "120s",
+			"audit_retention":             "180d",
+			"api_key_prefix":              DefaultAPIKeyPrefix,
+			"api_key_random_length":       DefaultAPIKeyRandomLength,
+			syntheticDNSEnabledField:      false,
+			syntheticDNSCIDRsField:        defaultSyntheticDNSCIDRs,
+			syntheticDNSAllowPrivateField: false,
 		},
 	})
 	if err := ensureProviderSyntheticDNSSettings(store); err != nil {
@@ -402,13 +403,14 @@ func seedAdminResources(store Store) error {
 		Description: "Default OpenAI-compatible gateway configuration.",
 		Status:      StatusActive,
 		Fields: map[string]any{
-			"public_base_url":        "http://localhost:8080",
-			"default_timeout":        "120s",
-			"audit_retention":        "180d",
-			"api_key_prefix":         DefaultAPIKeyPrefix,
-			"api_key_random_length":  DefaultAPIKeyRandomLength,
-			syntheticDNSEnabledField: false,
-			syntheticDNSCIDRsField:   defaultSyntheticDNSCIDRs,
+			"public_base_url":             "http://localhost:8080",
+			"default_timeout":             "120s",
+			"audit_retention":             "180d",
+			"api_key_prefix":              DefaultAPIKeyPrefix,
+			"api_key_random_length":       DefaultAPIKeyRandomLength,
+			syntheticDNSEnabledField:      false,
+			syntheticDNSCIDRsField:        defaultSyntheticDNSCIDRs,
+			syntheticDNSAllowPrivateField: false,
 		},
 	})
 	store.CreateResource("security-policies", AdminResource{

--- a/backend/internal/server/store.go
+++ b/backend/internal/server/store.go
@@ -219,8 +219,10 @@ type Store interface {
 	ListAuditEvents() []AuditEvent
 	RecordAuditEvent(event AuditEvent)
 	CreateResource(kind string, resource AdminResource) AdminResource
+	CreateResourceChecked(kind string, resource AdminResource) (AdminResource, error)
 	CreateRoutingPolicy(resource AdminResource) (AdminResource, error)
 	ListResources(kind string) []AdminResource
+	ListResourcesChecked(kind string) ([]AdminResource, error)
 	UpdateResource(kind string, id string, patch AdminResource) (AdminResource, error)
 	DeleteResource(kind string, id string) error
 	DeleteTeam(id string) error

--- a/backend/internal/server/store_admin.go
+++ b/backend/internal/server/store_admin.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -58,6 +59,12 @@ func (s *GormStore) ListResources(kind string) []AdminResource {
 	var items []AdminResource
 	_ = s.db.Where("kind = ?", kind).Order("created_at asc").Find(&items).Error
 	return items
+}
+
+func (s *GormStore) ListResourcesContext(ctx context.Context, kind string) ([]AdminResource, error) {
+	var items []AdminResource
+	err := s.db.WithContext(ctx).Where("kind = ?", kind).Order("created_at asc").Find(&items).Error
+	return items, err
 }
 
 func (s *GormStore) UpdateResource(kind string, id string, patch AdminResource) (AdminResource, error) {

--- a/backend/internal/server/store_admin.go
+++ b/backend/internal/server/store_admin.go
@@ -12,10 +12,14 @@ import (
 )
 
 func (s *GormStore) CreateResource(kind string, resource AdminResource) AdminResource {
+	resource, _ = s.CreateResourceChecked(kind, resource)
+	return resource
+}
+
+func (s *GormStore) CreateResourceChecked(kind string, resource AdminResource) (AdminResource, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	resource, _ = s.createResourceLocked(kind, resource, true)
-	return resource
+	return s.createResourceLocked(kind, resource, true)
 }
 
 func (s *GormStore) CreateRoutingPolicy(resource AdminResource) (AdminResource, error) {
@@ -56,9 +60,16 @@ func (s *GormStore) createResourceLocked(kind string, resource AdminResource, up
 }
 
 func (s *GormStore) ListResources(kind string) []AdminResource {
-	var items []AdminResource
-	_ = s.db.Where("kind = ?", kind).Order("created_at asc").Find(&items).Error
+	items, _ := s.ListResourcesChecked(kind)
 	return items
+}
+
+// ListResourcesChecked preserves any context already attached to s.db (for
+// example, the startup lease context) while making query failures observable.
+func (s *GormStore) ListResourcesChecked(kind string) ([]AdminResource, error) {
+	var items []AdminResource
+	err := s.db.Where("kind = ?", kind).Order("created_at asc").Find(&items).Error
+	return items, err
 }
 
 func (s *GormStore) ListResourcesContext(ctx context.Context, kind string) ([]AdminResource, error) {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -404,6 +404,8 @@ Options: `--rebuild`, `--reset` to drop the local database, `--backend-port N`, 
 | `TOKENHUB_DB_CONN_MAX_LIFETIME_MINUTES` | `30` | Maximum connection lifetime in minutes (PostgreSQL only) |
 | `TOKENHUB_API` | empty | Target Admin API for the `tokenhub-migrate` CLI. Read only by that CLI, never by the running server; overridden by `--to` |
 
+When the TokenHub host runs a proxy in Fake-IP mode, configure **System Settings → Base Settings → Synthetic DNS / Fake-IP ranges**. The exception is disabled by default and applies only to hostname resolution results, never to literal-IP Provider URLs. Enter the proxy's actual pool rather than assuming every implementation uses `198.18.0.0/15`: that range is reserved for benchmarking and is common, but not exclusive, for Fake-IP. Loopback, link-local, metadata, multicast, and NAT64 ranges remain blocked.
+
 ## Frontend Environment Variables
 
 | Variable | Default | Description |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -404,7 +404,7 @@ Options: `--rebuild`, `--reset` to drop the local database, `--backend-port N`, 
 | `TOKENHUB_DB_CONN_MAX_LIFETIME_MINUTES` | `30` | Maximum connection lifetime in minutes (PostgreSQL only) |
 | `TOKENHUB_API` | empty | Target Admin API for the `tokenhub-migrate` CLI. Read only by that CLI, never by the running server; overridden by `--to` |
 
-When the TokenHub host runs a proxy in Fake-IP mode, configure **System Settings → Base Settings → Synthetic DNS / Fake-IP ranges**. The exception is disabled by default and applies only to hostname resolution results, never to literal-IP Provider URLs. Enter the proxy's actual pool rather than assuming every implementation uses `198.18.0.0/15`: that range is reserved for benchmarking and is common, but not exclusive, for Fake-IP. Loopback, link-local, metadata, multicast, and NAT64 ranges remain blocked.
+When the TokenHub host runs a proxy in Fake-IP mode, configure **System Settings → Base Settings → Synthetic DNS / Fake-IP ranges**. The exception is disabled by default and applies only to hostname resolution results, never to literal-IP Provider URLs. Enter the proxy's actual pool rather than assuming every implementation uses `198.18.0.0/15`: that range is reserved for benchmarking and is common, but not exclusive, for Fake-IP. RFC1918 private networks and IPv6 ULA remain blocked in ordinary mode. If a proxy genuinely uses one of those ranges (for example, an Xray IPv6 Fake-IP pool), the separate high-risk private-range trust switch is required; enabling it allows provider hostnames to reach real internal services in the configured range. Loopback, link-local, metadata, multicast, and NAT64 ranges remain blocked in every mode.
 
 ## Frontend Environment Variables
 

--- a/docs/ja/deployment.md
+++ b/docs/ja/deployment.md
@@ -401,7 +401,7 @@ docker compose --env-file deploy/.env -f deploy/docker-compose.yml down -v
 | `TOKENHUB_RESPONSE_MAX_QUEUED_JOBS` | `1000` | 1 つのデプロイが受け付ける待機中および実行中のバックグラウンド Responses ジョブ上限 |
 | `TOKENHUB_API` | 空 | `tokenhub-migrate` CLI が対象とする Admin API の URL。この CLI のみが読み取り、バックエンドサーバーは読み取りません。`--to` で上書きされます |
 
-TokenHub ホストのプロキシが Fake-IP モードで動作する場合は、**システム設定 → 基本設定 → Synthetic DNS / Fake-IP 範囲** で設定します。この例外は既定で無効であり、ホスト名の DNS 解決結果にだけ適用され、リテラル IP の Provider URL には適用されません。すべての実装が `198.18.0.0/15` を使うと仮定せず、プロキシが実際に使用するプールを入力してください。この範囲はベンチマーク用に予約され、Fake-IP でよく使われますが、Fake-IP 専用ではありません。loopback、link-local、metadata、multicast、NAT64 の各範囲は引き続きブロックされます。
+TokenHub ホストのプロキシが Fake-IP モードで動作する場合は、**システム設定 → 基本設定 → Synthetic DNS / Fake-IP 範囲** で設定します。この例外は既定で無効であり、ホスト名の DNS 解決結果にだけ適用され、リテラル IP の Provider URL には適用されません。すべての実装が `198.18.0.0/15` を使うと仮定せず、プロキシが実際に使用するプールを入力してください。この範囲はベンチマーク用に予約され、Fake-IP でよく使われますが、Fake-IP 専用ではありません。通常モードでは RFC1918 プライベートネットワークと IPv6 ULA は引き続きブロックされます。プロキシが実際にこれらの範囲を使用する場合（例：Xray の IPv6 Fake-IP プール）は、別の高リスクなプライベート範囲信頼を明示的に有効にする必要があります。有効にすると、Provider ホスト名が設定範囲内の実在する内部サービスへ到達できる可能性があります。loopback、link-local、metadata、multicast、NAT64 の各範囲はどのモードでもブロックされます。
 
 ## フロントエンド環境変数
 

--- a/docs/ja/deployment.md
+++ b/docs/ja/deployment.md
@@ -401,6 +401,8 @@ docker compose --env-file deploy/.env -f deploy/docker-compose.yml down -v
 | `TOKENHUB_RESPONSE_MAX_QUEUED_JOBS` | `1000` | 1 つのデプロイが受け付ける待機中および実行中のバックグラウンド Responses ジョブ上限 |
 | `TOKENHUB_API` | 空 | `tokenhub-migrate` CLI が対象とする Admin API の URL。この CLI のみが読み取り、バックエンドサーバーは読み取りません。`--to` で上書きされます |
 
+TokenHub ホストのプロキシが Fake-IP モードで動作する場合は、**システム設定 → 基本設定 → Synthetic DNS / Fake-IP 範囲** で設定します。この例外は既定で無効であり、ホスト名の DNS 解決結果にだけ適用され、リテラル IP の Provider URL には適用されません。すべての実装が `198.18.0.0/15` を使うと仮定せず、プロキシが実際に使用するプールを入力してください。この範囲はベンチマーク用に予約され、Fake-IP でよく使われますが、Fake-IP 専用ではありません。loopback、link-local、metadata、multicast、NAT64 の各範囲は引き続きブロックされます。
+
 ## フロントエンド環境変数
 
 | 変数 | デフォルト | 説明 |

--- a/docs/zh-CN/deployment.md
+++ b/docs/zh-CN/deployment.md
@@ -401,6 +401,8 @@ docker compose --env-file deploy/.env -f deploy/docker-compose.yml down -v
 | `TOKENHUB_RESPONSE_MAX_QUEUED_JOBS` | `1000` | 单个部署接受的排队中与运行中后台 Responses 任务总上限 |
 | `TOKENHUB_API` | 空 | `tokenhub-migrate` CLI 的目标 Admin API 地址。仅由该 CLI 读取，后端服务不会读取；可被 `--to` 覆盖 |
 
+当 TokenHub 所在主机的代理工作在 Fake-IP 模式时，在「系统设置 → 基础设置 → Synthetic DNS / Fake-IP 网段」中配置。该例外默认关闭，只作用于域名解析结果，不允许字面量 IP Provider URL。应填写代理实际使用的地址池，不要假设所有实现都使用 `198.18.0.0/15`：这个网段为基准测试保留，虽常被 Fake-IP 使用，但并非 Fake-IP 专属。loopback、link-local、metadata、multicast、NAT64 等范围仍会被拒绝。
+
 ## 前端环境变量
 
 | 变量 | 默认值 | 说明 |

--- a/docs/zh-CN/deployment.md
+++ b/docs/zh-CN/deployment.md
@@ -401,7 +401,7 @@ docker compose --env-file deploy/.env -f deploy/docker-compose.yml down -v
 | `TOKENHUB_RESPONSE_MAX_QUEUED_JOBS` | `1000` | 单个部署接受的排队中与运行中后台 Responses 任务总上限 |
 | `TOKENHUB_API` | 空 | `tokenhub-migrate` CLI 的目标 Admin API 地址。仅由该 CLI 读取，后端服务不会读取；可被 `--to` 覆盖 |
 
-当 TokenHub 所在主机的代理工作在 Fake-IP 模式时，在「系统设置 → 基础设置 → Synthetic DNS / Fake-IP 网段」中配置。该例外默认关闭，只作用于域名解析结果，不允许字面量 IP Provider URL。应填写代理实际使用的地址池，不要假设所有实现都使用 `198.18.0.0/15`：这个网段为基准测试保留，虽常被 Fake-IP 使用，但并非 Fake-IP 专属。loopback、link-local、metadata、multicast、NAT64 等范围仍会被拒绝。
+当 TokenHub 所在主机的代理工作在 Fake-IP 模式时，在「系统设置 → 基础设置 → Synthetic DNS / Fake-IP 网段」中配置。该例外默认关闭，只作用于域名解析结果，不允许字面量 IP Provider URL。应填写代理实际使用的地址池，不要假设所有实现都使用 `198.18.0.0/15`：这个网段为基准测试保留，虽常被 Fake-IP 使用，但并非 Fake-IP 专属。普通模式仍禁止 RFC1918 私网和 IPv6 ULA；如果代理确实使用这些范围（例如 Xray 的 IPv6 Fake-IP 池），必须另行开启高风险私网信任。开启后，Provider 域名可能访问配置范围内的真实内网服务。loopback、link-local、metadata、multicast、NAT64 等范围在任何模式下仍会被拒绝。
 
 ## 前端环境变量
 

--- a/frontend/features/admin/i18n/synthetic-dns.tsx
+++ b/frontend/features/admin/i18n/synthetic-dns.tsx
@@ -2,22 +2,28 @@ const syntheticDNSTranslations = {
   en: {
     "允许 Provider 使用 Synthetic DNS / Fake-IP": "Allow Providers to Use Synthetic DNS / Fake-IP",
     "仅当 TokenHub 所在主机启用了 Fake-IP 代理，且 Provider 域名因此解析到合成地址时开启。该例外只用于域名解析结果，不允许把字面量 IP 直接配置为 Provider Base URL。": "Enable only when the TokenHub host uses a Fake-IP proxy and provider domains therefore resolve to synthetic addresses. This exception applies only to DNS results; a literal IP still cannot be used as a Provider Base URL.",
+    "允许信任私网 / ULA Synthetic DNS 网段（高风险）": "Trust Private / ULA Synthetic DNS Ranges (High Risk)",
+    "默认仍禁止 RFC1918 私网和 IPv6 ULA。仅当代理确实把这些范围用作 Fake-IP 池（例如部分 Xray IPv6 配置）时开启；开启后，恶意或被劫持的 Provider 域名可能访问该范围内的真实内网服务。": "RFC1918 private networks and IPv6 ULA remain blocked by default. Enable only when the proxy actually uses these ranges as its Fake-IP pool (for example, some Xray IPv6 configurations). Once enabled, a malicious or hijacked provider hostname could reach real internal services in those ranges.",
     "Synthetic DNS / Fake-IP 网段": "Synthetic DNS / Fake-IP Ranges",
     "安全提示：每行一个 CIDR，必须与本机代理的实际 Fake-IP 池一致。198.18.0.0/15 是基准测试保留网段，只是常被代理软件用作 Fake-IP，并非 Fake-IP 专属；不同软件或配置可使用其他网段。配置过宽或填入真实内网会削弱 SSRF 防护。loopback、link-local、metadata、multicast、NAT64 等敏感范围始终禁止。": "Security notice: enter one CIDR per line and match the Fake-IP pool actually used by the local proxy. 198.18.0.0/15 is reserved for benchmarking and is merely common for Fake-IP; it is not exclusive to Fake-IP, and other software or configurations may use different ranges. Overly broad ranges or real internal networks weaken SSRF protection. Sensitive loopback, link-local, metadata, multicast, and NAT64 ranges always remain blocked.",
     "开启时至少填写一个 Synthetic DNS CIDR。": "Enter at least one Synthetic DNS CIDR when the exception is enabled.",
     "Synthetic DNS CIDR 格式无效，请每行填写一个 CIDR。": "The Synthetic DNS CIDR format is invalid. Enter one CIDR per line.",
     "Synthetic DNS CIDR 范围过宽，请缩小后重试。": "The Synthetic DNS CIDR is too broad. Narrow the range and try again.",
     "该 Synthetic DNS CIDR 与受保护地址范围重叠，无法保存。": "This Synthetic DNS CIDR overlaps a protected address range and cannot be saved.",
+    "该 Synthetic DNS CIDR 属于私网或 ULA；如确认代理使用此网段，请先开启高风险私网信任。": "This Synthetic DNS CIDR is private or ULA. If the proxy really uses it, enable high-risk private-range trust first.",
   },
   ja: {
     "允许 Provider 使用 Synthetic DNS / Fake-IP": "Provider による Synthetic DNS / Fake-IP の使用を許可",
     "仅当 TokenHub 所在主机启用了 Fake-IP 代理，且 Provider 域名因此解析到合成地址时开启。该例外只用于域名解析结果，不允许把字面量 IP 直接配置为 Provider Base URL。": "TokenHub ホストで Fake-IP プロキシを使用し、Provider ドメインが合成アドレスに解決される場合にのみ有効にしてください。この例外は DNS の解決結果だけに適用され、リテラル IP を Provider Base URL に直接指定することはできません。",
+    "允许信任私网 / ULA Synthetic DNS 网段（高风险）": "プライベート / ULA Synthetic DNS 範囲を信頼（高リスク）",
+    "默认仍禁止 RFC1918 私网和 IPv6 ULA。仅当代理确实把这些范围用作 Fake-IP 池（例如部分 Xray IPv6 配置）时开启；开启后，恶意或被劫持的 Provider 域名可能访问该范围内的真实内网服务。": "RFC1918 プライベートネットワークと IPv6 ULA は既定では引き続きブロックされます。プロキシが実際にこれらを Fake-IP プールとして使用する場合（例：一部の Xray IPv6 設定）にのみ有効にしてください。有効にすると、悪意のある、または乗っ取られた Provider ホスト名が該当範囲の実在する内部サービスへ到達できる可能性があります。",
     "Synthetic DNS / Fake-IP 网段": "Synthetic DNS / Fake-IP 範囲",
     "安全提示：每行一个 CIDR，必须与本机代理的实际 Fake-IP 池一致。198.18.0.0/15 是基准测试保留网段，只是常被代理软件用作 Fake-IP，并非 Fake-IP 专属；不同软件或配置可使用其他网段。配置过宽或填入真实内网会削弱 SSRF 防护。loopback、link-local、metadata、multicast、NAT64 等敏感范围始终禁止。": "セキュリティ上の注意：1 行に 1 つの CIDR を入力し、ローカルプロキシが実際に使用する Fake-IP プールと一致させてください。198.18.0.0/15 はベンチマーク用の予約範囲であり、Fake-IP でよく使われるだけで専用ではありません。ソフトウェアや設定によっては別の範囲が使われます。広すぎる範囲や実在する内部ネットワークを指定すると SSRF 防御が弱まります。loopback、link-local、metadata、multicast、NAT64 などの機密範囲は常にブロックされます。",
     "开启时至少填写一个 Synthetic DNS CIDR。": "この例外を有効にする場合は、Synthetic DNS CIDR を 1 つ以上入力してください。",
     "Synthetic DNS CIDR 格式无效，请每行填写一个 CIDR。": "Synthetic DNS CIDR の形式が正しくありません。1 行に 1 つの CIDR を入力してください。",
     "Synthetic DNS CIDR 范围过宽，请缩小后重试。": "Synthetic DNS CIDR の範囲が広すぎます。範囲を狭めて再試行してください。",
     "该 Synthetic DNS CIDR 与受保护地址范围重叠，无法保存。": "この Synthetic DNS CIDR は保護対象のアドレス範囲と重複しているため保存できません。",
+    "该 Synthetic DNS CIDR 属于私网或 ULA；如确认代理使用此网段，请先开启高风险私网信任。": "この Synthetic DNS CIDR はプライベート範囲または ULA です。プロキシが実際に使用している場合は、先に高リスクのプライベート範囲信頼を有効にしてください。",
   },
 };
 

--- a/frontend/features/admin/i18n/synthetic-dns.tsx
+++ b/frontend/features/admin/i18n/synthetic-dns.tsx
@@ -1,0 +1,24 @@
+const syntheticDNSTranslations = {
+  en: {
+    "允许 Provider 使用 Synthetic DNS / Fake-IP": "Allow Providers to Use Synthetic DNS / Fake-IP",
+    "仅当 TokenHub 所在主机启用了 Fake-IP 代理，且 Provider 域名因此解析到合成地址时开启。该例外只用于域名解析结果，不允许把字面量 IP 直接配置为 Provider Base URL。": "Enable only when the TokenHub host uses a Fake-IP proxy and provider domains therefore resolve to synthetic addresses. This exception applies only to DNS results; a literal IP still cannot be used as a Provider Base URL.",
+    "Synthetic DNS / Fake-IP 网段": "Synthetic DNS / Fake-IP Ranges",
+    "安全提示：每行一个 CIDR，必须与本机代理的实际 Fake-IP 池一致。198.18.0.0/15 是基准测试保留网段，只是常被代理软件用作 Fake-IP，并非 Fake-IP 专属；不同软件或配置可使用其他网段。配置过宽或填入真实内网会削弱 SSRF 防护。loopback、link-local、metadata、multicast、NAT64 等敏感范围始终禁止。": "Security notice: enter one CIDR per line and match the Fake-IP pool actually used by the local proxy. 198.18.0.0/15 is reserved for benchmarking and is merely common for Fake-IP; it is not exclusive to Fake-IP, and other software or configurations may use different ranges. Overly broad ranges or real internal networks weaken SSRF protection. Sensitive loopback, link-local, metadata, multicast, and NAT64 ranges always remain blocked.",
+    "开启时至少填写一个 Synthetic DNS CIDR。": "Enter at least one Synthetic DNS CIDR when the exception is enabled.",
+    "Synthetic DNS CIDR 格式无效，请每行填写一个 CIDR。": "The Synthetic DNS CIDR format is invalid. Enter one CIDR per line.",
+    "Synthetic DNS CIDR 范围过宽，请缩小后重试。": "The Synthetic DNS CIDR is too broad. Narrow the range and try again.",
+    "该 Synthetic DNS CIDR 与受保护地址范围重叠，无法保存。": "This Synthetic DNS CIDR overlaps a protected address range and cannot be saved.",
+  },
+  ja: {
+    "允许 Provider 使用 Synthetic DNS / Fake-IP": "Provider による Synthetic DNS / Fake-IP の使用を許可",
+    "仅当 TokenHub 所在主机启用了 Fake-IP 代理，且 Provider 域名因此解析到合成地址时开启。该例外只用于域名解析结果，不允许把字面量 IP 直接配置为 Provider Base URL。": "TokenHub ホストで Fake-IP プロキシを使用し、Provider ドメインが合成アドレスに解決される場合にのみ有効にしてください。この例外は DNS の解決結果だけに適用され、リテラル IP を Provider Base URL に直接指定することはできません。",
+    "Synthetic DNS / Fake-IP 网段": "Synthetic DNS / Fake-IP 範囲",
+    "安全提示：每行一个 CIDR，必须与本机代理的实际 Fake-IP 池一致。198.18.0.0/15 是基准测试保留网段，只是常被代理软件用作 Fake-IP，并非 Fake-IP 专属；不同软件或配置可使用其他网段。配置过宽或填入真实内网会削弱 SSRF 防护。loopback、link-local、metadata、multicast、NAT64 等敏感范围始终禁止。": "セキュリティ上の注意：1 行に 1 つの CIDR を入力し、ローカルプロキシが実際に使用する Fake-IP プールと一致させてください。198.18.0.0/15 はベンチマーク用の予約範囲であり、Fake-IP でよく使われるだけで専用ではありません。ソフトウェアや設定によっては別の範囲が使われます。広すぎる範囲や実在する内部ネットワークを指定すると SSRF 防御が弱まります。loopback、link-local、metadata、multicast、NAT64 などの機密範囲は常にブロックされます。",
+    "开启时至少填写一个 Synthetic DNS CIDR。": "この例外を有効にする場合は、Synthetic DNS CIDR を 1 つ以上入力してください。",
+    "Synthetic DNS CIDR 格式无效，请每行填写一个 CIDR。": "Synthetic DNS CIDR の形式が正しくありません。1 行に 1 つの CIDR を入力してください。",
+    "Synthetic DNS CIDR 范围过宽，请缩小后重试。": "Synthetic DNS CIDR の範囲が広すぎます。範囲を狭めて再試行してください。",
+    "该 Synthetic DNS CIDR 与受保护地址范围重叠，无法保存。": "この Synthetic DNS CIDR は保護対象のアドレス範囲と重複しているため保存できません。",
+  },
+};
+
+export default syntheticDNSTranslations;

--- a/frontend/features/admin/i18n/translations.tsx
+++ b/frontend/features/admin/i18n/translations.tsx
@@ -8,8 +8,9 @@ import { codexImageTranslations } from "./codex-image";
 import { scopedRoutingPolicyTranslations } from "./scoped-routing-policy";
 import { securityTranslations } from "./security";
 import { usageTranslations } from "./usage";
+import syntheticDNSTranslations from "./synthetic-dns";
 
 export const translations: Record<"en" | "ja", Record<string, string>> = {
-  en: { ...enTranslations, ...routingTranslations.en, ...codexImageTranslations.en, ...scopedRoutingPolicyTranslations.en, ...modelGovernanceTranslations.en, ...providerConnectionTranslations.en, ...usageTranslations.en, ...playgroundTranslations.en, ...securityTranslations.en },
-  ja: { ...jaTranslations, ...routingTranslations.ja, ...codexImageTranslations.ja, ...scopedRoutingPolicyTranslations.ja, ...modelGovernanceTranslations.ja, ...providerConnectionTranslations.ja, ...usageTranslations.ja, ...playgroundTranslations.ja, ...securityTranslations.ja },
+  en: { ...enTranslations, ...routingTranslations.en, ...codexImageTranslations.en, ...scopedRoutingPolicyTranslations.en, ...modelGovernanceTranslations.en, ...providerConnectionTranslations.en, ...usageTranslations.en, ...playgroundTranslations.en, ...securityTranslations.en, ...syntheticDNSTranslations.en },
+  ja: { ...jaTranslations, ...routingTranslations.ja, ...codexImageTranslations.ja, ...scopedRoutingPolicyTranslations.ja, ...modelGovernanceTranslations.ja, ...providerConnectionTranslations.ja, ...usageTranslations.ja, ...playgroundTranslations.ja, ...securityTranslations.ja, ...syntheticDNSTranslations.ja },
 };

--- a/frontend/features/admin/resources/payloads.tsx
+++ b/frontend/features/admin/resources/payloads.tsx
@@ -723,6 +723,8 @@ function localizedAdminErrorCode(code?: string) {
       return tx("Synthetic DNS CIDR 范围过宽，请缩小后重试。");
     case "provider_synthetic_dns_cidrs_not_allowed":
       return tx("该 Synthetic DNS CIDR 与受保护地址范围重叠，无法保存。");
+    case "provider_synthetic_dns_private_cidr_requires_unsafe_mode":
+      return tx("该 Synthetic DNS CIDR 属于私网或 ULA；如确认代理使用此网段，请先开启高风险私网信任。");
     default:
       return "";
   }

--- a/frontend/features/admin/resources/payloads.tsx
+++ b/frontend/features/admin/resources/payloads.tsx
@@ -698,6 +698,8 @@ export async function readAdminError(resp: Response, fallback: string) {
   if (!body) return resp.status === 403 ? permissionDeniedMessage(fallback) : `${fallback} (${resp.status})`;
   try {
     const parsed = JSON.parse(body) as { error?: { code?: string; message?: string }; message?: string };
+    const localized = localizedAdminErrorCode(parsed.error?.code);
+    if (localized) return localized;
     if (parsed.error?.code === "provider_resource_reauthorization_required") return tx("OpenAI/Codex 账号会话已失效，请重新进行账号授权。");
     if (parsed.error?.code === "codex_image_forbidden") return tx("所选 Codex 账号不支持生图，无法创建图片。可更换账号后重试。");
     if (parsed.error?.code === "codex_rate_limited") return tx("Codex 生图测试被限流，请稍后重试；本次结果不会标记为不支持。");
@@ -708,6 +710,21 @@ export async function readAdminError(resp: Response, fallback: string) {
     return parsed.error?.message || parsed.message || `${fallback} (${resp.status})`;
   } catch {
     return body.length > 180 ? `${body.slice(0, 180)}...` : body;
+  }
+}
+
+function localizedAdminErrorCode(code?: string) {
+  switch (code) {
+    case "provider_synthetic_dns_cidrs_required":
+      return tx("开启时至少填写一个 Synthetic DNS CIDR。");
+    case "provider_synthetic_dns_cidrs_invalid":
+      return tx("Synthetic DNS CIDR 格式无效，请每行填写一个 CIDR。");
+    case "provider_synthetic_dns_cidrs_too_broad":
+      return tx("Synthetic DNS CIDR 范围过宽，请缩小后重试。");
+    case "provider_synthetic_dns_cidrs_not_allowed":
+      return tx("该 Synthetic DNS CIDR 与受保护地址范围重叠，无法保存。");
+    default:
+      return "";
   }
 }
 

--- a/frontend/features/admin/resources/settings-config.tsx
+++ b/frontend/features/admin/resources/settings-config.tsx
@@ -80,6 +80,19 @@ export function systemSettingConfig(): ResourceConfig<AdminResource> {
     { key: "audit_retention", label: "审计保留", help: "请求审计日志的默认保留周期，例如 180d。" },
     { key: "api_key_prefix", label: "API Key 前缀", placeholder: "sk_", help: "新建和轮换 Key 时使用；建议以 _ 结尾，例如 sk_。" },
     { key: "api_key_random_length", label: "API Key 随机长度", type: "number", placeholder: "48", help: "前缀后面的随机字符数，系统会限制在 24-128 之间。" },
+    {
+      key: "provider_synthetic_dns_enabled",
+      label: "允许 Provider 使用 Synthetic DNS / Fake-IP",
+      type: "boolean",
+      help: "仅当 TokenHub 所在主机启用了 Fake-IP 代理，且 Provider 域名因此解析到合成地址时开启。该例外只用于域名解析结果，不允许把字面量 IP 直接配置为 Provider Base URL。",
+    },
+    {
+      key: "provider_synthetic_dns_cidrs",
+      label: "Synthetic DNS / Fake-IP 网段",
+      type: "textarea",
+      placeholder: "198.18.0.0/15\nfc00::/18",
+      help: "安全提示：每行一个 CIDR，必须与本机代理的实际 Fake-IP 池一致。198.18.0.0/15 是基准测试保留网段，只是常被代理软件用作 Fake-IP，并非 Fake-IP 专属；不同软件或配置可使用其他网段。配置过宽或填入真实内网会削弱 SSRF 防护。loopback、link-local、metadata、multicast、NAT64 等敏感范围始终禁止。",
+    },
   ]);
   return {
     ...base,

--- a/frontend/features/admin/resources/settings-config.tsx
+++ b/frontend/features/admin/resources/settings-config.tsx
@@ -87,10 +87,17 @@ export function systemSettingConfig(): ResourceConfig<AdminResource> {
       help: "仅当 TokenHub 所在主机启用了 Fake-IP 代理，且 Provider 域名因此解析到合成地址时开启。该例外只用于域名解析结果，不允许把字面量 IP 直接配置为 Provider Base URL。",
     },
     {
+      key: "provider_synthetic_dns_allow_private_ranges",
+      label: "允许信任私网 / ULA Synthetic DNS 网段（高风险）",
+      type: "boolean",
+      visible: (values) => values.provider_synthetic_dns_enabled === "true",
+      help: "默认仍禁止 RFC1918 私网和 IPv6 ULA。仅当代理确实把这些范围用作 Fake-IP 池（例如部分 Xray IPv6 配置）时开启；开启后，恶意或被劫持的 Provider 域名可能访问该范围内的真实内网服务。",
+    },
+    {
       key: "provider_synthetic_dns_cidrs",
       label: "Synthetic DNS / Fake-IP 网段",
       type: "textarea",
-      placeholder: "198.18.0.0/15\nfc00::/18",
+      placeholder: "198.18.0.0/15",
       help: "安全提示：每行一个 CIDR，必须与本机代理的实际 Fake-IP 池一致。198.18.0.0/15 是基准测试保留网段，只是常被代理软件用作 Fake-IP，并非 Fake-IP 专属；不同软件或配置可使用其他网段。配置过宽或填入真实内网会削弱 SSRF 防护。loopback、link-local、metadata、multicast、NAT64 等敏感范围始终禁止。",
     },
   ]);


### PR DESCRIPTION
## Summary

Allow TokenHub deployments behind fake-IP/synthetic-DNS transparent proxies to reach upstream providers without weakening the default SSRF policy. The exception is opt-in, configurable in Gateway Settings, and applies only to addresses resolved from administrator-configured hostnames.

## Related Issue

Closes #211

## Changes

- Add an opt-in synthetic DNS setting with configurable IPv4/IPv6 CIDRs and a documented `198.18.0.0/15` preset.
- Keep literal-IP provider URLs and protected address ranges blocked, while allowing configured synthetic ranges only after hostname resolution.
- Rotate upstream transport generations when the setting changes so new requests use the new policy without interrupting in-flight requests.
- Validate every settings mutation path, refresh settings safely across replicas, and propagate bootstrap backfill failures.
- Add regression coverage for validation, concurrent updates, cache refreshes, transport rotation, and SSRF boundaries.
- Add localized admin UI guidance and synchronized English, Simplified Chinese, and Japanese deployment documentation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [x] Documentation
- [ ] Deployment or configuration

## Verification

- [x] `go test ./...`
- [x] `go test -race ./internal/server` with focused synthetic-DNS, settings mutation, transport rotation, and guarded dial tests
- [x] `go vet ./...`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `node --test tools/*.test.mjs` (122 tests passed)
- [x] Documentation translation, UI translation, environment contract, source line, and `git diff --check` gates
- [x] Manual browser walkthrough of the settings form, validation state, and successful save

## Compatibility, Security, and Operations

- No compatibility change to the OpenAI-compatible `/v1` API.
- The exception is disabled by default. Existing installations retain the current SSRF behavior until an administrator enables it.
- Literal IP URLs, loopback, link-local, metadata, multicast, NAT64, and other protected ranges remain non-bypassable.
- Enabling custom CIDRs deliberately trusts the transparent proxy to intercept those resolved addresses; the UI warns administrators about this security boundary.
- Local setting changes apply immediately. Other replicas converge from the shared store within approximately five seconds.
- Policy changes close idle connections and direct new requests to a new transport generation; in-flight requests are allowed to finish.
- Rollback by disabling the setting or reverting this change.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
