### PR TITLE
fix(gateway): expose codex cache and reasoning metadata

### DIFF
--- a/backend/internal/server/chat_stream_encoder.go
+++ b/backend/internal/server/chat_stream_encoder.go
@@ -99,6 +99,26 @@ func (e *openAIChatStreamEncoder) EmitReasoningSignature(provider string, signat
 	return e.emitDelta(map[string]any{"reasoning_signature": encodeProviderSignature(provider, signature)})
 }
 
+// EmitToolReasoningDetail carries an opaque reasoning continuation beside the
+// tool call it precedes. pi-ai persists this OpenRouter-compatible extension
+// on the tool call, whereas it treats a standalone reasoning_signature as a
+// display-only delta.
+func (e *openAIChatStreamEncoder) EmitToolReasoningDetail(toolCallID string, provider string, signature string) error {
+	if toolCallID == "" || signature == "" {
+		return nil
+	}
+	if err := e.EmitRole(); err != nil {
+		return err
+	}
+	return e.emitDelta(map[string]any{
+		"reasoning_details": []any{map[string]any{
+			"type": "reasoning.encrypted",
+			"id":   toolCallID,
+			"data": encodeProviderSignature(provider, signature),
+		}},
+	})
+}
+
 func (e *openAIChatStreamEncoder) EmitRedactedReasoning(data string) error {
 	if data == "" {
 		return nil
@@ -173,7 +193,7 @@ func (e *openAIChatStreamEncoder) Finalize(finishReason string, usage Usage) err
 	if e.includeUsage {
 		usageFrame := e.newFrame()
 		usageFrame["choices"] = []any{}
-		usageFrame["usage"] = usage
+		usageFrame["usage"] = openAIChatUsageObject(usage)
 		if err := e.writeFrame(usageFrame); err != nil {
 			return err
 		}

--- a/backend/internal/server/chat_stream_encoder_test.go
+++ b/backend/internal/server/chat_stream_encoder_test.go
@@ -108,7 +108,14 @@ func TestStreamEncoderEmitsTrailingUsageChunkWhenRequested(t *testing.T) {
 	if err := encoder.EmitText("hi"); err != nil {
 		t.Fatalf("EmitText: %v", err)
 	}
-	if err := encoder.Finalize("stop", Usage{PromptTokens: 3, CompletionTokens: 4, TotalTokens: 7}); err != nil {
+	if err := encoder.Finalize("stop", Usage{
+		PromptTokens:          10,
+		CachedInputTokens:     6,
+		CacheWriteInputTokens: 2,
+		CompletionTokens:      4,
+		ReasoningOutputTokens: 3,
+		TotalTokens:           14,
+	}); err != nil {
 		t.Fatalf("Finalize: %v", err)
 	}
 
@@ -121,6 +128,17 @@ func TestStreamEncoderEmitsTrailingUsageChunkWhenRequested(t *testing.T) {
 	usage, _ := final["usage"].(map[string]any)
 	if usage == nil {
 		t.Fatalf("expected a usage payload on the final chunk, got %v", final)
+	}
+	inputDetails, _ := usage["prompt_tokens_details"].(map[string]any)
+	if inputDetails["cached_tokens"] != float64(6) || inputDetails["cache_write_tokens"] != float64(2) {
+		t.Fatalf("standard input details = %#v", inputDetails)
+	}
+	outputDetails, _ := usage["completion_tokens_details"].(map[string]any)
+	if outputDetails["reasoning_tokens"] != float64(3) {
+		t.Fatalf("standard output details = %#v", outputDetails)
+	}
+	if usage["cached_input_tokens"] != float64(6) || usage["cache_write_input_tokens"] != float64(2) {
+		t.Fatalf("legacy usage aliases = %#v", usage)
 	}
 	// Every preceding chunk carries an explicit null usage.
 	for _, frame := range frames[:len(frames)-1] {
@@ -168,6 +186,26 @@ func TestStreamEncoderAssignsDenseToolSlots(t *testing.T) {
 	call, _ := calls[0].(map[string]any)
 	if index, _ := call["index"].(float64); int(index) != 1 {
 		t.Fatalf("tool call must report its dense index, got %v", call)
+	}
+}
+
+func TestStreamEncoderEmitsToolBoundReasoningDetail(t *testing.T) {
+	writer := &recordingWriter{}
+	encoder := newOpenAIChatStreamEncoder(writer, "model-x", false)
+
+	if err := encoder.EmitToolReasoningDetail("call_1", codexSignatureProvider, "opaque-state"); err != nil {
+		t.Fatalf("EmitToolReasoningDetail: %v", err)
+	}
+
+	frames := writer.frames(t)
+	delta := frameDelta(t, frames[len(frames)-1])
+	details, _ := delta["reasoning_details"].([]any)
+	if len(details) != 1 {
+		t.Fatalf("reasoning_details = %#v, want one item", delta["reasoning_details"])
+	}
+	detail, _ := details[0].(map[string]any)
+	if detail["type"] != "reasoning.encrypted" || detail["id"] != "call_1" || detail["data"] != encodeProviderSignature(codexSignatureProvider, "opaque-state") {
+		t.Fatalf("reasoning detail = %#v", detail)
 	}
 }
 

--- a/backend/internal/server/codex_compat_request.go
+++ b/backend/internal/server/codex_compat_request.go
@@ -481,7 +481,7 @@ func chatMessageToCodex(message ChatMessage, toolNames map[string]string) ([]any
 		}}, nil
 	case "assistant":
 		items := make([]any, 0, 3)
-		if encrypted, ok := decodeProviderSignature(codexSignatureProvider, message.ReasoningSignature); ok {
+		if encrypted, ok := chatCodexReasoningContinuation(message); ok {
 			reasoning := map[string]any{
 				"type":              "reasoning",
 				"summary":           []any{},
@@ -548,6 +548,42 @@ func chatMessageToCodex(message ChatMessage, toolNames map[string]string) ([]any
 	default:
 		return nil, NewHTTPError(http.StatusBadRequest, "invalid_message", fmt.Sprintf("unsupported message role %q", message.Role))
 	}
+}
+
+func chatCodexReasoningContinuation(message ChatMessage) (string, bool) {
+	if encrypted, ok := decodeProviderSignature(codexSignatureProvider, message.ReasoningSignature); ok {
+		return encrypted, true
+	}
+	if message.raw == nil {
+		return "", false
+	}
+	var details []map[string]any
+	if err := json.Unmarshal(message.raw["reasoning_details"], &details); err != nil {
+		return "", false
+	}
+	toolCallIDs := map[string]struct{}{}
+	if calls, ok := anySlice(message.ToolCalls); ok {
+		for _, rawCall := range calls {
+			call, _ := rawCall.(map[string]any)
+			if id, _ := call["id"].(string); id != "" {
+				toolCallIDs[id] = struct{}{}
+			}
+		}
+	}
+	for _, detail := range details {
+		id, _ := detail["id"].(string)
+		data, _ := detail["data"].(string)
+		if detail["type"] != "reasoning.encrypted" || id == "" {
+			continue
+		}
+		if _, exists := toolCallIDs[id]; !exists {
+			continue
+		}
+		if encrypted, ok := decodeProviderSignature(codexSignatureProvider, data); ok {
+			return encrypted, true
+		}
+	}
+	return "", false
 }
 
 func chatContentToCodex(content any, assistant bool) ([]any, error) {

--- a/backend/internal/server/codex_compat_response.go
+++ b/backend/internal/server/codex_compat_response.go
@@ -154,6 +154,15 @@ func codexResponsesToChat(
 	}
 	if len(toolCalls) > 0 {
 		message["tool_calls"] = toolCalls
+		if reasoningSignature != "" {
+			firstCall, _ := toolCalls[0].(map[string]any)
+			callID, _ := firstCall["id"].(string)
+			message["reasoning_details"] = []any{map[string]any{
+				"type": "reasoning.encrypted",
+				"id":   callID,
+				"data": reasoningSignature,
+			}}
+		}
 		if text.Len() == 0 {
 			message["content"] = nil
 		}
@@ -182,7 +191,7 @@ func codexResponsesToChat(
 			"message":       message,
 			"finish_reason": finishReason,
 		}},
-		"usage": usage,
+		"usage": openAIChatUsageObject(usage),
 	}, nil
 }
 

--- a/backend/internal/server/codex_compat_route_test.go
+++ b/backend/internal/server/codex_compat_route_test.go
@@ -182,7 +182,7 @@ func TestCodexCompatibilityRoutesBridgeChatAndAnthropicNonStreaming(t *testing.T
 		payload map[string]any
 		markers []string
 	}{
-		{name: "chat", path: "/v1/chat/completions", payload: codexCompatibilityChatPayload(false), markers: []string{"bridge text", `"tool_calls"`, `"reasoning_signature":"codex:`}},
+		{name: "chat", path: "/v1/chat/completions", payload: codexCompatibilityChatPayload(false), markers: []string{"bridge text", `"tool_calls"`, `"reasoning_signature":"codex:`, `"reasoning_details":[{"data":"codex:`}},
 		{name: "anthropic", path: "/v1/messages", payload: codexCompatibilityAnthropicPayload(false), markers: []string{"bridge text", `"type":"tool_use"`, `"type":"thinking"`, `"signature":"codex:`}},
 	}
 	for _, test := range cases {
@@ -210,7 +210,7 @@ func TestCodexCompatibilityRoutesBridgeChatAndAnthropicStreaming(t *testing.T) {
 		payload map[string]any
 		markers []string
 	}{
-		{name: "chat", path: "/v1/chat/completions", payload: codexCompatibilityChatPayload(true), markers: []string{"bridge text", `"tool_calls"`, "[DONE]"}},
+		{name: "chat", path: "/v1/chat/completions", payload: codexCompatibilityChatPayload(true), markers: []string{"bridge text", `"tool_calls"`, `"reasoning_details":[{"data":"codex:`, "[DONE]"}},
 		{name: "anthropic", path: "/v1/messages", payload: codexCompatibilityAnthropicPayload(true), markers: []string{"bridge text", "content_block_delta", "input_json_delta", "message_stop"}},
 	}
 	for _, test := range cases {

--- a/backend/internal/server/codex_compat_stream.go
+++ b/backend/internal/server/codex_compat_stream.go
@@ -1111,9 +1111,10 @@ func (s *codexAnthropicStreamSink) emit(event string, payload map[string]any) er
 }
 
 type codexChatStreamSink struct {
-	encoder      *openAIChatStreamEncoder
-	reverseNames map[string]string
-	toolSlots    map[string]int
+	encoder                   *openAIChatStreamEncoder
+	reverseNames              map[string]string
+	toolSlots                 map[string]int
+	pendingReasoningSignature string
 }
 
 func (s *codexChatStreamSink) Start(map[string]any) error {
@@ -1133,6 +1134,7 @@ func (s *codexChatStreamSink) ReasoningDelta(delta string) error {
 }
 
 func (s *codexChatStreamSink) ReasoningDone(signature string) error {
+	s.pendingReasoningSignature = signature
 	return s.encoder.EmitReasoningSignature(codexSignatureProvider, signature)
 }
 
@@ -1146,11 +1148,20 @@ func (s *codexChatStreamSink) ToolStart(
 	}
 	slot := s.encoder.NextToolSlot()
 	s.toolSlots[key] = slot
-	return s.encoder.EmitToolCallStart(
+	toolCallID := codexShortIdentifier(id)
+	if err := s.encoder.EmitToolCallStart(
 		slot,
-		codexShortIdentifier(id),
+		toolCallID,
 		codexRestoreToolName(s.reverseNames, name),
-	)
+	); err != nil {
+		return err
+	}
+	if s.pendingReasoningSignature == "" {
+		return nil
+	}
+	signature := s.pendingReasoningSignature
+	s.pendingReasoningSignature = ""
+	return s.encoder.EmitToolReasoningDetail(toolCallID, codexSignatureProvider, signature)
 }
 
 func (s *codexChatStreamSink) ToolArguments(key string, delta string) error {

--- a/backend/internal/server/codex_reasoning_details_test.go
+++ b/backend/internal/server/codex_reasoning_details_test.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestChatCodexReasoningContinuationReadsToolBoundDetail(t *testing.T) {
+	message := ChatMessage{
+		ToolCalls: []any{map[string]any{"id": "call_1"}},
+		raw: map[string]json.RawMessage{
+			"reasoning_details": json.RawMessage(`[{"type":"reasoning.encrypted","id":"call_1","data":"codex:opaque-state"}]`),
+		},
+	}
+
+	encrypted, ok := chatCodexReasoningContinuation(message)
+	if !ok || encrypted != "opaque-state" {
+		t.Fatalf("reasoning continuation = %q, %v", encrypted, ok)
+	}
+}
+
+func TestChatCodexReasoningContinuationRejectsUnboundOrForeignDetail(t *testing.T) {
+	for _, details := range []string{
+		`[{"type":"reasoning.encrypted","id":"call_other","data":"codex:opaque-state"}]`,
+		`[{"type":"reasoning.encrypted","id":"call_1","data":"anthropic:opaque-state"}]`,
+	} {
+		message := ChatMessage{
+			ToolCalls: []any{map[string]any{"id": "call_1"}},
+			raw: map[string]json.RawMessage{
+				"reasoning_details": json.RawMessage(details),
+			},
+		}
+		if encrypted, ok := chatCodexReasoningContinuation(message); ok {
+			t.Fatalf("accepted invalid reasoning continuation %q from %s", encrypted, details)
+		}
+	}
+}

--- a/backend/internal/server/openai_usage.go
+++ b/backend/internal/server/openai_usage.go
@@ -31,6 +31,8 @@ func openAIResponsesUsageObject(usage Usage) map[string]any {
 	result := tokenHubUsageAliases(usage)
 	result["input_tokens"] = usage.PromptTokens
 	result["output_tokens"] = usage.CompletionTokens
+	result["prompt_tokens"] = usage.PromptTokens
+	result["completion_tokens"] = usage.CompletionTokens
 	result["total_tokens"] = usage.TotalTokens
 
 	inputDetails := map[string]any{}

--- a/backend/internal/server/openai_usage.go
+++ b/backend/internal/server/openai_usage.go
@@ -1,0 +1,91 @@
+package server
+
+// openAIChatUsageObject renders TokenHub's internal accounting in the public
+// Chat Completions shape. The legacy top-level detail fields remain available
+// for existing TokenHub clients, while standard clients read the nested detail
+// objects.
+func openAIChatUsageObject(usage Usage) map[string]any {
+	result := tokenHubUsageAliases(usage)
+	result["prompt_tokens"] = usage.PromptTokens
+	result["completion_tokens"] = usage.CompletionTokens
+	result["total_tokens"] = usage.TotalTokens
+
+	inputDetails := map[string]any{}
+	setNonZeroInt64(inputDetails, "cached_tokens", usage.CachedInputTokens)
+	setNonZeroInt64(inputDetails, "cache_write_tokens", usage.CacheWriteInputTokens)
+	setNonZeroInt64(inputDetails, "audio_tokens", usage.InputAudioTokens)
+	if len(inputDetails) > 0 {
+		result["prompt_tokens_details"] = inputDetails
+	}
+
+	outputDetails := openAIOutputTokenDetails(usage)
+	if len(outputDetails) > 0 {
+		result["completion_tokens_details"] = outputDetails
+	}
+	return result
+}
+
+// openAIResponsesUsageObject renders TokenHub's internal accounting in the
+// public Responses shape while retaining TokenHub's compatibility aliases.
+func openAIResponsesUsageObject(usage Usage) map[string]any {
+	result := tokenHubUsageAliases(usage)
+	result["input_tokens"] = usage.PromptTokens
+	result["output_tokens"] = usage.CompletionTokens
+	result["total_tokens"] = usage.TotalTokens
+
+	inputDetails := map[string]any{}
+	setNonZeroInt64(inputDetails, "cached_tokens", usage.CachedInputTokens)
+	setNonZeroInt64(inputDetails, "cache_write_tokens", usage.CacheWriteInputTokens)
+	setNonZeroInt64(inputDetails, "audio_tokens", usage.InputAudioTokens)
+	if len(inputDetails) > 0 {
+		result["input_tokens_details"] = inputDetails
+	}
+
+	outputDetails := openAIOutputTokenDetails(usage)
+	if len(outputDetails) > 0 {
+		result["output_tokens_details"] = outputDetails
+	}
+	return result
+}
+
+func tokenHubUsageAliases(usage Usage) map[string]any {
+	result := map[string]any{}
+	setNonZeroInt64(result, "cached_input_tokens", usage.CachedInputTokens)
+	setNonZeroInt64(result, "cache_write_input_tokens", usage.CacheWriteInputTokens)
+	setNonZeroInt64(result, "input_audio_tokens", usage.InputAudioTokens)
+	setNonZeroInt64(result, "reasoning_output_tokens", usage.ReasoningOutputTokens)
+	setNonZeroInt64(result, "output_audio_tokens", usage.OutputAudioTokens)
+	setNonZeroInt64(result, "accepted_prediction_tokens", usage.AcceptedPredictionTokens)
+	setNonZeroInt64(result, "rejected_prediction_tokens", usage.RejectedPredictionTokens)
+	if usage.CostUSD != 0 {
+		result["estimated_cost_usd"] = usage.CostUSD
+	}
+	if usage.UpstreamRequestID != "" {
+		result["upstream_request_id"] = usage.UpstreamRequestID
+	}
+	if usage.ServedModel != "" {
+		result["served_model"] = usage.ServedModel
+	}
+	if usage.ModelETag != "" {
+		result["model_etag"] = usage.ModelETag
+	}
+	if usage.Transport != "" {
+		result["transport"] = usage.Transport
+	}
+	return result
+}
+
+func openAIOutputTokenDetails(usage Usage) map[string]any {
+	details := map[string]any{}
+	setNonZeroInt64(details, "reasoning_tokens", usage.ReasoningOutputTokens)
+	setNonZeroInt64(details, "audio_tokens", usage.OutputAudioTokens)
+	setNonZeroInt64(details, "accepted_prediction_tokens", usage.AcceptedPredictionTokens)
+	setNonZeroInt64(details, "rejected_prediction_tokens", usage.RejectedPredictionTokens)
+	return details
+}
+
+func setNonZeroInt64(target map[string]any, key string, value int64) {
+	if value != 0 {
+		target[key] = value
+	}
+}

--- a/backend/internal/server/openai_usage_route_test.go
+++ b/backend/internal/server/openai_usage_route_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestResponsesRoutePreservesLegacyUsageTotals(t *testing.T) {
+	store := NewMemoryStore()
+	project := store.CreateProject(Project{Name: "Usage compatibility project", Status: StatusActive})
+	_, secret, err := store.CreateAPIKey(project.ID, APIKey{Name: "Usage compatibility key", Status: StatusActive}, "thk_usage_compatibility")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.AddModel(Model{Name: "usage-compatible-model", Modality: "chat", Status: StatusActive})
+	provider := store.AddProvider(Provider{Name: "Usage compatibility provider", Type: ProviderMock, Status: StatusActive, Healthy: true})
+	store.AddRoute(ModelRoute{
+		ModelName: "usage-compatible-model", ProviderID: provider.ID, ProviderModel: "usage-compatible-model",
+		Priority: 1, Weight: 100, Status: StatusActive,
+	})
+
+	resp := doJSON(t, New(store).Handler(), http.MethodPost, "/v1/responses", map[string]any{
+		"model": "usage-compatible-model",
+		"input": "preserve existing response usage fields",
+	}, secret)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body)
+	}
+	var body map[string]any
+	if err := json.Unmarshal([]byte(resp.Body), &body); err != nil {
+		t.Fatal(err)
+	}
+	usage, _ := body["usage"].(map[string]any)
+	if usage["input_tokens"] == nil || usage["output_tokens"] == nil ||
+		usage["prompt_tokens"] != usage["input_tokens"] ||
+		usage["completion_tokens"] != usage["output_tokens"] {
+		t.Fatalf("Responses usage totals = %#v", usage)
+	}
+}

--- a/backend/internal/server/openai_usage_test.go
+++ b/backend/internal/server/openai_usage_test.go
@@ -1,0 +1,112 @@
+package server
+
+import "testing"
+
+func TestOpenAIChatUsageObjectIncludesStandardDetailsAndLegacyAliases(t *testing.T) {
+	usage := completeOpenAIUsageFixture()
+	result := openAIChatUsageObject(usage)
+
+	if result["prompt_tokens"] != usage.PromptTokens ||
+		result["completion_tokens"] != usage.CompletionTokens ||
+		result["total_tokens"] != usage.TotalTokens {
+		t.Fatalf("Chat token totals = %#v", result)
+	}
+	input := usageMapField(t, result, "prompt_tokens_details")
+	if input["cached_tokens"] != usage.CachedInputTokens ||
+		input["cache_write_tokens"] != usage.CacheWriteInputTokens ||
+		input["audio_tokens"] != usage.InputAudioTokens {
+		t.Fatalf("Chat input details = %#v", input)
+	}
+	assertOpenAIOutputDetails(t, usageMapField(t, result, "completion_tokens_details"), usage)
+	assertLegacyUsageAliases(t, result, usage)
+}
+
+func TestOpenAIResponsesUsageObjectIncludesStandardDetailsAndLegacyAliases(t *testing.T) {
+	usage := completeOpenAIUsageFixture()
+	result := openAIResponsesUsageObject(usage)
+
+	if result["input_tokens"] != usage.PromptTokens ||
+		result["output_tokens"] != usage.CompletionTokens ||
+		result["total_tokens"] != usage.TotalTokens {
+		t.Fatalf("Responses token totals = %#v", result)
+	}
+	input := usageMapField(t, result, "input_tokens_details")
+	if input["cached_tokens"] != usage.CachedInputTokens ||
+		input["cache_write_tokens"] != usage.CacheWriteInputTokens ||
+		input["audio_tokens"] != usage.InputAudioTokens {
+		t.Fatalf("Responses input details = %#v", input)
+	}
+	assertOpenAIOutputDetails(t, usageMapField(t, result, "output_tokens_details"), usage)
+	assertLegacyUsageAliases(t, result, usage)
+}
+
+func TestOpenAIUsageObjectsOmitEmptyDetailObjects(t *testing.T) {
+	usage := Usage{PromptTokens: 3, CompletionTokens: 2, TotalTokens: 5}
+	chat := openAIChatUsageObject(usage)
+	responses := openAIResponsesUsageObject(usage)
+	if _, exists := chat["prompt_tokens_details"]; exists {
+		t.Fatalf("empty Chat input details were emitted: %#v", chat)
+	}
+	if _, exists := chat["completion_tokens_details"]; exists {
+		t.Fatalf("empty Chat output details were emitted: %#v", chat)
+	}
+	if _, exists := responses["input_tokens_details"]; exists {
+		t.Fatalf("empty Responses input details were emitted: %#v", responses)
+	}
+	if _, exists := responses["output_tokens_details"]; exists {
+		t.Fatalf("empty Responses output details were emitted: %#v", responses)
+	}
+}
+
+func completeOpenAIUsageFixture() Usage {
+	return Usage{
+		PromptTokens:             100,
+		CachedInputTokens:        60,
+		CacheWriteInputTokens:    10,
+		InputAudioTokens:         5,
+		CompletionTokens:         40,
+		ReasoningOutputTokens:    20,
+		OutputAudioTokens:        4,
+		AcceptedPredictionTokens: 3,
+		RejectedPredictionTokens: 2,
+		TotalTokens:              140,
+		CostUSD:                  0.25,
+		UpstreamRequestID:        "req_upstream",
+		ServedModel:              "served-model",
+		ModelETag:                "model-etag",
+		Transport:                "websocket",
+	}
+}
+
+func usageMapField(t *testing.T, result map[string]any, name string) map[string]any {
+	t.Helper()
+	value, ok := result[name].(map[string]any)
+	if !ok {
+		t.Fatalf("%s = %#v", name, result[name])
+	}
+	return value
+}
+
+func assertOpenAIOutputDetails(t *testing.T, details map[string]any, usage Usage) {
+	t.Helper()
+	if details["reasoning_tokens"] != usage.ReasoningOutputTokens ||
+		details["audio_tokens"] != usage.OutputAudioTokens ||
+		details["accepted_prediction_tokens"] != usage.AcceptedPredictionTokens ||
+		details["rejected_prediction_tokens"] != usage.RejectedPredictionTokens {
+		t.Fatalf("output details = %#v", details)
+	}
+}
+
+func assertLegacyUsageAliases(t *testing.T, result map[string]any, usage Usage) {
+	t.Helper()
+	if result["cached_input_tokens"] != usage.CachedInputTokens ||
+		result["cache_write_input_tokens"] != usage.CacheWriteInputTokens ||
+		result["reasoning_output_tokens"] != usage.ReasoningOutputTokens ||
+		result["estimated_cost_usd"] != usage.CostUSD ||
+		result["upstream_request_id"] != usage.UpstreamRequestID ||
+		result["served_model"] != usage.ServedModel ||
+		result["model_etag"] != usage.ModelETag ||
+		result["transport"] != usage.Transport {
+		t.Fatalf("legacy aliases = %#v", result)
+	}
+}

--- a/backend/internal/server/openai_usage_test.go
+++ b/backend/internal/server/openai_usage_test.go
@@ -27,6 +27,8 @@ func TestOpenAIResponsesUsageObjectIncludesStandardDetailsAndLegacyAliases(t *te
 
 	if result["input_tokens"] != usage.PromptTokens ||
 		result["output_tokens"] != usage.CompletionTokens ||
+		result["prompt_tokens"] != usage.PromptTokens ||
+		result["completion_tokens"] != usage.CompletionTokens ||
 		result["total_tokens"] != usage.TotalTokens {
 		t.Fatalf("Responses token totals = %#v", result)
 	}

--- a/backend/internal/server/provider_anthropic_convert.go
+++ b/backend/internal/server/provider_anthropic_convert.go
@@ -391,6 +391,6 @@ func anthropicChatResponse(body map[string]any, model string, usage Usage) (map[
 			"message":       message,
 			"finish_reason": finishReason,
 		}},
-		"usage": usage,
+		"usage": openAIChatUsageObject(usage),
 	}, nil
 }

--- a/backend/internal/server/provider_chat_convert.go
+++ b/backend/internal/server/provider_chat_convert.go
@@ -350,9 +350,11 @@ func withoutGatewayExtensions(req ChatCompletionRequest, preserveReasoningConten
 		_, hasReasoningContent := message.raw["reasoning_content"]
 		_, hasReasoningSignature := message.raw["reasoning_signature"]
 		_, hasRedactedReasoningContent := message.raw["redacted_reasoning_content"]
+		_, hasReasoningDetails := message.raw["reasoning_details"]
 		if (!preserveReasoningContent && (message.ReasoningContent != "" || hasReasoningContent)) ||
 			message.ReasoningSignature != "" || hasReasoningSignature ||
-			message.RedactedReasoningContent != "" || hasRedactedReasoningContent {
+			message.RedactedReasoningContent != "" || hasRedactedReasoningContent ||
+			hasReasoningDetails {
 			needsCopy = true
 			break
 		}
@@ -374,6 +376,7 @@ func withoutGatewayExtensions(req ChatCompletionRequest, preserveReasoningConten
 		messages[index].RedactedReasoningContent = ""
 		delete(messages[index].raw, "reasoning_signature")
 		delete(messages[index].raw, "redacted_reasoning_content")
+		delete(messages[index].raw, "reasoning_details")
 	}
 	req.Messages = messages
 	return req

--- a/backend/internal/server/provider_chat_convert.go
+++ b/backend/internal/server/provider_chat_convert.go
@@ -350,11 +350,11 @@ func withoutGatewayExtensions(req ChatCompletionRequest, preserveReasoningConten
 		_, hasReasoningContent := message.raw["reasoning_content"]
 		_, hasReasoningSignature := message.raw["reasoning_signature"]
 		_, hasRedactedReasoningContent := message.raw["redacted_reasoning_content"]
-		_, hasReasoningDetails := message.raw["reasoning_details"]
+		_, hasCodexReasoningDetails := withoutCodexReasoningDetails(message.raw["reasoning_details"])
 		if (!preserveReasoningContent && (message.ReasoningContent != "" || hasReasoningContent)) ||
 			message.ReasoningSignature != "" || hasReasoningSignature ||
 			message.RedactedReasoningContent != "" || hasRedactedReasoningContent ||
-			hasReasoningDetails {
+			hasCodexReasoningDetails {
 			needsCopy = true
 			break
 		}
@@ -376,10 +376,48 @@ func withoutGatewayExtensions(req ChatCompletionRequest, preserveReasoningConten
 		messages[index].RedactedReasoningContent = ""
 		delete(messages[index].raw, "reasoning_signature")
 		delete(messages[index].raw, "redacted_reasoning_content")
-		delete(messages[index].raw, "reasoning_details")
+		if details, changed := withoutCodexReasoningDetails(messages[index].raw["reasoning_details"]); changed {
+			if len(details) == 0 {
+				delete(messages[index].raw, "reasoning_details")
+			} else {
+				messages[index].raw["reasoning_details"] = details
+			}
+		}
 	}
 	req.Messages = messages
 	return req
+}
+
+func withoutCodexReasoningDetails(value json.RawMessage) (json.RawMessage, bool) {
+	var details []json.RawMessage
+	if len(value) == 0 || json.Unmarshal(value, &details) != nil {
+		return value, false
+	}
+	filtered := make([]json.RawMessage, 0, len(details))
+	changed := false
+	for _, detail := range details {
+		var encoded struct {
+			Data string `json:"data"`
+		}
+		if json.Unmarshal(detail, &encoded) == nil {
+			if _, codex := decodeProviderSignature(codexSignatureProvider, encoded.Data); codex {
+				changed = true
+				continue
+			}
+		}
+		filtered = append(filtered, detail)
+	}
+	if !changed {
+		return value, false
+	}
+	if len(filtered) == 0 {
+		return nil, true
+	}
+	encoded, err := json.Marshal(filtered)
+	if err != nil {
+		return value, false
+	}
+	return encoded, true
 }
 
 func encodeProviderSignature(provider string, raw string) string {

--- a/backend/internal/server/provider_chat_convert_test.go
+++ b/backend/internal/server/provider_chat_convert_test.go
@@ -43,6 +43,7 @@ func TestWithoutGatewayExtensionsStripsExplicitEmptyRawFields(t *testing.T) {
 			"reasoning_content":"",
 			"reasoning_signature":"",
 			"redacted_reasoning_content":"",
+			"reasoning_details":[{"type":"reasoning.encrypted","id":"call_1","data":"codex:opaque-state"}],
 			"provider_message":"preserve me"
 		}]
 	}`), &req); err != nil {
@@ -60,7 +61,7 @@ func TestWithoutGatewayExtensionsStripsExplicitEmptyRawFields(t *testing.T) {
 	}
 	messages, _ := forwarded["messages"].([]any)
 	message, _ := messages[0].(map[string]any)
-	for _, field := range []string{"reasoning_content", "reasoning_signature", "redacted_reasoning_content"} {
+	for _, field := range []string{"reasoning_content", "reasoning_signature", "redacted_reasoning_content", "reasoning_details"} {
 		if _, present := message[field]; present {
 			t.Fatalf("explicit empty %s must not be forwarded: %v", field, message)
 		}
@@ -71,6 +72,9 @@ func TestWithoutGatewayExtensionsStripsExplicitEmptyRawFields(t *testing.T) {
 
 	if _, present := req.Messages[0].raw["reasoning_signature"]; !present {
 		t.Fatal("the original request was mutated")
+	}
+	if _, present := req.Messages[0].raw["reasoning_details"]; !present {
+		t.Fatal("the original reasoning details were mutated")
 	}
 }
 
@@ -93,6 +97,9 @@ func TestDeepSeekAdapterForwardsReasoningContentOnly(t *testing.T) {
 			ReasoningContent:         "deepseek continuation",
 			ReasoningSignature:       "anthropic:sig",
 			RedactedReasoningContent: "opaque",
+			raw: map[string]json.RawMessage{
+				"reasoning_details": json.RawMessage(`[{"type":"reasoning.encrypted","id":"call_1","data":"codex:opaque-state"}]`),
+			},
 		}},
 	})
 	if err != nil {
@@ -104,7 +111,7 @@ func TestDeepSeekAdapterForwardsReasoningContentOnly(t *testing.T) {
 	if message["reasoning_content"] != "deepseek continuation" {
 		t.Fatalf("DeepSeek reasoning_content was not forwarded: %v", message)
 	}
-	for _, field := range []string{"reasoning_signature", "redacted_reasoning_content"} {
+	for _, field := range []string{"reasoning_signature", "redacted_reasoning_content", "reasoning_details"} {
 		if _, present := message[field]; present {
 			t.Fatalf("%s must remain gateway-local: %v", field, message)
 		}

--- a/backend/internal/server/provider_chat_convert_test.go
+++ b/backend/internal/server/provider_chat_convert_test.go
@@ -98,7 +98,7 @@ func TestDeepSeekAdapterForwardsReasoningContentOnly(t *testing.T) {
 			ReasoningSignature:       "anthropic:sig",
 			RedactedReasoningContent: "opaque",
 			raw: map[string]json.RawMessage{
-				"reasoning_details": json.RawMessage(`[{"type":"reasoning.encrypted","id":"call_1","data":"codex:opaque-state"}]`),
+				"reasoning_details": json.RawMessage(`[{"type":"reasoning.encrypted","id":"call_foreign","data":"openrouter-state"},{"type":"reasoning.encrypted","id":"call_1","data":"codex:opaque-state"}]`),
 			},
 		}},
 	})
@@ -111,10 +111,18 @@ func TestDeepSeekAdapterForwardsReasoningContentOnly(t *testing.T) {
 	if message["reasoning_content"] != "deepseek continuation" {
 		t.Fatalf("DeepSeek reasoning_content was not forwarded: %v", message)
 	}
-	for _, field := range []string{"reasoning_signature", "redacted_reasoning_content", "reasoning_details"} {
+	for _, field := range []string{"reasoning_signature", "redacted_reasoning_content"} {
 		if _, present := message[field]; present {
 			t.Fatalf("%s must remain gateway-local: %v", field, message)
 		}
+	}
+	details, _ := message["reasoning_details"].([]any)
+	if len(details) != 1 {
+		t.Fatalf("non-Codex reasoning details were not preserved: %v", message)
+	}
+	detail, _ := details[0].(map[string]any)
+	if detail["id"] != "call_foreign" || detail["data"] != "openrouter-state" {
+		t.Fatalf("unexpected forwarded reasoning detail: %v", detail)
 	}
 }
 

--- a/backend/internal/server/provider_gemini_convert.go
+++ b/backend/internal/server/provider_gemini_convert.go
@@ -437,7 +437,7 @@ func geminiChatResponse(body map[string]any, model string, usage Usage) (map[str
 			"message":       message,
 			"finish_reason": mapped,
 		}},
-		"usage": usage,
+		"usage": openAIChatUsageObject(usage),
 	}, nil
 }
 

--- a/backend/internal/server/providers.go
+++ b/backend/internal/server/providers.go
@@ -66,7 +66,7 @@ func (a MockAdapter) Chat(ctx context.Context, provider Provider, providerModel 
 				"finish_reason": "stop",
 			},
 		},
-		"usage": usage,
+		"usage": openAIChatUsageObject(usage),
 	}, usage, nil
 }
 
@@ -133,7 +133,7 @@ func (a MockAdapter) Responses(ctx context.Context, provider Provider, providerM
 				},
 			},
 		},
-		"usage": usage,
+		"usage": openAIResponsesUsageObject(usage),
 	}, usage, nil
 }
 
@@ -1204,7 +1204,7 @@ func responseObject(model string, text string, usage Usage) map[string]any {
 				"content": []map[string]any{{"type": "output_text", "text": text}},
 			},
 		},
-		"usage": usage,
+		"usage": openAIResponsesUsageObject(usage),
 	}
 }
 

--- a/docs/ja/user-guide.md
+++ b/docs/ja/user-guide.md
@@ -151,10 +151,11 @@ Anthropic と Gemini では、複数ステップのツール呼び出しにお�
 | --- | --- |
 | `message.reasoning_content` | Anthropic の `thinking` テキスト、Gemini の thought パート、Codex の推論サマリー |
 | `message.reasoning_signature` | Anthropic の `thinking.signature`、Codex の暗号化推論 |
+| `message.reasoning_details` | ツール呼び出し ID に紐づく Codex の暗号化推論 |
 | `message.redacted_reasoning_content` | Anthropic の `redacted_thinking.data` |
 | `message.tool_calls[].thought_signature` | Gemini の `thoughtSignature` |
 
-次のリクエストの assistant メッセージでこれらのフィールドをそのまま返すと、推論の連続性が保たれます。これらを無視するクライアントでも動作します。TokenHub はプロバイダーが拒否する署名を送り返すのではなく、推論ブロックを省略します。署名には発行元プロバイダーの識別子が付与され、別のプロバイダーへ送られることはありません。
+次のリクエストの assistant メッセージでこれらのフィールドをそのまま返すと、推論の連続性が保たれます。`reasoning_details` では項目全体と `id` を維持してください。TokenHub は、その ID が同じ assistant メッセージ内のツール呼び出しと一致する場合にのみ受け付けます。これらを無視するクライアントでも動作します。TokenHub はプロバイダーが拒否する署名を送り返すのではなく、推論ブロックを省略します。署名には発行元プロバイダーの識別子が付与され、別のプロバイダーへ送られることはありません。
 
 ## Anthropic Messages と Claude Code
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -151,10 +151,11 @@ Anthropic and Gemini require the opaque signature attached to a reasoning step t
 | --- | --- |
 | `message.reasoning_content` | Anthropic `thinking` text, Gemini thought parts, Codex reasoning summaries |
 | `message.reasoning_signature` | Anthropic `thinking.signature`, Codex encrypted reasoning |
+| `message.reasoning_details` | Codex encrypted reasoning bound to a tool call ID |
 | `message.redacted_reasoning_content` | Anthropic `redacted_thinking.data` |
 | `message.tool_calls[].thought_signature` | Gemini `thoughtSignature` |
 
-Echo these fields on the assistant message of the following request to preserve reasoning continuity. Clients that ignore them still work: TokenHub omits the reasoning block rather than replaying a signature the provider would reject. Signatures are tagged with the provider that issued them and are never replayed to a different provider.
+Echo these fields on the assistant message of the following request to preserve reasoning continuity. For `reasoning_details`, preserve the complete item and its `id`; TokenHub accepts it only when that ID matches a tool call in the same assistant message. Clients that ignore these fields still work: TokenHub omits the reasoning block rather than replaying a signature the provider would reject. Signatures are tagged with the provider that issued them and are never replayed to a different provider.
 
 ## Anthropic Messages and Claude Code
 

--- a/docs/zh-CN/user-guide.md
+++ b/docs/zh-CN/user-guide.md
@@ -151,10 +151,11 @@ Anthropic 与 Gemini 要求在多轮工具调用的下一轮中，原样回传�
 | --- | --- |
 | `message.reasoning_content` | Anthropic `thinking` 文本、Gemini thought 片段、Codex 推理摘要 |
 | `message.reasoning_signature` | Anthropic `thinking.signature`、Codex 加密推理内容 |
+| `message.reasoning_details` | 与工具调用 ID 绑定的 Codex 加密推理内容 |
 | `message.redacted_reasoning_content` | Anthropic `redacted_thinking.data` |
 | `message.tool_calls[].thought_signature` | Gemini `thoughtSignature` |
 
-在后续请求的 assistant 消息中回传这些字段即可保持推理连续性。忽略这些字段的客户端同样可用：TokenHub 会省略推理块，而不会回传供应商将拒绝的签名。签名带有签发供应商的标记，绝不会被回传给其他供应商。
+在后续请求的 assistant 消息中回传这些字段即可保持推理连续性。对于 `reasoning_details`，必须完整保留条目及其 `id`；只有该 ID 与同一 assistant 消息中的工具调用匹配时，TokenHub 才会接受。忽略这些字段的客户端同样可用：TokenHub 会省略推理块，而不会回传供应商将拒绝的签名。签名带有签发供应商的标记，绝不会被回传给其他供应商。
 
 ## Anthropic Messages 与 Claude Code
 


### PR DESCRIPTION
## Summary

Expose Codex cache accounting and encrypted reasoning continuation through the OpenAI-compatible fields understood by standard clients, including DeepSeek Harness and pi-ai.

TokenHub previously returned cache and reasoning counters only through TokenHub-specific top-level usage fields. Clients that read the standard nested OpenAI usage objects therefore reported zero cache hits. The Codex Chat bridge also emitted a standalone reasoning signature that pi-ai displayed but did not persist for the next tool-call turn.

## Related Issue

N/A.

## Changes

- Emit standard `prompt_tokens_details` and `completion_tokens_details` for Chat Completions, and the corresponding `input_tokens_details` and `output_tokens_details` for Responses.
- Preserve existing TokenHub usage aliases so current clients remain compatible.
- Emit tool-bound encrypted `reasoning_details` in streaming and non-streaming Codex Chat responses and restore the continuation on the next tool-result request.
- Add focused regression tests for usage mapping, streaming output, route conversion, tool binding, and rejection of foreign or unbound reasoning details.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [x] `cd backend && go test ./...`
- [x] `cd backend && go vet ./...`
- [x] `node --test tools/*.test.mjs` (122 tests passed)
- [x] `node tools/check-doc-translations.mjs`
- [x] `node tools/check-ui-translations.mjs`
- [x] `node tools/check-env-contract.mjs`
- [x] `node tools/check-source-lines.mjs`
- [x] `git diff --check`

## Compatibility, Security, and Operations

The response schema gains standard nested token details while retaining all existing TokenHub aliases. No request field is removed, no environment variable or database migration is introduced, and no credential, backup, or runtime data is included. Codex upstream requests and cache behavior are unchanged; this change fixes response accounting and multi-turn reasoning-state preservation.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
