### PR TITLE
fix(catalog): preserve routes during catalog refresh

### DIFF
--- a/backend/internal/server/seed.go
+++ b/backend/internal/server/seed.go
@@ -156,7 +156,6 @@ func BootstrapBaseDataWithConfig(store Store, config Config) error {
 	if err := seedBuiltinProviderCatalog(store); err != nil {
 		return err
 	}
-	pruneProviderImportedModelCatalog(store)
 	if err := seedDefaultModelCatalog(store, config.ModelCatalogFile); err != nil {
 		return err
 	}
@@ -198,14 +197,6 @@ func seedDefaultProject(store Store) {
 		CostCenter:  "AI-PLATFORM",
 		Status:      StatusActive,
 	})
-}
-
-func pruneProviderImportedModelCatalog(store Store) {
-	for _, model := range store.ListModels() {
-		if model.Metadata != nil && model.Metadata["source"] == "public-provider-conf" {
-			_ = store.DeleteModel(model.Name)
-		}
-	}
 }
 
 func seedDefaultModelCatalog(store Store, catalogFile string) error {

--- a/backend/internal/server/seed_test.go
+++ b/backend/internal/server/seed_test.go
@@ -213,3 +213,47 @@ models:
 		t.Fatalf("new catalog model did not use catalog prices: %+v", newModel)
 	}
 }
+
+func TestBootstrapBaseDataPreservesRoutesWhenRefreshingLegacyCatalogModel(t *testing.T) {
+	store := NewMemoryStore()
+	const modelName = "deepseek-v4-flash"
+	store.AddModel(Model{
+		Name:     modelName,
+		Modality: "chat",
+		Status:   StatusActive,
+		Metadata: map[string]string{"source": "public-provider-conf"},
+	})
+	provider := store.AddProvider(Provider{
+		ID:      "prv_catalog_route",
+		Name:    "Catalog Route Provider",
+		Type:    ProviderOpenAICompatible,
+		Status:  StatusActive,
+		Healthy: true,
+	})
+	route := store.AddRoute(ModelRoute{
+		ID:            "route_catalog_model",
+		ModelName:     modelName,
+		ProviderID:    provider.ID,
+		ProviderModel: modelName,
+		Status:        StatusActive,
+	})
+	config := Config{
+		BootstrapAdminPassword: "catalog-route-bootstrap-password",
+		ModelCatalogFile:       "../../../data/model-catalog.yaml",
+	}
+
+	if err := BootstrapBaseDataWithConfig(store, config); err != nil {
+		t.Fatal(err)
+	}
+
+	model, ok := modelByNameForTest(store.ListModels(), modelName)
+	if !ok || model.Metadata["source"] != "tokenhub-standard-catalog" {
+		t.Fatalf("expected standard catalog model after refresh, got %+v", model)
+	}
+	for _, existing := range store.ListRoutes() {
+		if existing.ID == route.ID && existing.ModelName == modelName {
+			return
+		}
+	}
+	t.Fatalf("expected catalog refresh to preserve route %+v", route)
+}


### PR DESCRIPTION
## Summary

Preserve configured routes while refreshing catalog models by removing an obsolete startup prune path that could delete a model and cascade-delete its routes.

## Related Issue

Fixes #231.

## Changes

- Remove the unreachable and destructive provider-imported catalog prune step.
- Keep catalog refresh as an upsert that preserves routes.
- Add a regression test using the tracked deepseek-v4-flash catalog entry.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [x] go test ./...
- [x] go vet ./...
- [x] node --test tools/*.test.mjs
- [x] node tools/check-ui-translations.mjs
- [x] node tools/check-source-lines.mjs
- [x] git diff --check
- [x] Two consecutive independent post-fix scans found no actionable issues.

## Compatibility, Security, and Operations

The change does not invent default Provider routes. It retains operator-configured routes during catalog refresh and continues to expose unrouted models through the existing administrative state. No API, credential, configuration, or deployment changes are required.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local .env files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, start.sh, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] data/model-catalog.yaml remains tracked and catalog changes were reviewed where applicable.
- [x] git diff --check passes.