### PR TITLE
perf(metrics): cache the model catalog behind the rejection label

### DIFF
--- a/backend/internal/server/model_label_cache.go
+++ b/backend/internal/server/model_label_cache.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	// modelLabelTTL bounds how stale a cached catalog snapshot may become. Model
+	// changes made through this process invalidate the snapshot immediately;
+	// changes made by another replica are picked up within one TTL. The snapshot
+	// only decides whether a model name is safe to use as a metrics label — it
+	// takes no part in authentication or routing — so a label that lags the
+	// catalog by up to one TTL is acceptable.
+	modelLabelTTL = 60 * time.Second
+	// modelLabelRetryBackoff keeps a database outage from turning every rejected
+	// request back into a query: a failed refresh is not retried before it elapses.
+	modelLabelRetryBackoff = 5 * time.Second
+)
+
+// modelLabelCache holds the set of model names the catalog knows, so bounding a
+// metrics label to that set costs a map lookup instead of a query per request.
+type modelLabelCache struct {
+	mu sync.Mutex
+	// names stays nil until a refresh has succeeded at least once.
+	names       map[string]struct{}
+	fetchedAt   time.Time
+	nextAttempt time.Time
+}
+
+func newModelLabelCache() *modelLabelCache {
+	return &modelLabelCache{}
+}
+
+// invalidate marks the snapshot stale so the next lookup reloads it. Callers must
+// not hold an open database transaction: a refresh already in flight runs its
+// query while holding the same mutex.
+func (c *modelLabelCache) invalidate() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.fetchedAt = time.Time{}
+	c.nextAttempt = time.Time{}
+	c.mu.Unlock()
+}
+
+// lookup reports whether name is a known model, refreshing the snapshot through
+// load when it is missing or older than modelLabelTTL. The second result is false
+// only when there is no cache to consult at all: a cache whose refresh is failing
+// answers from its last snapshot, or reports the model as unknown when it has
+// none, rather than sending the caller back to a database it just failed to reach.
+func (c *modelLabelCache) lookup(name string, clock func() time.Time, load func() ([]string, error)) (bool, bool) {
+	if c == nil {
+		return false, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := clock()
+	if c.stale(now) && !now.Before(c.nextAttempt) {
+		names, err := load()
+		// A failing database usually fails slowly, so both stamps are read after
+		// the query returns. Timing them from before it would let a load that took
+		// longer than the interval hand back a window that has already elapsed.
+		completed := clock()
+		if err != nil {
+			// Serving a stale snapshot is strictly better than widening the label
+			// set, so the previous one is kept and only the retry is delayed.
+			c.nextAttempt = completed.Add(modelLabelRetryBackoff)
+		} else {
+			set := make(map[string]struct{}, len(names))
+			for _, modelName := range names {
+				set[modelName] = struct{}{}
+			}
+			c.names = set
+			c.fetchedAt = completed
+			c.nextAttempt = time.Time{}
+		}
+	}
+	if c.names == nil {
+		// The catalog has never been read. Reporting the model as unknown keeps the
+		// label bounded and, unlike a query per call, does not let a client hammering
+		// invented names pile load onto a database that is already failing.
+		return false, true
+	}
+	_, known := c.names[name]
+	return known, true
+}
+
+func (c *modelLabelCache) stale(now time.Time) bool {
+	return c.names == nil || now.Sub(c.fetchedAt) >= modelLabelTTL
+}

--- a/backend/internal/server/model_label_cache_test.go
+++ b/backend/internal/server/model_label_cache_test.go
@@ -1,0 +1,400 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// newModelLabelStore returns a store seeded with the gpt-4.1-mini catalog entry
+// and metrics attached, which is all knownModelLabel reads. No server is built,
+// so nothing else is querying the database while these tests break it.
+func newModelLabelStore(t *testing.T) *GormStore {
+	t.Helper()
+	store, _, _ := newResourceRoutedStore(t, ProviderMock)
+	store.SetGatewayMetrics(NewGatewayMetrics(false))
+	return store
+}
+
+// closeStoreDB makes every later query fail, standing in for a database that has
+// become unreachable.
+func closeStoreDB(t *testing.T, store *GormStore) {
+	t.Helper()
+	sqlDB, err := store.db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// dropModelDirectly removes a model without going through the store, so the label
+// snapshot is left pointing at a catalog that no longer contains it. That is how
+// these tests tell a cached answer apart from a fresh query.
+func dropModelDirectly(t *testing.T, store *GormStore, name string) {
+	t.Helper()
+	if err := store.db.Where("name = ?", name).Delete(&Model{}).Error; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func expireModelLabels(store *GormStore) {
+	store.modelLabels.mu.Lock()
+	store.modelLabels.fetchedAt = time.Now().Add(-2 * modelLabelTTL)
+	store.modelLabels.mu.Unlock()
+}
+
+// The label bound is what keeps a rejected request from minting a series per
+// invented model name, so caching must not change which names survive.
+func TestKnownModelLabelKeepsCatalogNamesAndCollapsesTheRest(t *testing.T) {
+	store := newModelLabelStore(t)
+
+	if got := store.knownModelLabel("gpt-4.1-mini"); got != "gpt-4.1-mini" {
+		t.Fatalf("a catalog model must keep its name, got %q", got)
+	}
+	if got := store.knownModelLabel("definitely-not-a-model"); got != "unknown" {
+		t.Fatalf("an unknown model must collapse, got %q", got)
+	}
+	if got := store.knownModelLabel("   "); got != "" {
+		t.Fatalf("a blank model name must stay blank, got %q", got)
+	}
+}
+
+// The point of the cache: a warm store answers without touching the database.
+func TestKnownModelLabelAnswersFromSnapshotWithoutQuerying(t *testing.T) {
+	store := newModelLabelStore(t)
+	if got := store.knownModelLabel("gpt-4.1-mini"); got != "gpt-4.1-mini" {
+		t.Fatalf("warm-up lookup = %q", got)
+	}
+
+	dropModelDirectly(t, store, "gpt-4.1-mini")
+
+	if got := store.knownModelLabel("gpt-4.1-mini"); got != "gpt-4.1-mini" {
+		t.Fatalf("a fresh snapshot must be reused, got %q from a re-read of the catalog", got)
+	}
+}
+
+func TestKnownModelLabelRefreshesAfterTTL(t *testing.T) {
+	store := newModelLabelStore(t)
+	if got := store.knownModelLabel("gpt-4.1-mini"); got != "gpt-4.1-mini" {
+		t.Fatalf("warm-up lookup = %q", got)
+	}
+	dropModelDirectly(t, store, "gpt-4.1-mini")
+
+	expireModelLabels(store)
+
+	if got := store.knownModelLabel("gpt-4.1-mini"); got != "unknown" {
+		t.Fatalf("an expired snapshot must be reloaded, got %q", got)
+	}
+}
+
+func TestKnownModelLabelFollowsModelMutations(t *testing.T) {
+	store := newModelLabelStore(t)
+	if got := store.knownModelLabel("added-model"); got != "unknown" {
+		t.Fatalf("warm-up lookup = %q", got)
+	}
+
+	store.AddModel(Model{Name: "added-model", Modality: "chat", Status: StatusActive})
+	if got := store.knownModelLabel("added-model"); got != "added-model" {
+		t.Fatalf("AddModel must be visible at once, got %q", got)
+	}
+
+	if _, err := store.UpdateModel("added-model", Model{Name: "renamed-model"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.knownModelLabel("renamed-model"); got != "renamed-model" {
+		t.Fatalf("the new name must be visible at once, got %q", got)
+	}
+	if got := store.knownModelLabel("added-model"); got != "unknown" {
+		t.Fatalf("the old name must stop being a label, got %q", got)
+	}
+
+	if err := store.DeleteModel("renamed-model"); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.knownModelLabel("renamed-model"); got != "unknown" {
+		t.Fatalf("DeleteModel must be visible at once, got %q", got)
+	}
+}
+
+func TestKnownModelLabelFollowsCreateModelWithRoutes(t *testing.T) {
+	store := newModelLabelStore(t)
+	if got := store.knownModelLabel("gpt-4.1-mini"); got != "gpt-4.1-mini" {
+		t.Fatalf("warm-up lookup = %q", got)
+	}
+
+	if _, err := store.CreateModelWithRoutes(Model{Name: "bundled-model", Modality: "chat", Status: StatusActive}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := store.knownModelLabel("bundled-model"); got != "bundled-model" {
+		t.Fatalf("CreateModelWithRoutes must be visible at once, got %q", got)
+	}
+}
+
+// A database that stops answering must not widen the label set, so the last good
+// snapshot keeps serving.
+func TestKnownModelLabelKeepsSnapshotWhenRefreshFails(t *testing.T) {
+	store := newModelLabelStore(t)
+	if got := store.knownModelLabel("gpt-4.1-mini"); got != "gpt-4.1-mini" {
+		t.Fatalf("warm-up lookup = %q", got)
+	}
+
+	expireModelLabels(store)
+	closeStoreDB(t, store)
+
+	if got := store.knownModelLabel("gpt-4.1-mini"); got != "gpt-4.1-mini" {
+		t.Fatalf("a failed refresh must keep the last snapshot, got %q", got)
+	}
+	if got := store.knownModelLabel("definitely-not-a-model"); got != "unknown" {
+		t.Fatalf("a failed refresh must not widen the label set, got %q", got)
+	}
+}
+
+// With no snapshot and no database there is nothing to answer from: the label must
+// collapse rather than pass client input through, and — the whole point of the
+// cache — the rejection path must stop querying instead of letting a client
+// hammering invented names amplify into a query per request.
+func TestKnownModelLabelStopsQueryingWhenTheCatalogIsUnreachable(t *testing.T) {
+	store := newModelLabelStore(t)
+	var queries atomic.Int64
+	if err := store.db.Callback().Query().Before("gorm:query").Register("test:count_queries", func(tx *gorm.DB) {
+		queries.Add(1)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	closeStoreDB(t, store)
+
+	for i := 0; i < 10; i++ {
+		if got := store.knownModelLabel(fmt.Sprintf("attacker-model-%d", i)); got != "unknown" {
+			t.Fatalf("an unreachable catalog must collapse the label, got %q", got)
+		}
+	}
+	if got := queries.Load(); got > 1 {
+		t.Fatalf("a failed refresh must not put a query back on every rejected request, got %d queries across 10 requests", got)
+	}
+}
+
+// While there is no cache object at all, the single row check still has to bound
+// the label correctly.
+func TestKnownModelLabelFallsBackToSingleRowCheck(t *testing.T) {
+	store := newModelLabelStore(t)
+	store.modelLabels = nil
+
+	if got := store.knownModelLabel("gpt-4.1-mini"); got != "gpt-4.1-mini" {
+		t.Fatalf("the fallback must keep a catalog model, got %q", got)
+	}
+	if got := store.knownModelLabel("definitely-not-a-model"); got != "unknown" {
+		t.Fatalf("the fallback must collapse an unknown model, got %q", got)
+	}
+}
+
+// fakeClock drives the cache's TTL and backoff without sleeping, and lets a load
+// function bill its own duration to the clock.
+type fakeClock struct {
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time { return c.now }
+
+func (c *fakeClock) advance(d time.Duration) { c.now = c.now.Add(d) }
+
+func TestModelLabelCacheReloadsOnlyWhenStale(t *testing.T) {
+	cache := newModelLabelCache()
+	clock := &fakeClock{now: time.Now()}
+	loads := 0
+	load := func() ([]string, error) {
+		loads++
+		return []string{"alpha"}, nil
+	}
+
+	if known, resolved := cache.lookup("alpha", clock.Now, load); !known || !resolved {
+		t.Fatalf("first lookup = (%v, %v)", known, resolved)
+	}
+	clock.advance(modelLabelTTL - time.Millisecond)
+	if known, _ := cache.lookup("beta", clock.Now, load); known {
+		t.Fatal("beta is not in the snapshot")
+	}
+	if loads != 1 {
+		t.Fatalf("a fresh snapshot must be reused, loaded %d times", loads)
+	}
+
+	clock.advance(time.Millisecond)
+	if _, resolved := cache.lookup("alpha", clock.Now, load); !resolved {
+		t.Fatal("expected the expired snapshot to resolve after a reload")
+	}
+	if loads != 2 {
+		t.Fatalf("an expired snapshot must reload, loaded %d times", loads)
+	}
+
+	cache.invalidate()
+	if _, resolved := cache.lookup("alpha", clock.Now, load); !resolved {
+		t.Fatal("expected an invalidated cache to resolve after a reload")
+	}
+	if loads != 3 {
+		t.Fatalf("invalidate must force a reload, loaded %d times", loads)
+	}
+}
+
+// A snapshot is fresh for a TTL counted from when the load returned, so a slow
+// load does not come back already expired.
+func TestModelLabelCacheTTLStartsWhenTheRefreshReturns(t *testing.T) {
+	cache := newModelLabelCache()
+	clock := &fakeClock{now: time.Now()}
+	loads := 0
+	slowLoad := func() ([]string, error) {
+		loads++
+		clock.advance(2 * modelLabelTTL)
+		return []string{"alpha"}, nil
+	}
+
+	if known, resolved := cache.lookup("alpha", clock.Now, slowLoad); !known || !resolved {
+		t.Fatalf("first lookup = (%v, %v)", known, resolved)
+	}
+	if _, resolved := cache.lookup("alpha", clock.Now, slowLoad); !resolved {
+		t.Fatal("expected the snapshot to resolve")
+	}
+	if loads != 1 {
+		t.Fatalf("a slow load must still produce a fresh snapshot, loaded %d times", loads)
+	}
+}
+
+// A refresh that fails must not be retried on every call, or a database outage
+// puts the query back on the rejection path the cache exists to protect.
+func TestModelLabelCacheBacksOffAfterFailedRefresh(t *testing.T) {
+	cache := newModelLabelCache()
+	clock := &fakeClock{now: time.Now()}
+	loads := 0
+	failing := func() ([]string, error) {
+		loads++
+		return nil, errors.New("database unavailable")
+	}
+
+	if known, _ := cache.lookup("alpha", clock.Now, failing); known {
+		t.Fatal("a cache that never loaded must not vouch for a model")
+	}
+	clock.advance(modelLabelRetryBackoff - time.Millisecond)
+	if known, _ := cache.lookup("alpha", clock.Now, failing); known {
+		t.Fatal("a cache that never loaded must not vouch for a model")
+	}
+	if loads != 1 {
+		t.Fatalf("a failed refresh must back off, loaded %d times", loads)
+	}
+
+	clock.advance(time.Millisecond)
+	if known, _ := cache.lookup("alpha", clock.Now, failing); known {
+		t.Fatal("a cache that never loaded must not vouch for a model")
+	}
+	if loads != 2 {
+		t.Fatalf("the backoff must expire, loaded %d times", loads)
+	}
+}
+
+// A failing database usually fails slowly, which is exactly when the backoff has
+// to hold: timed from before the query it would come back already elapsed, and
+// every rejected request would go back to waiting on a doomed query.
+func TestModelLabelCacheBackoffStartsWhenTheFailedRefreshReturns(t *testing.T) {
+	cache := newModelLabelCache()
+	clock := &fakeClock{now: time.Now()}
+	loads := 0
+	slowFailing := func() ([]string, error) {
+		loads++
+		clock.advance(2 * modelLabelRetryBackoff)
+		return nil, errors.New("database unavailable")
+	}
+
+	cache.lookup("alpha", clock.Now, slowFailing)
+	cache.lookup("alpha", clock.Now, slowFailing)
+	if loads != 1 {
+		t.Fatalf("the backoff must start when the failed refresh returns, loaded %d times", loads)
+	}
+
+	clock.advance(modelLabelRetryBackoff)
+	cache.lookup("alpha", clock.Now, slowFailing)
+	if loads != 2 {
+		t.Fatalf("the backoff must still expire, loaded %d times", loads)
+	}
+}
+
+// A store that came up against a dead database must not stay collapsed: the first
+// lookup after the backoff rebuilds the snapshot and the labels come back.
+func TestModelLabelCacheRecoversWhenTheDatabaseReturns(t *testing.T) {
+	cache := newModelLabelCache()
+	clock := &fakeClock{now: time.Now()}
+	healthy := false
+	load := func() ([]string, error) {
+		if !healthy {
+			return nil, errors.New("database unavailable")
+		}
+		return []string{"alpha"}, nil
+	}
+
+	if known, _ := cache.lookup("alpha", clock.Now, load); known {
+		t.Fatal("a cache that never loaded must not vouch for a model")
+	}
+
+	healthy = true
+	if known, _ := cache.lookup("alpha", clock.Now, load); known {
+		t.Fatal("the backoff must hold even once the database is back")
+	}
+
+	clock.advance(modelLabelRetryBackoff)
+	known, resolved := cache.lookup("alpha", clock.Now, load)
+	if !known || !resolved {
+		t.Fatalf("a recovered database must restore the label, got (%v, %v)", known, resolved)
+	}
+}
+
+func TestModelLabelCacheServesStaleSnapshotThroughFailure(t *testing.T) {
+	cache := newModelLabelCache()
+	clock := &fakeClock{now: time.Now()}
+	if known, resolved := cache.lookup("alpha", clock.Now, func() ([]string, error) {
+		return []string{"alpha"}, nil
+	}); !known || !resolved {
+		t.Fatalf("first lookup = (%v, %v)", known, resolved)
+	}
+
+	failing := func() ([]string, error) { return nil, errors.New("database unavailable") }
+	clock.advance(modelLabelTTL)
+	known, resolved := cache.lookup("alpha", clock.Now, failing)
+	if !known || !resolved {
+		t.Fatalf("a failed refresh must serve the stale snapshot, got (%v, %v)", known, resolved)
+	}
+	if known, _ := cache.lookup("beta", clock.Now, failing); known {
+		t.Fatal("a failed refresh must not widen the snapshot")
+	}
+}
+
+func TestKnownModelLabelIsRaceFreeUnderConcurrentMutation(t *testing.T) {
+	store := newModelLabelStore(t)
+
+	var wg sync.WaitGroup
+	for worker := 0; worker < 4; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 50; i++ {
+				store.knownModelLabel("gpt-4.1-mini")
+				store.knownModelLabel("definitely-not-a-model")
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			store.AddModel(Model{Name: "churn-model", Modality: "chat", Status: StatusActive})
+			_ = store.DeleteModel("churn-model")
+		}
+	}()
+	wg.Wait()
+
+	if got := store.knownModelLabel("gpt-4.1-mini"); got != "gpt-4.1-mini" {
+		t.Fatalf("the seeded model must survive the churn, got %q", got)
+	}
+}

--- a/backend/internal/server/model_route_store.go
+++ b/backend/internal/server/model_route_store.go
@@ -11,6 +11,10 @@ func (s *GormStore) AddModel(model Model) Model {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	model, _ = createModelRecord(s.db, model)
+	// createModelRecord reports no error here, so the snapshot is dropped either
+	// way: an unnecessary invalidation costs one reload, a missed one leaves a new
+	// model reported as unknown for a full TTL.
+	s.modelLabels.invalidate()
 	return model
 }
 
@@ -32,6 +36,9 @@ func (s *GormStore) CreateModelWithRoutes(model Model, routes []ModelRoute) (Mod
 		}
 		return nil
 	})
+	if err == nil {
+		s.modelLabels.invalidate()
+	}
 	return created, err
 }
 

--- a/backend/internal/server/store.go
+++ b/backend/internal/server/store.go
@@ -272,6 +272,7 @@ type GormStore struct {
 	analyticsDB          *gorm.DB
 	mu                   *sync.Mutex
 	leaseHeartbeats      *sync.Map
+	modelLabels          *modelLabelCache
 	secretKey            string
 	metrics              *GatewayMetrics
 	failureThreshold     int

--- a/backend/internal/server/store_database.go
+++ b/backend/internal/server/store_database.go
@@ -285,6 +285,7 @@ func NewStoreWithDialect(databaseURL string, config Config) (*GormStore, error) 
 		analyticsDB:          analyticsDB,
 		mu:                   &sync.Mutex{},
 		leaseHeartbeats:      &sync.Map{},
+		modelLabels:          newModelLabelCache(),
 		secretKey:            config.SecretKey,
 		failureThreshold:     defaultInt(config.ResourceFailureThreshold, 3),
 		cooldownDuration:     cooldownSecondsToDuration(defaultInt(config.ResourceCooldownSeconds, 300)),
@@ -682,7 +683,9 @@ func backfillTeamRelationships(db *gorm.DB) error {
 }
 
 // WithContext returns a store view whose database operations inherit ctx.
-// Synchronization and lease bookkeeping remain shared with the parent store.
+// Synchronization, lease bookkeeping and the model label snapshot remain shared
+// with the parent store, which is why each is held behind a pointer: the shallow
+// copy below would otherwise hand every view its own mutex and its own cache.
 func (s *GormStore) WithContext(ctx context.Context) *GormStore {
 	if ctx == nil {
 		ctx = context.Background()

--- a/backend/internal/server/store_routing_calls.go
+++ b/backend/internal/server/store_routing_calls.go
@@ -148,6 +148,11 @@ func (s *GormStore) UpdateModel(name string, patch Model) (Model, error) {
 		updated = model
 		return nil
 	})
+	if err == nil {
+		// An update can rename the model, so both the old and the new name are
+		// wrong in the snapshot until it reloads.
+		s.modelLabels.invalidate()
+	}
 	return updated, err
 }
 
@@ -155,7 +160,7 @@ func (s *GormStore) DeleteModel(name string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.db.Transaction(func(tx *gorm.DB) error {
+	err := s.db.Transaction(func(tx *gorm.DB) error {
 		var model Model
 		if err := tx.First(&model, "name = ?", name).Error; err != nil {
 			return notFound(err, "model_not_found", "Model not found")
@@ -165,6 +170,10 @@ func (s *GormStore) DeleteModel(name string) error {
 		}
 		return tx.Delete(&model).Error
 	})
+	if err == nil {
+		s.modelLabels.invalidate()
+	}
+	return err
 }
 
 func (s *GormStore) ListRoutes() []ModelRoute {
@@ -866,16 +875,38 @@ func gatewayAttemptSamples(attempts []RouteAttempt) []GatewayAttemptSample {
 
 // knownModelLabel keeps a model name as a label only when the catalog knows it,
 // bounding the label to configured models instead of arbitrary client input.
+// The catalog is read through a short-lived snapshot, because the caller is the
+// rejection path: a client looping over invented model names would otherwise make
+// the cheapest outcome in the gateway pay for a query every time.
 func (s *GormStore) knownModelLabel(modelName string) string {
 	modelName = strings.TrimSpace(modelName)
 	if modelName == "" || s.metrics == nil {
 		return ""
 	}
+	if known, resolved := s.modelLabels.lookup(modelName, time.Now, s.loadModelNames); resolved {
+		if known {
+			return modelName
+		}
+		return "unknown"
+	}
+	// Reached only by a store built without a label cache. A cache that exists
+	// answers for itself even while its refresh is failing, so this stays off the
+	// path a failing database would otherwise be dragged down.
 	var count int64
 	if err := s.db.Model(&Model{}).Where("name = ?", modelName).Limit(1).Count(&count).Error; err != nil || count == 0 {
 		return "unknown"
 	}
 	return modelName
+}
+
+// loadModelNames reads only the catalog's name column, which is all a label bound
+// needs to know.
+func (s *GormStore) loadModelNames() ([]string, error) {
+	var names []string
+	if err := s.db.Model(&Model{}).Pluck("name", &names).Error; err != nil {
+		return nil, err
+	}
+	return names, nil
 }
 
 func (s *GormStore) RecordRequestPayload(requestID string, requestBody string, requestTruncated bool, responseBody string, responseTruncated bool) {


### PR DESCRIPTION
## Summary

`knownModelLabel` bounds a metrics label to catalog-known model names; its only production caller is `RecordRejectedRequest` — the rejection path. Every rejected request paid one `COUNT` query for that check, so the cheapest outcome in the gateway (refusing a request) carried a database round trip that a client looping over invented model names or bad keys could multiply at will. This PR replaces the per-request query with a 60-second cached snapshot of the catalog's name set.

## Related Issue

N/A (performance-review series; previous: #244, #245).

## Changes

- New `modelLabelCache` (`model_label_cache.go`): the set of catalog model names behind a mutex, refreshed at most once per 60 s TTL, held as a **pointer field** on `GormStore` so `WithContext`'s shallow copy shares one cache (same pattern as the store's `mu` and `leaseHeartbeats`).
- `knownModelLabel` answers from the snapshot. Failure semantics are deliberately conservative: a failed refresh keeps serving the previous snapshot and backs off 5 s; a cache that has **never** loaded collapses names to `"unknown"` instead of falling back to per-request queries against a database that is already failing. The label set can never widen past the catalog under any failure.
- Refresh timestamps are taken **after** the load returns, so a slow failing query cannot hand back an already-elapsed backoff window (caught by Codex review round 1).
- All four writers of the `models` table invalidate the snapshot after their transaction commits: `AddModel`, `CreateModelWithRoutes`, `UpdateModel` (renames), `DeleteModel`. Cross-replica and out-of-band changes (e.g. SQLite backup restore) converge within one TTL — acceptable for a label that takes no part in authentication or routing, documented in code.
- 400-line test file: behavior parity, invalidation on each mutator, TTL expiry, refresh-failure fallback, database-outage query bound (≤1 query across 10 rejections), backoff/recovery timing with a fake clock, `-race` concurrency. Each guard was mutation-tested (4 targeted mutations each make specific tests fail).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `gofmt -l .` / `go vet ./...` / `git diff --check` — clean.
- `go test ./internal/server/ -run 'ModelLabel|RejectedRequest' -count=3 -race` — ok, no flake.
- `go test ./... -count=1` — green (run independently in two sessions). One unattributed full-suite failure occurred during iteration; 8 of 9 full/package runs green, the failure's log signature matches the pre-existing load-sensitive flake already reproduced 2/3 runs on unmodified `origin/main` during PR #245 validation (`TestBackgroundResponsesSuccessPersistsEncryptedPayloadAndAccountsOnce` area), and this change's only production call path (`RecordRejectedRequest`) does not intersect response-job workers.
- `golangci-lint run ./...` (v2.12.2, CI-matching) — 10 pre-existing SA5011 findings in unrelated files, none in changed files, no new findings.
- Micro-benchmark (in-memory SQLite): cache hit ~43 ns vs ~5.3 µs per query (~120x; larger over a networked PostgreSQL).
- End-to-end smoke on a real process (temp SQLite, seeded demo): `/livez`, non-streaming + streaming `/v1/chat/completions`, `/api/admin/usage/summary` — pass.
- Codex review, 3 rounds (high effort): round 1 found timestamp-before-load backoff bug (fixed); round 2 found first-load fallback re-amplifying queries during outages (fixed by collapsing to `"unknown"`); round 3 — no new findings, one extra recovery-path regression test added on its suggestion.

## Compatibility, Security, and Operations

- Metrics label values are unchanged for a healthy database; during an outage, known models may label as `"unknown"` for up to one 5 s backoff window, and cross-replica model changes converge within 60 s. The security property — arbitrary client input can never mint a metrics label — holds under all failure modes.
- No API, schema, or configuration change.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable. (No environment variable changes.)
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable. (No user-facing behavior change.)
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable. (Not touched.)
- [x] `git diff --check` passes.
