### PR TITLE
fix(catalog): report seed model write failures

### DIFF
--- a/backend/internal/server/seed.go
+++ b/backend/internal/server/seed.go
@@ -224,7 +224,9 @@ func seedDefaultModelCatalog(store Store, catalogFile string) error {
 			model.OutputPriceUSDPer1M = existing.OutputPriceUSDPer1M
 			model.EmbeddingPriceUSDPer1M = existing.EmbeddingPriceUSDPer1M
 		}
-		store.AddModel(model)
+		if _, err := store.CreateModelWithRoutes(model, nil); err != nil {
+			return fmt.Errorf("seed catalog model %q: %w", model.Name, err)
+		}
 	}
 	return nil
 }

--- a/backend/internal/server/seed_test.go
+++ b/backend/internal/server/seed_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -47,6 +48,31 @@ func TestRunStartupBootstrapReloadsCatalogOnEveryStart(t *testing.T) {
 	}
 	if got := modelCategory(); got != "second-start" {
 		t.Fatalf("catalog edit was not applied on restart: category=%q", got)
+	}
+}
+
+func TestSeedDefaultModelCatalogReportsLegacyNameConflict(t *testing.T) {
+	store := NewMemoryStore()
+	store.AddModel(Model{
+		ID:       "legacy-catalog-id",
+		Name:     "catalog-conflict-model",
+		Modality: "chat",
+		Status:   StatusActive,
+	})
+	catalogPath := filepath.Join(t.TempDir(), "model-catalog.yaml")
+	if err := os.WriteFile(catalogPath, []byte("version: 1\nmodels:\n  - name: catalog-conflict-model\n    modality: chat\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := seedDefaultModelCatalog(store, catalogPath)
+	if err == nil {
+		t.Fatal("expected catalog seed conflict to be reported")
+	}
+	if !strings.Contains(err.Error(), `seed catalog model "catalog-conflict-model"`) {
+		t.Fatalf("expected model name in seed error, got %v", err)
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "duplicated key") {
+		t.Fatalf("expected database conflict cause in seed error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Make catalog seed write failures visible instead of silently dropping a model when a legacy database row conflicts with the catalog.

## Related Issue

Fixes #220.

## Changes

- Use the existing transactional model creation path while seeding the catalog.
- Return a model-specific wrapped error to the startup bootstrap path.
- Add a real SQLite legacy ID/name conflict regression test.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [x] go test ./...
- [x] go vet ./...
- [x] node --test tools/*.test.mjs
- [x] node tools/check-ui-translations.mjs
- [x] node tools/check-source-lines.mjs
- [x] git diff --check
- [x] Two consecutive independent post-fix scans found no actionable issues.

## Compatibility, Security, and Operations

A malformed or conflicting catalog seed now fails startup with the model name and database cause instead of continuing silently. No API, security, configuration, or deployment changes are required.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local .env files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, start.sh, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] data/model-catalog.yaml remains tracked and catalog changes were reviewed where applicable.
- [x] git diff --check passes.