### PR TITLE
perf(gateway): enlarge upstream idle connection pool

### DIFF
--- a/backend/internal/server/provider_catalog_ssrf_test.go
+++ b/backend/internal/server/provider_catalog_ssrf_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
 	"net/url"
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -346,6 +349,120 @@ func TestSSRFGuardedDialContextDialsValidatedAddress(t *testing.T) {
 		t.Fatalf("expected connection to a loopback address, got %s", conn.RemoteAddr())
 	}
 	conn.Close()
+}
+
+// TestSSRFGuardedProviderTransportPoolsIdleConnections covers the gateway
+// connection-pool sizing. A burst of concurrent requests to one upstream must
+// leave every connection in the idle pool, so the requests behind it reuse
+// them instead of paying a fresh TCP and TLS handshake; the standard library
+// default of two idle connections per host would discard the rest.
+func TestSSRFGuardedProviderTransportPoolsIdleConnections(t *testing.T) {
+	const parallel = 8
+
+	transport := ssrfGuardedProviderTransport(nil)
+	if transport.DialContext == nil {
+		t.Fatal("expected guarded transport to install a DialContext")
+	}
+	if transport.MaxIdleConnsPerHost != 64 {
+		t.Fatalf("expected 64 idle connections per host, got %d", transport.MaxIdleConnsPerHost)
+	}
+	if transport.MaxIdleConns != 256 {
+		t.Fatalf("expected a 256 connection idle pool, got %d", transport.MaxIdleConns)
+	}
+
+	// The burst handler holds every request until all of them have arrived, so
+	// the transport has to open one connection per request.
+	arrived := make(chan struct{}, parallel)
+	release := make(chan struct{})
+	var connections atomic.Int32
+	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/burst" {
+			arrived <- struct{}{}
+			<-release
+		}
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write([]byte("ok"))
+	}))
+	upstream.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			connections.Add(1)
+		}
+	}
+	upstream.Start()
+	defer upstream.Close()
+	// Registered after Close so it runs first: a failed burst must not leave
+	// handlers blocked, which would hang the server shutdown.
+	var releaseOnce sync.Once
+	releaseBurst := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseBurst()
+
+	// PutIdleConn reports per connection whether the transport kept it for
+	// reuse; under the default limit the surplus connections would report
+	// "too many idle connections for host" instead.
+	pooled := make(chan error, parallel)
+	trace := &httptrace.ClientTrace{PutIdleConn: func(err error) { pooled <- err }}
+	// The timeout bounds Do and the body read together, so a stalled request
+	// fails the test instead of hanging the package on the burst collection.
+	client := &http.Client{Transport: transport, Timeout: 30 * time.Second}
+
+	burst := make(chan error, parallel)
+	for i := 0; i < parallel; i++ {
+		go func() {
+			request, err := http.NewRequestWithContext(httptrace.WithClientTrace(context.Background(), trace), http.MethodGet, upstream.URL+"/burst", nil)
+			if err != nil {
+				burst <- err
+				return
+			}
+			response, err := client.Do(request)
+			if err == nil {
+				_, _ = io.Copy(io.Discard, response.Body)
+				err = response.Body.Close()
+			}
+			burst <- err
+		}()
+	}
+	for i := 0; i < parallel; i++ {
+		select {
+		case <-arrived:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out waiting for the concurrent burst, %d of %d requests arrived", i, parallel)
+		}
+	}
+	releaseBurst()
+	for i := 0; i < parallel; i++ {
+		if err := <-burst; err != nil {
+			t.Fatalf("burst request failed: %v", err)
+		}
+	}
+	if got := connections.Load(); got != parallel {
+		t.Fatalf("expected the burst to open %d connections, got %d", parallel, got)
+	}
+
+	// Draining a response returns its connection to the idle pool, so
+	// collecting every callback both asserts the pooling and synchronizes the
+	// reuse round below.
+	for i := 0; i < parallel; i++ {
+		select {
+		case err := <-pooled:
+			if err != nil {
+				t.Fatalf("expected every burst connection to stay pooled, got %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out waiting for idle connections, only %d of %d were pooled", i, parallel)
+		}
+	}
+
+	for i := 0; i < parallel; i++ {
+		response, err := client.Get(upstream.URL + "/reuse")
+		if err != nil {
+			t.Fatalf("reuse request %d failed: %v", i, err)
+		}
+		_, _ = io.Copy(io.Discard, response.Body)
+		_ = response.Body.Close()
+	}
+	if got := connections.Load(); got != parallel {
+		t.Fatalf("expected the reuse round to open no new connections, got %d in total", got)
+	}
 }
 
 func mustParseCIDRs(t *testing.T, cidrs ...string) []*net.IPNet {

--- a/backend/internal/server/provider_upstream_ssrf.go
+++ b/backend/internal/server/provider_upstream_ssrf.go
@@ -480,15 +480,29 @@ func raceValidatedUpstreamCandidates(ctx context.Context, network, port string, 
 // would receive the proxy address and the guard would validate the proxy rather
 // than the request target, letting the proxy's own DNS resolution bypass the
 // check. Provider catalog fetches therefore always connect directly.
+//
+// The idle pool is sized for a gateway workload: unlike a general-purpose
+// client, this transport fans a large amount of concurrent traffic out over a
+// handful of upstream hosts. The standard library's default of two idle
+// connections per host would retire every connection above that as soon as it
+// goes idle, so a busy host pays a fresh TCP and TLS handshake on nearly every
+// request. These limits cap how many idle connections are kept for reuse, not
+// how many requests may run at once; MaxConnsPerHost stays unset so the guard
+// never throttles concurrency. IdleConnTimeout stays at the standard 90
+// seconds — including on the fallback path, where a zero value would otherwise
+// keep the whole enlarged pool open forever — so connections to a host that
+// falls quiet are still released.
 func ssrfGuardedProviderTransport(allowedPrivate []*net.IPNet, syntheticDNS ...providerSyntheticDNSResolver) *http.Transport {
 	base, ok := http.DefaultTransport.(*http.Transport)
 	var transport *http.Transport
 	if ok {
 		transport = base.Clone()
 	} else {
-		transport = &http.Transport{}
+		transport = &http.Transport{IdleConnTimeout: 90 * time.Second}
 	}
 	transport.Proxy = nil
+	transport.MaxIdleConnsPerHost = 64
+	transport.MaxIdleConns = 256
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,


### PR DESCRIPTION
## Summary

Every upstream provider call goes through the SSRF-guarded transport, which clones `http.DefaultTransport` and therefore inherits its default of **2 idle connections per host**. A gateway fans a large amount of concurrent traffic out over a handful of upstream hosts (`api.openai.com` etc.), so under any real concurrency the surplus connections are retired the moment they go idle and nearly every request to a busy host pays a fresh TCP + TLS handshake. This PR sizes the idle pool for a gateway workload.

## Related Issue

N/A (first PR from an internal performance review of the request hot path).

## Changes

- `ssrfGuardedProviderTransport` now sets `MaxIdleConnsPerHost = 64` and `MaxIdleConns = 256` after cloning. These cap idle-pool retention only; `MaxConnsPerHost` stays unset so the guard never throttles concurrency.
- The rare fallback path (when `http.DefaultTransport` is not an `*http.Transport`) now sets `IdleConnTimeout: 90 * time.Second` explicitly, so the enlarged pool can never hold connections forever on that path.
- New test `TestSSRFGuardedProviderTransportPoolsIdleConnections`: an 8-way concurrent burst against a local server must open 8 connections, keep all of them pooled (asserted via `httptrace.ClientTrace.PutIdleConn`), and a follow-up serial round must open **no** new connections. Under the old default of 2 the test fails with `http: putIdleConn: too many idle connections for host`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `gofmt -l .` — clean.
- `go test ./... -count=1` (backend) — all packages ok, run twice independently.
- `go test ./internal/server/ -run TestSSRFGuardedProviderTransportPoolsIdleConnections -race -count=10` — ok.
- `go vet ./...` — clean.
- `golangci-lint run ./...` (v2.12.2, same version/working-directory as CI) — 10 pre-existing `staticcheck SA5011` findings in unrelated test files; verified via stash diff that the output is byte-identical with and without this change (no new findings).
- `git diff --check` — clean.
- End-to-end smoke on a real process (temp SQLite, seeded demo data): `/livez`, non-streaming and streaming `/v1/chat/completions` via the mock provider, and `/api/admin/usage/summary` all pass.
- Discriminating check: temporarily reverting `MaxIdleConnsPerHost` to 2 makes the new test fail as expected, then restored.

## Compatibility, Security, and Operations

- No API or behavior change other than connection reuse. SSRF guard, DialContext, proxy disablement, and redirect policy are untouched.
- Rotation of synthetic-DNS transports already calls `CloseIdleConnections()` on the retired transport; connections still serving in-flight requests during a rotate strand in the retired pool (unreachable for new requests) until the 90 s idle timeout — same behavior as before, now with a larger upper bound (64/host instead of 2/host) on that transient.
- File-descriptor budget: the gateway keeps 2 long-lived upstream transports (stream + non-stream), so the idle-pool ceiling is ~512 FDs process-wide (128 per host). Worth keeping in mind for containers with `ulimit -n 1024`; no deployment file change included.
- HTTP/2 upstreams multiplex and are unaffected; the win applies to HTTP/1.1 upstreams.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable. (No environment variable changes.)
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable. (No user-facing behavior change.)
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable. (Not touched.)
- [x] `git diff --check` passes.
