### PR TITLE
feat(audit): filter request logs by time and model

### DIFF
--- a/backend/internal/server/admin_request_logs.go
+++ b/backend/internal/server/admin_request_logs.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -49,12 +50,26 @@ func (s *Server) requestLogQueryForUser(user AdminUser, r *http.Request) (Reques
 	if page-1 > int(^uint(0)>>1)/pageSize {
 		return RequestLogQuery{}, NewHTTPError(http.StatusBadRequest, "invalid_request", "page offset is too large")
 	}
+	since, err := parseRequestLogQueryTime("since", r.URL.Query().Get("since"))
+	if err != nil {
+		return RequestLogQuery{}, err
+	}
+	until, err := parseRequestLogQueryTime("until", r.URL.Query().Get("until"))
+	if err != nil {
+		return RequestLogQuery{}, err
+	}
+	if !since.IsZero() && !until.IsZero() && since.After(until) {
+		return RequestLogQuery{}, NewHTTPError(http.StatusBadRequest, "invalid_request", "since must be before or equal to until")
+	}
 	query := RequestLogQuery{
-		Page:     page,
-		PageSize: pageSize,
-		Status:   strings.ToLower(strings.TrimSpace(r.URL.Query().Get("status"))),
-		Keyword:  strings.TrimSpace(r.URL.Query().Get("q")),
-		Global:   s.canViewGlobalOperations(user),
+		Page:      page,
+		PageSize:  pageSize,
+		Status:    strings.ToLower(strings.TrimSpace(r.URL.Query().Get("status"))),
+		Keyword:   strings.TrimSpace(r.URL.Query().Get("q")),
+		ModelName: strings.TrimSpace(r.URL.Query().Get("model")),
+		Since:     since,
+		Until:     until,
+		Global:    s.canViewGlobalOperations(user),
 	}
 	if query.Status == "" {
 		query.Status = "all"
@@ -70,6 +85,18 @@ func (s *Server) requestLogQueryForUser(user AdminUser, r *http.Request) (Reques
 	}
 	query.APIKeyIDs = trueMapKeys(s.visibleAPIKeyIDSet(user))
 	return query, nil
+}
+
+func parseRequestLogQueryTime(name, value string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, NewHTTPError(http.StatusBadRequest, "invalid_request", name+" must be an RFC3339 timestamp")
+	}
+	return parsed.UTC(), nil
 }
 
 func positiveRequestLogQueryInt(value string, fallback int) (int, error) {

--- a/backend/internal/server/admin_request_logs_test.go
+++ b/backend/internal/server/admin_request_logs_test.go
@@ -129,6 +129,47 @@ func TestAdminRequestLogsFiltersStatusBeforePagination(t *testing.T) {
 	}
 }
 
