### PR TITLE
fix(anthropic): return cache usage in streaming responses

### DIFF
--- a/backend/internal/server/anthropic_messages.go
+++ b/backend/internal/server/anthropic_messages.go
@@ -750,10 +750,12 @@ func anySlice(value any) ([]any, bool) {
 }
 
 func anthropicUsageObject(usage Usage) map[string]any {
-	cachedInputTokens := minInt64(maxInt64(usage.CachedInputTokens, 0), maxInt64(usage.PromptTokens, 0))
+	promptTokens := maxInt64(usage.PromptTokens, 0)
+	cachedInputTokens := minInt64(maxInt64(usage.CachedInputTokens, 0), promptTokens)
+	cacheWriteInputTokens := minInt64(maxInt64(usage.CacheWriteInputTokens, 0), promptTokens-cachedInputTokens)
 	return map[string]any{
-		"input_tokens":                maxInt64(usage.PromptTokens-cachedInputTokens, 0),
-		"cache_creation_input_tokens": int64(0),
+		"input_tokens":                promptTokens - cachedInputTokens - cacheWriteInputTokens,
+		"cache_creation_input_tokens": cacheWriteInputTokens,
 		"cache_read_input_tokens":     cachedInputTokens,
 		"output_tokens":               usage.CompletionTokens,
 	}

--- a/backend/internal/server/anthropic_messages_stream.go
+++ b/backend/internal/server/anthropic_messages_stream.go
@@ -432,9 +432,7 @@ func (c *openAIAnthropicStreamConverter) Finalize(usage Usage) error {
 			"stop_reason":   stopReason,
 			"stop_sequence": nil,
 		},
-		"usage": map[string]any{
-			"output_tokens": usage.CompletionTokens,
-		},
+		"usage": anthropicUsageObject(usage),
 	}); err != nil {
 		return err
 	}

--- a/backend/internal/server/anthropic_messages_test.go
+++ b/backend/internal/server/anthropic_messages_test.go
@@ -283,7 +283,7 @@ func TestAnthropicMessagesConvertsOpenAIStreamingTextAndToolCall(t *testing.T) {
 		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl_stream\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_read\",\"type\":\"function\",\"function\":{\"name\":\"Read\",\"arguments\":\"{\\\"file_path\\\":\"}}]},\"finish_reason\":null}]}\n\n")
 		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl_stream\",\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"README.md\\\"}\"}}]},\"finish_reason\":null}]}\n\n")
 		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl_stream\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n")
-		_, _ = io.WriteString(w, "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":90,\"completion_tokens\":12,\"total_tokens\":102}}\n\n")
+		_, _ = io.WriteString(w, "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":90,\"completion_tokens\":12,\"total_tokens\":102,\"prompt_tokens_details\":{\"cached_tokens\":80}}}\n\n")
 		_, _ = io.WriteString(w, "data: [DONE]\n\n")
 	}))
 	defer upstream.Close()
@@ -319,8 +319,13 @@ func TestAnthropicMessagesConvertsOpenAIStreamingTextAndToolCall(t *testing.T) {
 			t.Fatalf("stream is missing %q:\n%s", expected, body)
 		}
 	}
+	events := parsePlaygroundSSE(t, body)
+	finalUsage, _ := findPlaygroundSSEEvent(t, events, "message_delta").Data["usage"].(map[string]any)
+	if finalUsage["input_tokens"] != float64(10) || finalUsage["cache_read_input_tokens"] != float64(80) || finalUsage["cache_creation_input_tokens"] != float64(0) || finalUsage["output_tokens"] != float64(12) {
+		t.Fatalf("expected authoritative Anthropic cache usage in the final event, got %#v", finalUsage)
+	}
 	records := store.ListUsageRecords()
-	if len(records) != 1 || records[0].TotalTokens != 102 {
+	if len(records) != 1 || records[0].InputTokens != 90 || records[0].CachedInputTokens != 80 || records[0].OutputTokens != 12 || records[0].TotalTokens != 102 {
 		t.Fatalf("unexpected streaming usage records: %+v", records)
 	}
 }

--- a/backend/internal/server/providers_test.go
+++ b/backend/internal/server/providers_test.go
@@ -187,6 +187,12 @@ func TestAnthropicUsageRecordsCacheWriteTokens(t *testing.T) {
 	if usage.CachedInputTokens != 50 {
 		t.Fatalf("cached input tokens = %d, want 50", usage.CachedInputTokens)
 	}
+	if got := anthropicUsageObject(usage); got["input_tokens"] != int64(10) || got["cache_creation_input_tokens"] != int64(40) || got["cache_read_input_tokens"] != int64(50) {
+		t.Fatalf("Anthropic cache usage = %#v", got)
+	}
+	if got := anthropicUsageObject(Usage{PromptTokens: 10, CachedInputTokens: 9, CacheWriteInputTokens: 9}); got["input_tokens"] != int64(0) || got["cache_creation_input_tokens"] != int64(1) || got["cache_read_input_tokens"] != int64(9) {
+		t.Fatalf("Anthropic bounded cache usage = %#v", got)
+	}
 	if usage.TotalTokens != 105 {
 		t.Fatalf("total tokens = %d, want 105", usage.TotalTokens)
 	}


### PR DESCRIPTION
## Summary

Return complete cumulative cache usage in final Anthropic streaming events when an OpenAI-compatible upstream reports it, keeping billing and usage displays accurate.

## Related Issue

Fixes #208.

## Changes

- Map cache-read and cache-write input tokens into the final Anthropic message_delta usage.
- Bound cache components to total prompt tokens.
- Add streaming and persisted-usage regression coverage.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [x] go test ./...
- [x] go vet ./...
- [x] git diff --check
- [x] Two consecutive independent post-fix scans found no actionable issues.

## Compatibility, Security, and Operations

The final Anthropic streaming usage event now includes standard cumulative cache fields when the upstream reports them. No configuration, security, or deployment changes are required.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local .env files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, start.sh, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] data/model-catalog.yaml remains tracked and catalog changes were reviewed where applicable.
- [x] git diff --check passes.