### PR TITLE
perf(quota): aggregate runtime budget spend in one query

### DIFF
--- a/backend/internal/server/runtime_budget_test.go
+++ b/backend/internal/server/runtime_budget_test.go
@@ -1,0 +1,598 @@
+package server
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+func addRuntimeBudgetUsage(t *testing.T, store *MemoryStore, projectID string, cost float64, at time.Time) {
+	t.Helper()
+	if err := store.db.Create(&UsageRecord{
+		ID:        NewID("usage"),
+		RequestID: NewID("req"),
+		ProjectID: projectID,
+		ModelName: "gpt-4.1-mini",
+		CostUSD:   cost,
+		CreatedAt: at,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func addRuntimeBudgetResource(t *testing.T, store *MemoryStore, name string, fields map[string]any) {
+	t.Helper()
+	budget := store.CreateResource("budgets", AdminResource{Name: name, Status: StatusActive, Fields: fields})
+	if budget.ID == "" {
+		t.Fatalf("failed to create budget %s", name)
+	}
+}
+
+func addRuntimeBudgetProject(t *testing.T, store *MemoryStore, project Project) Project {
+	t.Helper()
+	created := store.CreateProject(project)
+	if created.ID == "" {
+		t.Fatalf("failed to create project %s", project.Name)
+	}
+	return created
+}
+
+// runtimeBudgetNow returns a timestamp inside the current billing period.
+// checkRuntimeBudget reads the clock itself, so a fixture built moments before
+// a period rollover would be measured against the next period instead.
+func runtimeBudgetNow(t *testing.T) time.Time {
+	t.Helper()
+	now := time.Now().UTC()
+	if periodEnd(now.Format("2006-01")).Sub(now) < time.Minute {
+		t.Skip("skipped within a minute of the billing period rollover")
+	}
+	return now
+}
+
+// countStoreStatements counts the statements a store operation sends to the
+// database. Finder calls run the query callbacks while aggregates scanned with
+// Scan run the row callbacks, so both are needed for a complete count.
+func countStoreStatements(t *testing.T, store *MemoryStore, fn func()) int {
+	t.Helper()
+	suffix := NewID("callback")
+	queryName := "test:count-query:" + suffix
+	rowName := "test:count-row:" + suffix
+	count := 0
+	record := func(*gorm.DB) { count++ }
+	if err := store.db.Callback().Query().Before("gorm:query").Register(queryName, record); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.Callback().Row().Before("gorm:row").Register(rowName, record); err != nil {
+		t.Fatal(err)
+	}
+	fn()
+	if err := store.db.Callback().Query().Remove(queryName); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.Callback().Row().Remove(rowName); err != nil {
+		t.Fatal(err)
+	}
+	return count
+}
+
+// TestCheckRuntimeBudgetScopes pins the spend each budget scope attributes to a
+// call, including the cost center fallback chain and the records the scopes
+// deliberately ignore.
+func TestCheckRuntimeBudgetScopes(t *testing.T) {
+	now := runtimeBudgetNow(t)
+	previousMonth := periodStart(now.Format("2006-01")).Add(-time.Hour)
+
+	for _, test := range []struct {
+		name        string
+		setup       func(t *testing.T, store *MemoryStore) Project
+		budgets     func(project Project) []map[string]any
+		wantBlocked bool
+	}{
+		{
+			name: "project scope below amount admits the call",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Under"})
+				addRuntimeBudgetUsage(t, store, project.ID, 0.5, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "project", "scope_id": project.ID, "amount_usd": 1}}
+			},
+		},
+		{
+			name: "project scope at amount rejects the call",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Over"})
+				addRuntimeBudgetUsage(t, store, project.ID, 0.6, now)
+				addRuntimeBudgetUsage(t, store, project.ID, 0.4, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "project", "scope_id": project.ID, "amount_usd": 1}}
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "project scope ignores other projects",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Isolated"})
+				other := addRuntimeBudgetProject(t, store, Project{Name: "Noisy Neighbour"})
+				addRuntimeBudgetUsage(t, store, project.ID, 0.5, now)
+				addRuntimeBudgetUsage(t, store, other.ID, 5, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "project", "scope_id": project.ID, "amount_usd": 1}}
+			},
+		},
+		{
+			name: "global scope counts usage left by deleted projects",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Global Member"})
+				addRuntimeBudgetUsage(t, store, project.ID, 0.4, now)
+				addRuntimeBudgetUsage(t, store, "prj_deleted", 0.7, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "global", "amount_usd": 1}}
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "team scope sums the projects sharing the primary team",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				store.CreateResource("teams", AdminResource{ID: "team_alpha", Name: "Alpha", Status: StatusActive})
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Alpha One", TeamID: "team_alpha"})
+				sibling := addRuntimeBudgetProject(t, store, Project{Name: "Alpha Two", TeamID: "team_alpha"})
+				addRuntimeBudgetUsage(t, store, project.ID, 0.4, now)
+				addRuntimeBudgetUsage(t, store, sibling.ID, 0.7, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "team", "scope_id": "team_alpha", "amount_usd": 1}}
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "team scope ignores secondary team membership",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				store.CreateResource("teams", AdminResource{ID: "team_alpha", Name: "Alpha", Status: StatusActive})
+				store.CreateResource("teams", AdminResource{ID: "team_beta", Name: "Beta", Status: StatusActive})
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Alpha One", TeamID: "team_alpha"})
+				shared := addRuntimeBudgetProject(t, store, Project{Name: "Beta One", TeamID: "team_beta"})
+				if _, err := store.AddProjectTeam(ProjectTeam{ProjectID: shared.ID, TeamID: "team_alpha", Role: "viewer"}); err != nil {
+					t.Fatal(err)
+				}
+				addRuntimeBudgetUsage(t, store, project.ID, 0.4, now)
+				addRuntimeBudgetUsage(t, store, shared.ID, 5, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "team", "scope_id": "team_alpha", "amount_usd": 1}}
+			},
+		},
+		{
+			name: "team scope ignores usage left by deleted projects",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				store.CreateResource("teams", AdminResource{ID: "team_alpha", Name: "Alpha", Status: StatusActive})
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Alpha One", TeamID: "team_alpha"})
+				addRuntimeBudgetUsage(t, store, project.ID, 0.4, now)
+				addRuntimeBudgetUsage(t, store, "prj_deleted", 5, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "team", "scope_id": "team_alpha", "amount_usd": 1}}
+			},
+		},
+		{
+			name: "team scope counts disabled project usage",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				store.CreateResource("teams", AdminResource{ID: "team_alpha", Name: "Alpha", Status: StatusActive})
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Alpha One", TeamID: "team_alpha"})
+				retired := addRuntimeBudgetProject(t, store, Project{Name: "Alpha Retired", TeamID: "team_alpha", Status: StatusDisabled})
+				addRuntimeBudgetUsage(t, store, project.ID, 0.4, now)
+				addRuntimeBudgetUsage(t, store, retired.ID, 0.7, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "team", "scope_id": "team_alpha", "amount_usd": 1}}
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "cost center scope reads the project field first",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				store.CreateResource("teams", AdminResource{ID: "team_cc", Name: "CC Team", Status: StatusActive, Fields: map[string]any{"cost_center": "CC-TEAM"}})
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Direct", TeamID: "team_cc", CostCenter: "CC-DIRECT"})
+				peer := addRuntimeBudgetProject(t, store, Project{Name: "Direct Peer", CostCenter: "CC-DIRECT"})
+				addRuntimeBudgetUsage(t, store, project.ID, 0.4, now)
+				addRuntimeBudgetUsage(t, store, peer.ID, 0.7, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "cost_center", "scope_id": "CC-DIRECT", "amount_usd": 1}}
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "cost center scope falls back to the team field",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				store.CreateResource("teams", AdminResource{ID: "team_cc", Name: "CC Team", Status: StatusActive, Fields: map[string]any{"cost_center": "CC-TEAM"}})
+				store.CreateResource("quota-policies", AdminResource{ID: "quota_cc", Name: "CC Quota", Status: StatusActive, Fields: map[string]any{"cost_center": "CC-QUOTA"}})
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Team Sourced", TeamID: "team_cc", DefaultQuotaRef: "quota_cc"})
+				addRuntimeBudgetUsage(t, store, project.ID, 1, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "cost_center", "scope_id": "CC-TEAM", "amount_usd": 1}}
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "cost center scope falls back to the quota policy field",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				store.CreateResource("quota-policies", AdminResource{ID: "quota_cc", Name: "CC Quota", Status: StatusActive, Fields: map[string]any{"cost_center": "CC-QUOTA"}})
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Quota Sourced", DefaultQuotaRef: "quota_cc"})
+				addRuntimeBudgetUsage(t, store, project.ID, 1, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "cost_center", "scope_id": "CC-QUOTA", "amount_usd": 1}}
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "cost center scope falls back to the team id",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				store.CreateResource("teams", AdminResource{ID: "team_plain", Name: "Plain", Status: StatusActive})
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Team Id Sourced", TeamID: "team_plain"})
+				addRuntimeBudgetUsage(t, store, project.ID, 1, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "cost_center", "scope_id": "team_plain", "amount_usd": 1}}
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "cost center scope falls back to the project id",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Project Id Sourced"})
+				addRuntimeBudgetUsage(t, store, project.ID, 1, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "cost_center", "scope_id": "project:" + project.ID, "amount_usd": 1}}
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "cost center scope counts disabled project usage",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				project := addRuntimeBudgetProject(t, store, Project{Name: "CC Active", CostCenter: "CC-MIXED"})
+				retired := addRuntimeBudgetProject(t, store, Project{Name: "CC Retired", CostCenter: "CC-MIXED", Status: StatusDisabled})
+				addRuntimeBudgetUsage(t, store, project.ID, 0.4, now)
+				addRuntimeBudgetUsage(t, store, retired.ID, 0.7, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "cost_center", "scope_id": "CC-MIXED", "amount_usd": 1}}
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "cost center scope ignores usage left by deleted projects",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				project := addRuntimeBudgetProject(t, store, Project{Name: "CC Only", CostCenter: "CC-ONLY"})
+				addRuntimeBudgetUsage(t, store, project.ID, 0.4, now)
+				addRuntimeBudgetUsage(t, store, "prj_deleted", 5, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "cost_center", "scope_id": "CC-ONLY", "amount_usd": 1}}
+			},
+		},
+		{
+			name: "cost center scope resolves peer projects through a disabled team",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				store.CreateResource("teams", AdminResource{ID: "team_cc", Name: "CC Team", Status: StatusDisabled, Fields: map[string]any{"cost_center": "CC-TEAM"}})
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Team Sourced", TeamID: "team_cc"})
+				peer := addRuntimeBudgetProject(t, store, Project{Name: "Team Sourced Peer", TeamID: "team_cc"})
+				addRuntimeBudgetUsage(t, store, project.ID, 0.4, now)
+				addRuntimeBudgetUsage(t, store, peer.ID, 0.7, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "cost_center", "scope_id": "CC-TEAM", "amount_usd": 1}}
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "organization scope behaves like global scope",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Organization Member"})
+				addRuntimeBudgetUsage(t, store, project.ID, 0.4, now)
+				addRuntimeBudgetUsage(t, store, "prj_deleted", 0.7, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "organization", "amount_usd": 1}}
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "hyphenated cost-center scope is recognised",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Hyphenated", CostCenter: "CC-HYPHEN"})
+				addRuntimeBudgetUsage(t, store, project.ID, 1, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "cost-center", "scope_id": "CC-HYPHEN", "amount_usd": 1}}
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "legacy scope id fields are honoured",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				store.CreateResource("teams", AdminResource{ID: "team_legacy", Name: "Legacy", Status: StatusActive})
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Legacy Fields", TeamID: "team_legacy", CostCenter: "CC-LEGACY"})
+				addRuntimeBudgetUsage(t, store, project.ID, 1, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{
+					{"scope": "project", "project_id": project.ID, "amount_usd": 100},
+					{"scope": "team", "team_id": "team_legacy", "amount_usd": 100},
+					{"scope": "cost_center", "cost_center": "CC-LEGACY", "amount_usd": 1},
+				}
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "budgets scoped elsewhere leave the project aggregate narrowed",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				store.CreateResource("teams", AdminResource{ID: "team_mine", Name: "Mine", Status: StatusActive})
+				store.CreateResource("teams", AdminResource{ID: "team_other", Name: "Other", Status: StatusActive})
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Narrowed", TeamID: "team_mine", CostCenter: "CC-MINE"})
+				other := addRuntimeBudgetProject(t, store, Project{Name: "Elsewhere", TeamID: "team_other", CostCenter: "CC-OTHER"})
+				addRuntimeBudgetUsage(t, store, project.ID, 0.5, now)
+				addRuntimeBudgetUsage(t, store, other.ID, 100, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{
+					{"scope": "project", "scope_id": project.ID, "amount_usd": 1},
+					{"scope": "team", "scope_id": "team_other", "amount_usd": 0.01},
+					{"scope": "cost_center", "scope_id": "CC-OTHER", "amount_usd": 0.01},
+				}
+			},
+		},
+		{
+			name: "previous period usage stays outside the window",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Fresh Month"})
+				addRuntimeBudgetUsage(t, store, project.ID, 5, previousMonth)
+				addRuntimeBudgetUsage(t, store, project.ID, 0.1, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "project", "scope_id": project.ID, "amount_usd": 1}}
+			},
+		},
+		{
+			name: "budget for another period is skipped",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Other Period"})
+				addRuntimeBudgetUsage(t, store, project.ID, 5, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{
+					"scope":      "project",
+					"scope_id":   project.ID,
+					"period_ref": previousMonth.Format("2006-01"),
+					"amount_usd": 1,
+				}}
+			},
+		},
+		{
+			name: "warn enforcement never blocks",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Warn Only"})
+				addRuntimeBudgetUsage(t, store, project.ID, 5, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "project", "scope_id": project.ID, "amount_usd": 1, "enforcement": "warn"}}
+			},
+		},
+		{
+			name: "monitor enforcement never blocks",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Monitor Only"})
+				addRuntimeBudgetUsage(t, store, project.ID, 5, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "project", "scope_id": project.ID, "amount_usd": 1, "enforcement": "monitor"}}
+			},
+		},
+		{
+			name: "budget without an amount never blocks",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				project := addRuntimeBudgetProject(t, store, Project{Name: "No Amount"})
+				addRuntimeBudgetUsage(t, store, project.ID, 5, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "project", "scope_id": project.ID}}
+			},
+		},
+		{
+			name: "budget for another project never blocks",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Unbudgeted"})
+				addRuntimeBudgetUsage(t, store, project.ID, 5, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{{"scope": "project", "scope_id": "prj_elsewhere", "amount_usd": 1}}
+			},
+		},
+		{
+			name: "any exceeded budget among several blocks",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				store.CreateResource("teams", AdminResource{ID: "team_alpha", Name: "Alpha", Status: StatusActive})
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Many Budgets", TeamID: "team_alpha", CostCenter: "CC-MANY"})
+				addRuntimeBudgetUsage(t, store, project.ID, 2, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{
+					{"scope": "project", "scope_id": project.ID, "amount_usd": 100},
+					{"scope": "team", "scope_id": "team_alpha", "amount_usd": 100},
+					{"scope": "cost_center", "scope_id": "CC-MANY", "amount_usd": 1},
+					{"scope": "global", "amount_usd": 100},
+				}
+			},
+			wantBlocked: true,
+		},
+		{
+			name: "several budgets all below their amounts admit the call",
+			setup: func(t *testing.T, store *MemoryStore) Project {
+				store.CreateResource("teams", AdminResource{ID: "team_alpha", Name: "Alpha", Status: StatusActive})
+				project := addRuntimeBudgetProject(t, store, Project{Name: "Many Budgets", TeamID: "team_alpha", CostCenter: "CC-MANY"})
+				addRuntimeBudgetUsage(t, store, project.ID, 2, now)
+				return project
+			},
+			budgets: func(project Project) []map[string]any {
+				return []map[string]any{
+					{"scope": "project", "scope_id": project.ID, "amount_usd": 100},
+					{"scope": "team", "scope_id": "team_alpha", "amount_usd": 100},
+					{"scope": "cost_center", "scope_id": "CC-MANY", "amount_usd": 100},
+					{"scope": "global", "amount_usd": 100},
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := NewMemoryStore()
+			project := test.setup(t, store)
+			for index, fields := range test.budgets(project) {
+				addRuntimeBudgetResource(t, store, "budget-"+strconv.Itoa(index), fields)
+			}
+			err := store.checkRuntimeBudget(store.db, project)
+			if test.wantBlocked && err != ErrBudgetExceeded {
+				t.Fatalf("expected budget_exceeded, got %v", err)
+			}
+			if !test.wantBlocked && err != nil {
+				t.Fatalf("expected the call to be admitted, got %v", err)
+			}
+		})
+	}
+}
+
+// TestCheckRuntimeBudgetSkipsLookupsWithoutApplicableBudgets keeps admission free
+// for deployments whose budgets cannot block the call.
+func TestCheckRuntimeBudgetSkipsLookupsWithoutApplicableBudgets(t *testing.T) {
+	now := runtimeBudgetNow(t)
+	previousPeriod := periodStart(now.Format("2006-01")).Add(-time.Hour).Format("2006-01")
+
+	for _, test := range []struct {
+		name    string
+		budgets []map[string]any
+	}{
+		{name: "no budgets at all"},
+		{
+			name: "only budgets that cannot enforce",
+			budgets: []map[string]any{
+				{"scope": "global", "amount_usd": 1, "enforcement": "warn"},
+				{"scope": "global", "amount_usd": 1, "enforcement": "monitor"},
+				{"scope": "global", "amount_usd": 0},
+				{"scope": "global", "amount_usd": 1, "period_ref": previousPeriod},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := NewMemoryStore()
+			// The project resolves its cost center through a team and a quota
+			// policy, which must stay unread while no budget can enforce.
+			store.CreateResource("teams", AdminResource{ID: "team_free", Name: "Free", Status: StatusActive})
+			store.CreateResource("quota-policies", AdminResource{ID: "quota_free", Name: "Free Quota", Status: StatusActive, Fields: map[string]any{"cost_center": "CC-FREE"}})
+			project := addRuntimeBudgetProject(t, store, Project{Name: "Budget Free", TeamID: "team_free", DefaultQuotaRef: "quota_free"})
+			for index := 0; index < 20; index++ {
+				addRuntimeBudgetUsage(t, store, project.ID, 1, now)
+			}
+			for index, fields := range test.budgets {
+				addRuntimeBudgetResource(t, store, "budget-"+strconv.Itoa(index), fields)
+			}
+			var err error
+			statements := countStoreStatements(t, store, func() {
+				err = store.checkRuntimeBudget(store.db, project)
+			})
+			if err != nil {
+				t.Fatalf("expected the call to be admitted, got %v", err)
+			}
+			if statements != 1 {
+				t.Fatalf("expected only the budget lookup, got %d statements", statements)
+			}
+		})
+	}
+}
+
+// TestCheckRuntimeBudgetUsesConstantQueries pins the aggregation to a fixed
+// number of statements no matter how many budgets, projects, or usage records
+// the period holds.
+func TestCheckRuntimeBudgetUsesConstantQueries(t *testing.T) {
+	now := runtimeBudgetNow(t)
+	build := func(t *testing.T, projects int, records int, budgetsPerScope int) (*MemoryStore, Project) {
+		t.Helper()
+		store := NewMemoryStore()
+		store.CreateResource("teams", AdminResource{ID: "team_scale", Name: "Scale", Status: StatusActive})
+		project := addRuntimeBudgetProject(t, store, Project{Name: "Scale Primary", TeamID: "team_scale", CostCenter: "CC-SCALE"})
+		for index := 0; index < projects; index++ {
+			peer := addRuntimeBudgetProject(t, store, Project{
+				Name:       "Scale Peer " + strconv.Itoa(index),
+				TeamID:     "team_scale",
+				CostCenter: "CC-SCALE",
+			})
+			for record := 0; record < records; record++ {
+				addRuntimeBudgetUsage(t, store, peer.ID, 0.01, now)
+			}
+		}
+		for index := 0; index < records; index++ {
+			addRuntimeBudgetUsage(t, store, project.ID, 0.01, now)
+		}
+		for index := 0; index < budgetsPerScope; index++ {
+			suffix := strconv.Itoa(index)
+			addRuntimeBudgetResource(t, store, "project-"+suffix, map[string]any{"scope": "project", "scope_id": project.ID, "amount_usd": 1e9})
+			addRuntimeBudgetResource(t, store, "team-"+suffix, map[string]any{"scope": "team", "scope_id": "team_scale", "amount_usd": 1e9})
+			addRuntimeBudgetResource(t, store, "cost-center-"+suffix, map[string]any{"scope": "cost_center", "scope_id": "CC-SCALE", "amount_usd": 1e9})
+			addRuntimeBudgetResource(t, store, "global-"+suffix, map[string]any{"scope": "global", "amount_usd": 1e9})
+		}
+		return store, project
+	}
+
+	smallStore, smallProject := build(t, 1, 1, 1)
+	largeStore, largeProject := build(t, 20, 10, 5)
+	var smallErr, largeErr error
+	smallStatements := countStoreStatements(t, smallStore, func() {
+		smallErr = smallStore.checkRuntimeBudget(smallStore.db, smallProject)
+	})
+	largeStatements := countStoreStatements(t, largeStore, func() {
+		largeErr = largeStore.checkRuntimeBudget(largeStore.db, largeProject)
+	})
+	if smallErr != nil || largeErr != nil {
+		t.Fatalf("expected both calls to be admitted, got %v and %v", smallErr, largeErr)
+	}
+	if smallStatements != largeStatements {
+		t.Fatalf("statement count grew with rows: small=%d large=%d", smallStatements, largeStatements)
+	}
+	// Budgets, teams with quota policies, the spend aggregate, and projects.
+	if largeStatements > 4 {
+		t.Fatalf("expected at most one statement per lookup, got %d", largeStatements)
+	}
+}