+func TestAdminRequestLogsFiltersExactModelAndInclusiveTimeRange(t *testing.T) {
+	store := NewMemoryStore()
+	base := time.Date(2026, time.August, 16, 1, 0, 0, 0, time.UTC)
+	logs := []RequestLog{
+		{ID: "log_before", RequestID: "req_before", ModelName: "gpt-4", StatusCode: http.StatusOK, LatencyMS: 100, CreatedAt: base.Add(-time.Second)},
+		{ID: "log_since", RequestID: "req_since", ModelName: "gpt-4", StatusCode: http.StatusBadGateway, LatencyMS: 200, CreatedAt: base},
+		{ID: "log_similar", RequestID: "req_similar", ModelName: "gpt-4o", StatusCode: http.StatusOK, LatencyMS: 300, CreatedAt: base.Add(30 * time.Minute)},
+		{ID: "log_until", RequestID: "req_until", ModelName: "gpt-4", StatusCode: http.StatusOK, LatencyMS: 400, CreatedAt: base.Add(time.Hour)},
+	}
+	for index := range logs {
+		if err := store.db.Create(&logs[index]).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	path := "/api/admin/audit/requests?model=gpt-4&since=" + url.QueryEscape(base.Format(time.RFC3339Nano)) + "&until=" + url.QueryEscape(base.Add(time.Hour).Format(time.RFC3339Nano))
+	response := doJSON(t, New(store).Handler(), http.MethodGet, path, nil, "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected filtered request logs 200, got %d: %s", response.Code, response.Body)
+	}
+	var payload RequestLogPage
+	if err := json.Unmarshal([]byte(response.Body), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Data) != 2 || payload.Data[0].ID != "log_until" || payload.Data[1].ID != "log_since" {
+		t.Fatalf("expected inclusive exact-model results, got %+v", payload.Data)
+	}
+	if payload.Pagination.Total != 2 || payload.Summary.All != 2 || payload.Summary.OK != 1 || payload.Summary.Error != 1 || payload.Summary.AverageLatencyMS != 300 {
+		t.Fatalf("filters must apply to page, pagination, and summary: pagination=%+v summary=%+v", payload.Pagination, payload.Summary)
+	}
+	for _, invalidPath := range []string{
+		"/api/admin/audit/requests?since=not-a-timestamp",
+		"/api/admin/audit/requests?since=2026-08-16T02:00:00Z&until=2026-08-16T01:00:00Z",
+	} {
+		invalid := doJSON(t, New(store).Handler(), http.MethodGet, invalidPath, nil, "")
+		if invalid.Code != http.StatusBadRequest {
+			t.Fatalf("expected invalid range %q to return 400, got %d: %s", invalidPath, invalid.Code, invalid.Body)
+		}
+	}
+}
+
 func TestAdminRequestLogsSearchesExistingAuditFields(t *testing.T) {
 	store := NewMemoryStore()
 	project := store.CreateProject(Project{ID: "project_search", Name: "Alpha Finance"})

--- a/backend/internal/server/store_request_logs.go
+++ b/backend/internal/server/store_request_logs.go
@@ -3,6 +3,7 @@ package server
 import (
 	"math"
 	"strings"
+	"time"
 
 	"gorm.io/gorm"
 )
@@ -12,6 +13,9 @@ type RequestLogQuery struct {
 	PageSize   int
 	Status     string
 	Keyword    string
+	ModelName  string
+	Since      time.Time
+	Until      time.Time
 	Global     bool
 	ProjectIDs []string
 	APIKeyIDs  []string
@@ -93,7 +97,20 @@ func (s *GormStore) QueryRequestLogs(query RequestLogQuery) (RequestLogPage, err
 }
 
 func requestLogBaseQuery(db *gorm.DB, query RequestLogQuery) *gorm.DB {
-	return applyRequestLogKeyword(applyRequestLogScope(db.Model(&RequestLog{}), query), query.Keyword)
+	return applyRequestLogFilters(applyRequestLogKeyword(applyRequestLogScope(db.Model(&RequestLog{}), query), query.Keyword), query)
+}
+
+func applyRequestLogFilters(db *gorm.DB, query RequestLogQuery) *gorm.DB {
+	if query.ModelName != "" {
+		db = db.Where("model_name = ?", query.ModelName)
+	}
+	if !query.Since.IsZero() {
+		db = db.Where("created_at >= ?", query.Since)
+	}
+	if !query.Until.IsZero() {
+		db = db.Where("created_at <= ?", query.Until)
+	}
+	return db
 }
 
 func applyRequestLogKeyword(db *gorm.DB, keyword string) *gorm.DB {

--- a/frontend/app/styles/legacy/audit.css
+++ b/frontend/app/styles/legacy/audit.css
@@ -124,8 +124,18 @@
 }
 
 .request-filter-tabs button.active {
-  background: var(--text);
-  color: white;
+	background: var(--text);
+	color: white;
+}
+
+.request-log-model-filter {
+	min-width: 160px;
+	height: 36px;
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	padding: 0 10px;
+	background: var(--surface-soft);
+	color: var(--text);
 }
 
 .request-metrics {

--- a/frontend/features/admin/domain/audit-request-page.test.mjs
+++ b/frontend/features/admin/domain/audit-request-page.test.mjs
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { importTypeScript } from "./typescript-test-loader.mjs";
 
-const { auditRequestPagePath } = await importTypeScript(new URL("./audit-request-page.ts", import.meta.url));
+const { auditRequestPagePath, auditRequestTimeRangeParameters } = await importTypeScript(new URL("./audit-request-page.ts", import.meta.url));
 
 test("audit request page path carries server-side filters and pagination", () => {
   assert.equal(
@@ -12,8 +12,11 @@ test("audit request page path carries server-side filters and pagination", () =>
       pageSize: 50,
       status: "error",
       query: "Alpha Finance / 429",
+	  model: "gpt-4.1",
+	  since: "2026-08-16T00:00:00.000Z",
+	  until: "2026-08-16T01:00:00.000Z",
     }),
-    "/api/admin/audit/requests?page=3&page_size=50&status=error&q=Alpha+Finance+%2F+429",
+    "/api/admin/audit/requests?page=3&page_size=50&status=error&q=Alpha+Finance+%2F+429&model=gpt-4.1&since=2026-08-16T00%3A00%3A00.000Z&until=2026-08-16T01%3A00%3A00.000Z",
   );
 });
 
@@ -24,7 +27,27 @@ test("audit request page path normalizes empty search terms", () => {
       pageSize: 20,
       status: "all",
       query: "   ",
+	  model: "",
+	  since: "",
+	  until: "",
     }),
     "/api/admin/audit/requests?page=1&page_size=20&status=all&q=",
   );
+});
+
+test("audit request time ranges use an inclusive UTC window", () => {
+  const now = new Date("2026-08-16T01:00:00.000Z");
+  assert.deepEqual(auditRequestTimeRangeParameters("15m", now), {
+    since: "2026-08-16T00:45:00.000Z",
+    until: "2026-08-16T01:00:00.000Z",
+  });
+  assert.deepEqual(auditRequestTimeRangeParameters("1h", now), {
+    since: "2026-08-16T00:00:00.000Z",
+    until: "2026-08-16T01:00:00.000Z",
+  });
+  assert.deepEqual(auditRequestTimeRangeParameters("24h", now), {
+    since: "2026-08-15T01:00:00.000Z",
+    until: "2026-08-16T01:00:00.000Z",
+  });
+  assert.deepEqual(auditRequestTimeRangeParameters("all", now), { since: "", until: "" });
 });

