### PR TITLE
fix(providers): probe upstream during provider tests

### DIFF
--- a/backend/internal/server/admin_provider_resources_test.go
+++ b/backend/internal/server/admin_provider_resources_test.go
@@ -723,6 +723,65 @@ func TestProviderAndResourceTestEndpoints(t *testing.T) {
 	}
 }
 
+func TestProviderTestPerformsUpstreamProbeWithoutResourceHeaders(t *testing.T) {
+	requests := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Header.Get("Authorization") != "Bearer provider-secret" {
+			t.Errorf("authorization = %q", r.Header.Get("Authorization"))
+			http.Error(w, "missing credentials", http.StatusUnauthorized)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"data": []map[string]string{{"id": "upstream-model"}}})
+	}))
+	defer upstream.Close()
+
+	store := NewMemoryStore()
+	provider := store.AddProvider(Provider{
+		ID: "prv_real_probe", Name: "Real probe", Type: ProviderOpenAICompatible, BaseURL: upstream.URL,
+		APIKey: "provider-secret", Status: StatusActive, Healthy: false,
+	})
+	response := doJSON(t, New(store).Handler(), http.MethodPost, "/api/admin/providers/"+provider.ID+"/test", nil, "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("provider test = %d: %s", response.Code, response.Body)
+	}
+	if requests != 1 {
+		t.Fatalf("upstream requests = %d, want 1", requests)
+	}
+	updated, ok := store.GetProvider(provider.ID)
+	if !ok || !updated.Healthy {
+		t.Fatalf("successful upstream probe did not restore Provider health: %+v", updated)
+	}
+}
+
+func TestProviderTestMarksProviderUnhealthyWhenAllResourceProbesFail(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "revoked credentials", http.StatusUnauthorized)
+	}))
+	defer upstream.Close()
+
+	store := NewMemoryStore()
+	provider := store.AddProvider(Provider{
+		ID: "prv_failed_resource_probe", Name: "Failed resource probe", Type: ProviderOpenAICompatible,
+		BaseURL: upstream.URL, Status: StatusActive, Healthy: true,
+	})
+	if _, err := store.AddProviderResource(ProviderResource{
+		ID: "rsrc_failed_resource_probe", ProviderID: provider.ID, Name: "Revoked", ResourceType: ProviderResourceAPIKey,
+		APIKey: "revoked-secret", Status: StatusActive, Healthy: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	response := doJSON(t, New(store).Handler(), http.MethodPost, "/api/admin/providers/"+provider.ID+"/test", nil, "")
+	if response.Code == http.StatusOK {
+		t.Fatalf("provider test unexpectedly succeeded: %s", response.Body)
+	}
+	updated, ok := store.GetProvider(provider.ID)
+	if !ok || updated.Healthy {
+		t.Fatalf("failed upstream probes did not mark Provider unhealthy: %+v", updated)
+	}
+}
+
 func TestProviderResourceBulkOperations(t *testing.T) {
 	store := NewMemoryStore()
 	if err := SeedDemoData(store); err != nil {

--- a/backend/internal/server/gateway_runtime_test.go
+++ b/backend/internal/server/gateway_runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -200,6 +201,20 @@ func TestDefaultAlertRulesAreAutoDiscovered(t *testing.T) {
 
 func TestProviderResourceCooldownAfterFailures(t *testing.T) {
 	store, secret, resourceID := newResourceRoutedStore(t, "failing_resource")
+	var upstreamCalls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			http.NotFound(w, r)
+			return
+		}
+		upstreamCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"resource-ops-chat"}]}`))
+	}))
+	defer upstream.Close()
+	if _, err := store.UpdateProviderResource(resourceID, ProviderResource{BaseURL: upstream.URL, Healthy: true}); err != nil {
+		t.Fatal(err)
+	}
 	store.failureThreshold = 2
 	server := New(store)
 	registerTestAdapter(server, "failing_resource", failingAdapter{})
@@ -224,6 +239,9 @@ func TestProviderResourceCooldownAfterFailures(t *testing.T) {
 	resp := doJSON(t, app, http.MethodPost, "/api/admin/provider-resources/"+resourceID+"/test", nil, "")
 	if resp.Code != http.StatusOK {
 		t.Fatalf("resource test should clear cooldown, got %d: %s", resp.Code, resp.Body)
+	}
+	if upstreamCalls.Load() != 1 {
+		t.Fatalf("expected one upstream probe, got %d", upstreamCalls.Load())
 	}
 	resource = findResource(t, store, resourceID)
 	if resource.FailureCount != 0 || resource.CooldownUntil != nil || !resource.Healthy {

--- a/backend/internal/server/integration_service.go
+++ b/backend/internal/server/integration_service.go
@@ -62,20 +62,20 @@ func (s *IntegrationService) TestProviderResource(ctx context.Context, resourceI
 	}
 	prober, supported := adapter.(ProviderResourceProber)
 	if !supported {
-		effective := effectiveProviderResourceConfig(provider, &resource)
-		if len(effective.Headers) > 0 {
-			startedAt := time.Now()
-			_, probeErr := CustomProviderCatalogFromUpstream(ctx, s.client, ProviderCreateRequest{
-				Type: effective.Type, BaseURL: effective.BaseURL, APIKey: effective.APIKey,
-				Headers: effective.Headers, SensitiveHeaders: effective.SensitiveHeaders, Options: effective.Options,
-			})
-			s.finishProbe(ctx, provider, resource, startedAt, probeErr, Usage{})
-			if probeErr != nil {
-				return nil, probeErr
-			}
-			return s.store.RecoverProviderResource(resourceID)
+		if provider.Type == ProviderMock {
+			return s.store.TestProviderResource(resourceID)
 		}
-		return s.store.TestProviderResource(resourceID)
+		effective := effectiveProviderResourceConfig(provider, &resource)
+		startedAt := time.Now()
+		_, probeErr := CustomProviderCatalogFromUpstream(ctx, s.client, ProviderCreateRequest{
+			Type: effective.Type, BaseURL: effective.BaseURL, APIKey: effective.APIKey,
+			Headers: effective.Headers, SensitiveHeaders: effective.SensitiveHeaders, Options: effective.Options,
+		})
+		s.finishProbe(ctx, provider, resource, startedAt, probeErr, Usage{})
+		if probeErr != nil {
+			return nil, probeErr
+		}
+		return s.store.RecoverProviderResource(resourceID)
 	}
 	probeRequest := prober.DefaultProbeRequest()
 	if request != nil {
@@ -87,9 +87,9 @@ func (s *IntegrationService) TestProviderResource(ctx context.Context, resourceI
 	if err != nil {
 		return nil, err
 	}
-	// A probe that reached the upstream and came back clean is the one signal strong
-	// enough to clear the breaker. This is deliberately confined to the prober branch:
-	// the fallback above never contacts the upstream, so its "success" proves nothing.
+	// An adapter probe that reached the upstream and came back clean is strong
+	// enough to clear the breaker. The catalog-discovery fallback performs the
+	// same upstream check and recovers its resource before returning above.
 	if _, recoverErr := s.store.RecoverProviderResource(resource.ID); recoverErr != nil {
 		return nil, recoverErr
 	}
@@ -118,37 +118,13 @@ func (s *IntegrationService) TestProvider(ctx context.Context, providerID string
 		return result, nil
 	}
 	if _, supported := adapter.(ProviderResourceProber); !supported {
+		if provider.Type == ProviderMock {
+			return s.store.TestProvider(providerID)
+		}
 		effectiveProvider := effectiveProviderResourceConfig(provider, nil)
 		var firstResourceErr error
-		if len(effectiveProvider.Headers) > 0 {
-			for _, resource := range s.store.ListProviderResources() {
-				if resource.ProviderID == providerID && resource.Status == StatusActive {
-					result, probeErr := s.TestProviderResource(ctx, resource.ID, nil)
-					if probeErr != nil {
-						if firstResourceErr == nil {
-							firstResourceErr = probeErr
-						}
-						continue
-					}
-					_, _ = s.store.SetProviderHealth(providerID, true)
-					return result, nil
-				}
-			}
-			if firstResourceErr != nil {
-				return nil, firstResourceErr
-			}
-			_, probeErr := CustomProviderCatalogFromUpstream(ctx, s.client, ProviderCreateRequest{
-				Type: effectiveProvider.Type, BaseURL: effectiveProvider.BaseURL, APIKey: effectiveProvider.APIKey,
-				Headers: effectiveProvider.Headers, SensitiveHeaders: effectiveProvider.SensitiveHeaders, Options: effectiveProvider.Options,
-			})
-			if probeErr != nil {
-				_, _ = s.store.SetProviderHealth(providerID, false)
-				return nil, probeErr
-			}
-			return s.store.SetProviderHealth(providerID, true)
-		}
 		for _, resource := range s.store.ListProviderResources() {
-			if resource.ProviderID == providerID && resource.Status == StatusActive && len(resource.Headers) > 0 {
+			if resource.ProviderID == providerID && resource.Status == StatusActive {
 				result, probeErr := s.TestProviderResource(ctx, resource.ID, nil)
 				if probeErr != nil {
 					if firstResourceErr == nil {
@@ -161,9 +137,18 @@ func (s *IntegrationService) TestProvider(ctx context.Context, providerID string
 			}
 		}
 		if firstResourceErr != nil {
+			_, _ = s.store.SetProviderHealth(providerID, false)
 			return nil, firstResourceErr
 		}
-		return s.store.TestProvider(providerID)
+		_, probeErr := CustomProviderCatalogFromUpstream(ctx, s.client, ProviderCreateRequest{
+			Type: effectiveProvider.Type, BaseURL: effectiveProvider.BaseURL, APIKey: effectiveProvider.APIKey,
+			Headers: effectiveProvider.Headers, SensitiveHeaders: effectiveProvider.SensitiveHeaders, Options: effectiveProvider.Options,
+		})
+		if probeErr != nil {
+			_, _ = s.store.SetProviderHealth(providerID, false)
+			return nil, probeErr
+		}
+		return s.store.SetProviderHealth(providerID, true)
 	}
 	result := ProviderProbeBatchResult{ProviderID: providerID}
 	var firstErr error


### PR DESCRIPTION
## Summary

Make the Provider and Provider resource test actions verify a reachable upstream service rather than reporting success from local configuration alone. This makes a revoked credential or unusable endpoint visible to an administrator.

## Related Issue

Fixes #219.

## Changes

- Use the guarded upstream model-catalog probe for non-specialized Provider adapters.
- Preserve the built-in local mock Provider behavior used for development and tests.
- Mark a Provider unhealthy when all active resource probes fail.
- Add regression coverage for credential forwarding, health transitions, and real probe-based cooldown recovery.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [x] `go test ./internal/server -run '^(TestProviderResourceCooldownAfterFailures|TestProviderTestPerformsUpstreamProbeWithoutResourceHeaders|TestProviderTestMarksProviderUnhealthyWhenAllResourceProbesFail)$' -count=1`
- [x] `go test ./internal/server -count=1`
- [x] `go vet ./...`
- [x] `git diff --check`
- [x] Two consecutive independent review scans reported no actionable findings.

## Compatibility, Security, and Operations

The administrative test action now fails when a non-mock Provider has no reachable upstream model endpoint. The request continues to use the existing server-side request forgery protection, effective resource credentials, and configured headers. No public gateway API, data migration, or deployment change is required.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.