### PR TITLE
fix(routing): validate model provider protocol compatibility

### DIFF
--- a/backend/internal/server/admin_provider_catalog_test.go
+++ b/backend/internal/server/admin_provider_catalog_test.go
@@ -96,6 +96,57 @@ func TestAdminCreatesProviderModelAndRoute(t *testing.T) {
 	}
 }
 
+func TestAdminRouteRejectsKnownModelProviderProtocolMismatch(t *testing.T) {
+	store := NewMemoryStore()
+	if err := SeedDemoData(store); err != nil {
+		t.Fatal(err)
+	}
+	provider := store.AddProvider(Provider{ID: "prv_native_anthropic", Name: "Native Anthropic", Type: ProviderAnthropic, Status: StatusActive, Healthy: true})
+	store.AddProviderModel(ProviderModel{ProviderID: provider.ID, UpstreamModel: "gpt-5.6-luna", Status: StatusActive})
+	store.AddModel(Model{Name: "gpt-5.6-luna", Modality: "chat", Status: StatusActive, Metadata: map[string]string{"endpoints": "responses,chat/completions"}})
+
+	response := doJSON(t, New(store).Handler(), http.MethodPost, "/api/admin/routing-rules", map[string]any{
+		"model_name": "gpt-5.6-luna", "provider_id": provider.ID, "provider_model": "gpt-5.6-luna", "status": StatusActive,
+	}, "")
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body, `"code":"route_protocol_mismatch"`) {
+		t.Fatalf("expected protocol mismatch rejection, got %d: %s", response.Code, response.Body)
+	}
+}
+
+func TestAdminModelCreateRejectsInitialRouteProtocolMismatch(t *testing.T) {
+	store := NewMemoryStore()
+	if err := SeedDemoData(store); err != nil {
+		t.Fatal(err)
+	}
+	provider := store.AddProvider(Provider{ID: "prv_initial_anthropic", Name: "Native Anthropic", Type: ProviderAnthropic, Status: StatusActive, Healthy: true})
+	store.AddProviderModel(ProviderModel{ProviderID: provider.ID, UpstreamModel: "responses-only", Status: StatusActive})
+
+	response := doJSON(t, New(store).Handler(), http.MethodPost, "/api/admin/models", map[string]any{
+		"name": "responses-only", "modality": "chat", "metadata": map[string]string{"endpoints": "responses"},
+		"routes": []map[string]any{{"provider_id": provider.ID, "provider_model": "responses-only", "status": StatusActive}},
+	}, "")
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body, `"code":"route_protocol_mismatch"`) {
+		t.Fatalf("expected initial route protocol mismatch rejection, got %d: %s", response.Code, response.Body)
+	}
+}
+
+func TestAdminRouteAllowsCatalogModelWithMatchingProviderProtocol(t *testing.T) {
+	store := NewMemoryStore()
+	if err := SeedDemoData(store); err != nil {
+		t.Fatal(err)
+	}
+	provider := store.AddProvider(Provider{ID: "prv_protocol_openai", Name: "OpenAI Compatible", Type: ProviderOpenAICompatible, Status: StatusActive, Healthy: true})
+	store.AddProviderModel(ProviderModel{ProviderID: provider.ID, UpstreamModel: "gpt-5.6-luna", Status: StatusActive})
+	store.AddModel(Model{Name: "gpt-5.6-luna", Modality: "chat", Status: StatusActive, Metadata: map[string]string{"endpoints": "responses,chat/completions"}})
+
+	response := doJSON(t, New(store).Handler(), http.MethodPost, "/api/admin/routing-rules", map[string]any{
+		"model_name": "gpt-5.6-luna", "provider_id": provider.ID, "provider_model": "gpt-5.6-luna", "status": StatusActive,
+	}, "")
+	if response.Code != http.StatusCreated {
+		t.Fatalf("expected compatible route creation, got %d: %s", response.Code, response.Body)
+	}
+}
+
 func TestAdminProviderConfigurationFailsEarlyAndPatchPreservesFields(t *testing.T) {
 	app := newTestServer()
 

--- a/backend/internal/server/admin_providers_http.go
+++ b/backend/internal/server/admin_providers_http.go
@@ -874,7 +874,7 @@ func (s *Server) serveAdminModelsPost(w http.ResponseWriter, r *http.Request, us
 			writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_route", "provider_id and provider_model are required"))
 			return
 		}
-		if err := s.validateRouteAdapter(route); err != nil {
+		if err := s.validateRouteAdapterForModel(route, &req.Model); err != nil {
 			writeError(w, r, err)
 			return
 		}
@@ -1223,6 +1223,10 @@ func (s *Server) serveAdminRouteDelete(w http.ResponseWriter, r *http.Request, u
 }
 
 func (s *Server) validateRouteAdapter(route ModelRoute) error {
+	return s.validateRouteAdapterForModel(route, nil)
+}
+
+func (s *Server) validateRouteAdapterForModel(route ModelRoute, pendingModel *Model) error {
 	if err := s.validateRoutePolicy(route); err != nil {
 		return err
 	}
@@ -1230,8 +1234,12 @@ func (s *Server) validateRouteAdapter(route ModelRoute) error {
 	if !ok {
 		return NewHTTPError(http.StatusBadRequest, "route_provider_not_found", "Route provider does not exist")
 	}
-	if _, ok := s.adapterRegistry.Describe(provider.Type); !ok {
+	descriptor, ok := s.adapterRegistry.Describe(provider.Type)
+	if !ok {
 		return NewHTTPError(http.StatusBadRequest, "provider_adapter_missing", "Route provider adapter is not registered")
+	}
+	if err := s.validateRouteModelProtocol(route.ModelName, pendingModel, provider.Type, descriptor); err != nil {
+		return err
 	}
 	if strings.TrimSpace(route.ProviderResourceID) == "" {
 		return nil
@@ -1241,6 +1249,57 @@ func (s *Server) validateRouteAdapter(route ModelRoute) error {
 		return NewHTTPError(http.StatusBadRequest, "route_resource_mismatch", "Route resource must belong to the selected Provider")
 	}
 	return nil
+}
+
+// validateRouteModelProtocol rejects only known catalog mismatches. Models
+// without endpoint metadata remain valid so operators can route custom models.
+func (s *Server) validateRouteModelProtocol(modelName string, pendingModel *Model, providerType string, descriptor AdapterDescriptor) error {
+	var model Model
+	found := pendingModel != nil && pendingModel.Name == modelName
+	if found {
+		model = *pendingModel
+	} else {
+		for _, candidate := range s.store.ListModels() {
+			if candidate.Name == modelName {
+				model, found = candidate, true
+				break
+			}
+		}
+	}
+	if !found || model.Metadata == nil {
+		return nil
+	}
+	endpoints := strings.Split(model.Metadata["endpoints"], ",")
+	if len(endpoints) == 0 || strings.TrimSpace(model.Metadata["endpoints"]) == "" {
+		return nil
+	}
+	compatible := routeProviderProtocols(providerType, descriptor)
+	for _, endpoint := range endpoints {
+		if compatible[strings.ToLower(strings.TrimSpace(endpoint))] {
+			return nil
+		}
+	}
+	return NewHTTPError(http.StatusBadRequest, "route_protocol_mismatch", "Model does not support the selected Provider protocol")
+}
+
+func routeProviderProtocols(providerType string, descriptor AdapterDescriptor) map[string]bool {
+	if providerType == ProviderAnthropic {
+		return map[string]bool{"anthropic": true}
+	}
+	if providerType == ProviderGemini {
+		return map[string]bool{"gemini": true}
+	}
+	protocols := map[string]bool{}
+	if adapterSupports(descriptor, AdapterCapabilityChat) {
+		protocols["chat/completions"] = true
+	}
+	if adapterSupports(descriptor, AdapterCapabilityResponses) {
+		protocols["responses"] = true
+	}
+	if adapterSupports(descriptor, AdapterCapabilityEmbeddings) {
+		protocols["embeddings"] = true
+	}
+	return protocols
 }
 
 func (s *Server) validateRoutePolicy(route ModelRoute) error {


### PR DESCRIPTION
## Summary

Reject routes whose Provider protocol cannot serve a catalog model's declared endpoint protocol. This prevents an Anthropic Provider from being attached to a responses-only model, including when the route is submitted with a newly created model.

## Related Issue

Fixes #233.

## Changes

- Validate route protocols from the registered Provider adapter capabilities.
- Validate routes supplied during model creation before the model is persisted.
- Add compatibility and rejection regression coverage.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [x] `go test ./internal/server -run 'TestAdmin(RouteRejectsKnownModelProviderProtocolMismatch|ModelCreateRejectsInitialRouteProtocolMismatch|RouteAllowsCatalogModelWithMatchingProviderProtocol)$'`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `git diff --check`
- [x] Two consecutive independent review scans reported no actionable findings.

## Compatibility, Security, and Operations

Rejects only routes for models that explicitly declare catalog endpoint metadata. Custom models without endpoint metadata retain their existing routing behavior. No configuration, deployment, or data migration is required.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.