--- a/frontend/features/admin/domain/audit-request-page.ts
+++ b/frontend/features/admin/domain/audit-request-page.ts
@@ -1,17 +1,37 @@
 export type AuditRequestStatus = "all" | "ok" | "error";
+export type AuditRequestTimeRange = "all" | "15m" | "1h" | "24h";
 
 export type AuditRequestPageParameters = {
   page: number;
   pageSize: number;
-  status: AuditRequestStatus;
-  query: string;
+	status: AuditRequestStatus;
+	query: string;
+	model?: string;
+	since?: string;
+	until?: string;
 };
+
+export function auditRequestTimeRangeParameters(range: AuditRequestTimeRange, now: Date) {
+	const durations: Record<Exclude<AuditRequestTimeRange, "all">, number> = {
+		"15m": 15 * 60 * 1000,
+		"1h": 60 * 60 * 1000,
+		"24h": 24 * 60 * 60 * 1000,
+	};
+	if (range === "all") return { since: "", until: "" };
+	return {
+		since: new Date(now.getTime() - durations[range]).toISOString(),
+		until: now.toISOString(),
+	};
+}
 
 export function auditRequestPagePath(parameters: AuditRequestPageParameters) {
   const query = new URLSearchParams();
   query.set("page", String(parameters.page));
   query.set("page_size", String(parameters.pageSize));
-  query.set("status", parameters.status);
-  query.set("q", parameters.query.trim());
-  return `/api/admin/audit/requests?${query.toString()}`;
+	query.set("status", parameters.status);
+	query.set("q", parameters.query.trim());
+	if (parameters.model?.trim()) query.set("model", parameters.model.trim());
+	if (parameters.since) query.set("since", parameters.since);
+	if (parameters.until) query.set("until", parameters.until);
+	return `/api/admin/audit/requests?${query.toString()}`;
 }

--- a/frontend/features/admin/i18n/audit-filters.tsx
+++ b/frontend/features/admin/i18n/audit-filters.tsx
@@ -1,0 +1,18 @@
+export const auditFilterTranslations = {
+  en: {
+    "请求时间范围": "Request time range",
+    "全部时间": "All time",
+    "最近 15 分钟": "Last 15 minutes",
+    "最近 1 小时": "Last hour",
+    "最近 24 小时": "Last 24 hours",
+    "按模型筛选": "Filter by model",
+  },
+  ja: {
+    "请求时间范围": "リクエスト期間",
+    "全部时间": "全期間",
+    "最近 15 分钟": "過去 15 分",
+    "最近 1 小时": "過去 1 時間",
+    "最近 24 小时": "過去 24 時間",
+    "按模型筛选": "モデルで絞り込み",
+  },
+};