--- a/backend/internal/server/store_backup_quota.go
+++ b/backend/internal/server/store_backup_quota.go
@@ -615,19 +615,119 @@ func quotaPolicyApplies(scope string, scopeID string, project Project, key APIKe
 	}
 }
 
+// runtimeBudgetCandidate is an active budget that can still block the current
+// call: enforced, covering the current period, and carrying a positive amount.
+type runtimeBudgetCandidate struct {
+	scope   string
+	scopeID string
+	amount  float64
+}
+
+// runtimeBudgetScopes records which scope totals the applicable budgets read, so
+// the aggregation only loads the data those budgets actually need.
+type runtimeBudgetScopes struct {
+	global     bool
+	team       bool
+	costCenter bool
+}
+
+// runtimeBudgetTotals holds the current period's spend per budget scope. Every
+// value is derived from one aggregate query, so admission issues a constant
+// number of statements no matter how many budgets or usage records exist.
+type runtimeBudgetTotals struct {
+	global     float64
+	project    float64
+	team       float64
+	costCenter float64
+}
+
+func (t runtimeBudgetTotals) forScope(scope string) float64 {
+	switch scope {
+	case "project":
+		return t.project
+	case "team":
+		return t.team
+	case "cost_center", "cost-center":
+		return t.costCenter
+	case "global", "organization":
+		return t.global
+	default:
+		return 0
+	}
+}
+
+// projectPeriodCost is one row of the per-project spend aggregate.
+type projectPeriodCost struct {
+	ProjectID string
+	Total     float64
+}
+
+// checkRuntimeBudget rejects the call when an enforced budget covering this
+// project is already spent. It filters budgets in two phases so a deployment
+// without matching budgets never reads the usage tables: the candidate pass
+// needs the budget rows alone, and the cost center, project, and usage lookups
+// only happen once a candidate is known to apply.
 func (s *GormStore) checkRuntimeBudget(tx *gorm.DB, project Project) error {
 	now := time.Now().UTC()
 	period := now.Format("2006-01")
-	costCenter := s.costCenterForProjectWithDB(tx, project)
 	var budgets []AdminResource
 	if err := tx.Where("kind = ? AND status = ?", "budgets", StatusActive).Find(&budgets).Error; err != nil {
 		return err
 	}
-	for _, budget := range budgets {
-		if !budgetEnforced(budget) {
+	candidates, hasCostCenterScope := runtimeBudgetCandidates(budgets, now, period)
+	if len(candidates) == 0 {
+		return nil
+	}
+	// The cost center only decides whether cost center scoped budgets apply, so
+	// deployments without one never read teams or quota policies here.
+	costCenter := ""
+	var teamsByID, quotasByID map[string]AdminResource
+	if hasCostCenterScope {
+		var err error
+		teamsByID, quotasByID, err = loadCostCenterResources(tx)
+		if err != nil {
+			return err
+		}
+		costCenter = costCenterForProject(project, teamsByID, quotasByID)
+	}
+	applicable := make([]runtimeBudgetCandidate, 0, len(candidates))
+	var scopes runtimeBudgetScopes
+	for _, candidate := range candidates {
+		if !budgetScopeAppliesToProject(candidate.scope, candidate.scopeID, project, costCenter) {
 			continue
 		}
-		if !budgetAppliesToProject(budget, project, costCenter) {
+		applicable = append(applicable, candidate)
+		switch candidate.scope {
+		case "team":
+			scopes.team = true
+		case "cost_center", "cost-center":
+			scopes.costCenter = true
+		case "global", "organization":
+			scopes.global = true
+		}
+	}
+	if len(applicable) == 0 {
+		return nil
+	}
+	totals, err := s.aggregateRuntimeBudgetTotals(tx, period, project, scopes, costCenter, teamsByID, quotasByID)
+	if err != nil {
+		return err
+	}
+	for _, candidate := range applicable {
+		if totals.forScope(candidate.scope) >= candidate.amount {
+			return ErrBudgetExceeded
+		}
+	}
+	return nil
+}
+
+// runtimeBudgetCandidates keeps the budgets that can block a call and reports
+// whether any of them is cost center scoped.
+func runtimeBudgetCandidates(budgets []AdminResource, now time.Time, period string) ([]runtimeBudgetCandidate, bool) {
+	candidates := make([]runtimeBudgetCandidate, 0, len(budgets))
+	hasCostCenterScope := false
+	for _, budget := range budgets {
+		if !budgetEnforced(budget) {
 			continue
 		}
 		if budgetPeriod := strings.TrimSpace(stringField(budget.Fields, "period_ref")); budgetPeriod != "" && normalizeBillingPeriod(budgetPeriod, now) != period {
@@ -637,66 +737,90 @@ func (s *GormStore) checkRuntimeBudget(tx *gorm.DB, project Project) error {
 		if amount <= 0 {
 			continue
 		}
-		used, err := s.runtimeBudgetUsed(tx, budget, period)
-		if err != nil {
-			return err
-		}
-		if used >= amount {
-			return ErrBudgetExceeded
+		scope := strings.ToLower(strings.TrimSpace(stringField(budget.Fields, "scope")))
+		candidates = append(candidates, runtimeBudgetCandidate{
+			scope:   scope,
+			scopeID: budgetScopeID(budget, scope),
+			amount:  amount,
+		})
+		if scope == "cost_center" || scope == "cost-center" {
+			hasCostCenterScope = true
 		}
 	}
-	return nil
+	return candidates, hasCostCenterScope
 }
 
-func (s *GormStore) runtimeBudgetUsed(tx *gorm.DB, budget AdminResource, period string) (float64, error) {
-	scope := strings.ToLower(strings.TrimSpace(stringField(budget.Fields, "scope")))
-	scopeID := budgetScopeID(budget, scope)
-	start := periodStart(period)
-	end := periodEnd(period)
-	switch scope {
-	case "project":
-		var total sql.NullFloat64
-		if err := tx.Model(&UsageRecord{}).
-			Where("project_id = ? AND created_at >= ? AND created_at < ?", scopeID, start, end).
-			Select("sum(cost_usd)").Scan(&total).Error; err != nil {
-			return 0, err
-		}
-		return total.Float64, nil
-	case "global", "organization":
-		var total sql.NullFloat64
-		if err := tx.Model(&UsageRecord{}).
-			Where("created_at >= ? AND created_at < ?", start, end).
-			Select("sum(cost_usd)").Scan(&total).Error; err != nil {
-			return 0, err
-		}
-		return total.Float64, nil
-	case "team", "cost_center", "cost-center":
-		var records []UsageRecord
-		if err := tx.Where("created_at >= ? AND created_at < ?", start, end).Find(&records).Error; err != nil {
-			return 0, err
-		}
-		projectCache := map[string]Project{}
-		var total float64
-		for _, record := range records {
-			project, ok := projectCache[record.ProjectID]
-			if !ok {
-				if err := tx.First(&project, "id = ?", record.ProjectID).Error; err != nil {
-					continue
-				}
-				projectCache[record.ProjectID] = project
-			}
-			if scope == "team" && project.TeamID == scopeID {
-				total += record.CostUSD
-				continue
-			}
-			if (scope == "cost_center" || scope == "cost-center") && s.costCenterForProjectWithDB(tx, project) == scopeID {
-				total += record.CostUSD
-			}
-		}
-		return total, nil
-	default:
-		return 0, nil
+// loadCostCenterResources reads the resources costCenterForProject resolves
+// against. Like the per-project lookups it replaces, it ignores resource status.
+// It does report read errors instead of falling through the cost center chain,
+// because a budget resolved against a half-read table would silently admit
+// spend the budget was meant to stop.
+func loadCostCenterResources(tx *gorm.DB) (map[string]AdminResource, map[string]AdminResource, error) {
+	var resources []AdminResource
+	if err := tx.Where("kind IN ?", []string{"teams", "quota-policies"}).Find(&resources).Error; err != nil {
+		return nil, nil, err
 	}
+	teamsByID := map[string]AdminResource{}
+	quotasByID := map[string]AdminResource{}
+	for _, resource := range resources {
+		switch resource.Kind {
+		case "teams":
+			teamsByID[resource.ID] = resource
+		case "quota-policies":
+			quotasByID[resource.ID] = resource
+		}
+	}
+	return teamsByID, quotasByID, nil
+}
+
+// aggregateRuntimeBudgetTotals sums the period once, grouped by project, and
+// folds those subtotals into every scope the applicable budgets consult.
+func (s *GormStore) aggregateRuntimeBudgetTotals(tx *gorm.DB, period string, project Project, scopes runtimeBudgetScopes, costCenter string, teamsByID, quotasByID map[string]AdminResource) (runtimeBudgetTotals, error) {
+	query := tx.Model(&UsageRecord{}).Where("created_at >= ? AND created_at < ?", periodStart(period), periodEnd(period))
+	if !scopes.global && !scopes.team && !scopes.costCenter {
+		// Only this project's own budgets are in play, so stay on the
+		// (project_id, created_at) index instead of scanning the whole period.
+		query = query.Where("project_id = ?", project.ID)
+	}
+	var rows []projectPeriodCost
+	if err := query.Select("project_id, COALESCE(SUM(cost_usd), 0) AS total").Group("project_id").Scan(&rows).Error; err != nil {
+		return runtimeBudgetTotals{}, err
+	}
+	var projectsByID map[string]Project
+	if scopes.team || scopes.costCenter {
+		var projects []Project
+		// These are the columns costCenterForProject and the team match read.
+		if err := tx.Select("id", "team_id", "cost_center", "default_quota_ref").Find(&projects).Error; err != nil {
+			return runtimeBudgetTotals{}, err
+		}
+		projectsByID = make(map[string]Project, len(projects))
+		for _, item := range projects {
+			projectsByID[item.ID] = item
+		}
+	}
+	var totals runtimeBudgetTotals
+	for _, row := range rows {
+		totals.global += row.Total
+		if row.ProjectID == project.ID {
+			totals.project += row.Total
+		}
+		if !scopes.team && !scopes.costCenter {
+			continue
+		}
+		// Usage left behind by a deleted project belongs to no team and no cost
+		// center, which is what the per-record project lookup used to decide.
+		rowProject, ok := projectsByID[row.ProjectID]
+		if !ok {
+			continue
+		}
+		if scopes.team && rowProject.TeamID == project.TeamID {
+			totals.team += row.Total
+		}
+		if scopes.costCenter && costCenterForProject(rowProject, teamsByID, quotasByID) == costCenter {
+			totals.costCenter += row.Total
+		}
+	}
+	return totals, nil
 }
 
 func budgetScopeID(budget AdminResource, scope string) string {
@@ -726,9 +850,7 @@ func budgetEnforced(budget AdminResource) bool {
 	return true
 }
 
-func budgetAppliesToProject(budget AdminResource, project Project, costCenter string) bool {
-	scope := strings.ToLower(strings.TrimSpace(stringField(budget.Fields, "scope")))
-	scopeID := budgetScopeID(budget, scope)
+func budgetScopeAppliesToProject(scope string, scopeID string, project Project, costCenter string) bool {
 	switch scope {
 	case "project":
 		return scopeID != "" && scopeID == project.ID


### PR DESCRIPTION
## Summary

`checkRuntimeBudget` runs inside **every** request's admission transaction. Its team and cost-center scopes loaded every usage record of the current month into memory and resolved each record's project with per-record lookups, so admission cost grew linearly with monthly traffic — inside the store-wide mutex. This PR makes admission issue at most four statements regardless of budget count, project count, or traffic, while pinning the old scope semantics with tests that also pass against the old implementation.

## Related Issue

N/A (performance-review series; previous: #244, #245, #247, #248).

## Changes

- Two-phase budget filtering: a candidate pass (enforced + period + positive amount) returns early with **one** statement for deployments without budgets; cost-center resources (`teams`, `quota-policies`) load in one batch only when a cost-center-scoped candidate exists; the usage table is only touched once a candidate actually applies.
- One aggregate — `SELECT project_id, SUM(cost_usd) … GROUP BY project_id` over the current period — folded in memory into the four scope totals (global / project / team / cost-center) every applicable budget consults. Because `budgetScopeAppliesToProject` guarantees all applicable team (and cost-center) budgets share the current project's team (cost center), each total is a single scalar.
- A purely project-scoped check narrows the aggregate with `WHERE project_id = ?`, staying on the `(project_id, created_at)` index instead of scanning the month.
- Reuses the existing pure `costCenterForProject(project, teamsByID, quotasByID)` resolver (already equivalence-tested against the DB version) instead of introducing a third implementation; `runtimeBudgetUsed` is deleted (its only caller was this path).
- New `runtime_budget_test.go` (598 lines): 28 scope-semantics subtests plus query-count guards.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `gofmt -l .` / `go vet ./...` / `git diff --check` / `node tools/check-source-lines.mjs` — clean.
- Narrow suite `-race` — ok; `go test ./... -count=1` — green (implementer and reviewer sessions independently; known baseline flakes not hit).
- `golangci-lint run ./...` (v2.12.2, CI-matching) — 10 pre-existing SA5011 findings in untouched files; no new findings.
- **Equivalence evidence**: with the implementation change stashed, the 28 semantics subtests pass 28/28 against the **old** implementation — the suite is a genuine oracle, not written to the new code. The two performance guards fail on the old implementation as expected (old: 9→231 statements growing with row count; new: constant ≤4. Old: 3 statements with no applicable budgets; new: 1).
- **PostgreSQL verified locally** against a disposable `postgres:16-alpine` container: cost-center with peer projects, team scope, global with orphaned records, and the project-narrowed path — 4/4 pass. Note: CI's `backend-postgres` job only runs `TestMultiInstancePostgresE2E` and does not cover this path; widening that job is a candidate follow-up.
- End-to-end smoke on a real process (temp SQLite, seeded demo): `/livez`, non-streaming + streaming `/v1/chat/completions`, `/api/admin/usage/summary` — pass.
- Codex review, 2 rounds (high effort): round 1 findings triaged (float re-association accepted as documented trade-off — the old code was already mixed SQL/Go accumulation; fail-loud on resource read errors kept deliberately; UTC month-boundary test clock fixed) plus 6 suggested test gaps filled; round 2 — "No new blocking findings … Ready to commit."

## Compatibility, Security, and Operations

- Scope semantics unchanged and pinned: global/project totals keep counting usage left by deleted projects; team/cost-center totals keep skipping it; team matching reads only the project's primary `TeamID` (not `project_teams` associations); the cost-center fallback chain (`Project.CostCenter → team field → quota field → TeamID → project:<id>`) is byte-identical via the shared resolver; `projects`/`teams`/`quota-policies` are read regardless of status, as before.
- One deliberate difference (documented in code): a failed read of cost-center resources now rejects the call instead of silently resolving the project to a different cost center and potentially admitting spend the budget should have stopped. A transient DB error becomes visible instead of silently weakening enforcement.
- Floating-point note: per-project SQL subtotals summed in Go are not bit-identical to either old accumulation order; near-threshold budgets could flip a single admission decision by sub-cent amounts. Accepted and documented — the old implementation was already internally inconsistent across scopes.
- No API, schema, or configuration change.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable. (No environment variable changes.)
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable. (No user-facing behavior change.)
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable. (Not touched.)
- [x] `git diff --check` passes.