--- a/frontend/features/admin/i18n/translations.tsx
+++ b/frontend/features/admin/i18n/translations.tsx
@@ -1,5 +1,6 @@
 import { enTranslations } from "./en";
 import { jaTranslations } from "./ja";
+import { auditFilterTranslations } from "./audit-filters";
 import { modelGovernanceTranslations } from "./model-governance";
 import { playgroundTranslations } from "./playground";
 import { providerConnectionTranslations } from "./provider-connection";
@@ -11,6 +12,6 @@ import { usageTranslations } from "./usage";
 import syntheticDNSTranslations from "./synthetic-dns";
 
 export const translations: Record<"en" | "ja", Record<string, string>> = {
-  en: { ...enTranslations, ...routingTranslations.en, ...codexImageTranslations.en, ...scopedRoutingPolicyTranslations.en, ...modelGovernanceTranslations.en, ...providerConnectionTranslations.en, ...usageTranslations.en, ...playgroundTranslations.en, ...securityTranslations.en, ...syntheticDNSTranslations.en },
-  ja: { ...jaTranslations, ...routingTranslations.ja, ...codexImageTranslations.ja, ...scopedRoutingPolicyTranslations.ja, ...modelGovernanceTranslations.ja, ...providerConnectionTranslations.ja, ...usageTranslations.ja, ...playgroundTranslations.ja, ...securityTranslations.ja, ...syntheticDNSTranslations.ja },
+  en: { ...enTranslations, ...auditFilterTranslations.en, ...routingTranslations.en, ...codexImageTranslations.en, ...scopedRoutingPolicyTranslations.en, ...modelGovernanceTranslations.en, ...providerConnectionTranslations.en, ...usageTranslations.en, ...playgroundTranslations.en, ...securityTranslations.en, ...syntheticDNSTranslations.en },
+  ja: { ...jaTranslations, ...auditFilterTranslations.ja, ...routingTranslations.ja, ...codexImageTranslations.ja, ...scopedRoutingPolicyTranslations.ja, ...modelGovernanceTranslations.ja, ...providerConnectionTranslations.ja, ...usageTranslations.ja, ...playgroundTranslations.ja, ...securityTranslations.ja, ...syntheticDNSTranslations.ja },
 };

--- a/frontend/features/admin/views/audit.tsx
+++ b/frontend/features/admin/views/audit.tsx
@@ -2,7 +2,7 @@ import { Activity, AlertCircle, Check, Copy, Gauge, Search, ShieldCheck } from "
 import { useEffect, useMemo, useState } from "react";
 import { canViewAdminAudit } from "../core/navigation";
 import { type AdminUser, type ApiContext, type AppData, type RequestDetail, type RequestLogPage, type RequestLogPagination, type RequestLogSummary, type RequestPayloadLog } from "../core/types";
-import { auditRequestPagePath, type AuditRequestStatus } from "../domain/audit-request-page";
+import { auditRequestPagePath, auditRequestTimeRangeParameters, type AuditRequestStatus, type AuditRequestTimeRange } from "../domain/audit-request-page";
 import { copyText } from "../domain/clipboard";
 import { apiKeyAuditLabel, projectName, providerAttemptLabel, providerAuditLabel, providerResourceAuditLabel } from "../domain/entities";
 import { compactNumber, formatMoney, formatNumber, formatTime } from "../domain/formatting";
@@ -16,6 +16,8 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
   const [activeAuditTab, setActiveAuditTab] = useState<"requests" | "admin">("requests");
   const [query, setQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<AuditRequestStatus>("all");
+  const [timeRange, setTimeRange] = useState<AuditRequestTimeRange>("all");
+  const [modelFilter, setModelFilter] = useState("");
   const [requestLogs, setRequestLogs] = useState<RequestLogPage["data"]>([]);
   const [requestPage, setRequestPage] = useState(1);
   const [requestPageSize, setRequestPageSize] = useState(20);
@@ -28,6 +30,10 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState("");
   const showAdminAudit = canViewAdminAudit(user);
+  const modelOptions = useMemo(
+    () => [...new Set(data.models.map((model) => model.name).filter(Boolean))].sort((left, right) => left.localeCompare(right)),
+    [data.models],
+  );
 
   useEffect(() => {
     if (!showAdminAudit && activeAuditTab === "admin") {
@@ -45,11 +51,14 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
     setRequestPagination(emptyRequestLogPagination(requestPage, requestPageSize));
     setRequestSummary(emptyRequestLogSummary());
     const timeout = window.setTimeout(() => {
+	  const requestTimeRange = auditRequestTimeRangeParameters(timeRange, new Date());
       adminFetch(api, auditRequestPagePath({
         page: requestPage,
         pageSize: requestPageSize,
         status: statusFilter,
         query,
+		model: modelFilter,
+		...requestTimeRange,
       }), { signal: controller.signal })
         .then(async (resp) => {
           if (!resp.ok) throw new Error(`request logs ${resp.status}`);
@@ -74,7 +83,7 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
       window.clearTimeout(timeout);
       controller.abort();
     };
-  }, [activeAuditTab, api, query, requestPage, requestPageSize, statusFilter]);
+  }, [activeAuditTab, api, modelFilter, query, requestPage, requestPageSize, statusFilter, timeRange]);
 
   const requestLogPagination = useMemo<PaginationState>(() => {
     const pageCount = Math.max(1, requestPagination.total_pages);
@@ -158,6 +167,12 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
     { key: "ok", label: `${tx("成功")} ${requestSummary.ok}` },
     { key: "error", label: `${tx("失败")} ${requestSummary.error}` },
   ] as const;
+  const timeFilters = [
+    { key: "all", label: tx("全部时间") },
+    { key: "15m", label: tx("最近 15 分钟") },
+    { key: "1h", label: tx("最近 1 小时") },
+    { key: "24h", label: tx("最近 24 小时") },
+  ] as const;
 
   return (
     <div className="audit-view">
@@ -218,6 +233,34 @@ export function AuditView({ api, data, user }: { api: ApiContext; data: AppData;
                   </button>
                 ))}
               </div>
+              <div className="request-filter-tabs" role="group" aria-label={tx("请求时间范围")}>
+                {timeFilters.map((filter) => (
+                  <button
+                    key={filter.key}
+                    type="button"
+                    className={timeRange === filter.key ? "active" : ""}
+					aria-pressed={timeRange === filter.key}
+                    onClick={() => {
+                      setTimeRange(filter.key);
+                      setRequestPage(1);
+                    }}
+                  >
+                    {filter.label}
+                  </button>
+                ))}
+              </div>
+              <select
+                aria-label={tx("按模型筛选")}
+                className="request-log-model-filter"
+                value={modelFilter}
+                onChange={(event) => {
+                  setModelFilter(event.target.value);
+                  setRequestPage(1);
+                }}
+              >
+                <option value="">{tx("全部模型")}</option>
+                {modelOptions.map((model) => <option key={model} value={model}>{model}</option>)}
+              </select>
             </div>
 
             <div className="metrics request-metrics">


### PR DESCRIPTION
## Summary

Add focused request-log filters so operators can inspect an exact model within an inclusive recent time window without changing audit payload retention or traffic instrumentation.

## Related Issue

Fixes #223.

## Changes

- Add validated RFC3339 since/until and exact model filters to the request-log API.
- Apply filters consistently to authorization-scoped results, summary, count, and pagination.
- Add 15-minute, 1-hour, and 24-hour controls plus a model selector to the audit console.
- Add backend and frontend regression coverage.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [x] go test ./...
- [x] go vet ./...
- [x] npm test
- [x] npm run typecheck
- [x] npm run build
- [x] node --test tools/*.test.mjs
- [x] node tools/check-ui-translations.mjs
- [x] node tools/check-source-lines.mjs
- [x] git diff --check
- [x] Two consecutive independent post-fix scans found no actionable issues.

## Compatibility, Security, and Operations

The existing request-log endpoint remains compatible; new query parameters are optional. No headers, first-token metrics, audit payload retention, credentials, or deployment settings are changed.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local .env files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, start.sh, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] data/model-catalog.yaml remains tracked and catalog changes were reviewed where applicable.
- [x] git diff --check passes.