### PR TITLE
perf: fetch API keys by ID

### DIFF
--- a/backend/internal/server/admin_authorization.go
+++ b/backend/internal/server/admin_authorization.go
@@ -669,10 +669,8 @@ func (s *Server) canManageAPIKey(user AdminUser, keyID string) bool {
 }
 
 func (s *Server) findAPIKey(keyID string) (APIKey, error) {
-	for _, key := range s.store.ListAPIKeys() {
-		if key.ID == keyID {
-			return key, nil
-		}
+	if key, ok := s.store.GetAPIKey(keyID); ok {
+		return key, nil
 	}
 	return APIKey{}, NewHTTPError(404, "api_key_not_found", "API key not found")
 }

--- a/backend/internal/server/store.go
+++ b/backend/internal/server/store.go
@@ -126,6 +126,7 @@ type Store interface {
 	CreateAPIKey(projectID string, key APIKey, rawSecret string) (APIKey, string, error)
 	ListProjectKeys(projectID string) []APIKey
 	ListAPIKeys() []APIKey
+	GetAPIKey(id string) (APIKey, bool)
 	UpdateAPIKey(id string, patch APIKey) (APIKey, error)
 	RotateAPIKey(id string, graceUntil *time.Time) (APIKey, string, error)
 	DeleteAPIKey(id string) error

--- a/backend/internal/server/store_api_keys_test.go
+++ b/backend/internal/server/store_api_keys_test.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestGetAPIKeyHydratesAndRedactsLegacyRecord(t *testing.T) {
+	store := NewMemoryStore()
+	project := store.CreateProject(Project{ID: "prj_get_api_key", Name: "Get API key"})
+	stored := APIKey{
+		ID:        "key_get_api_key",
+		ProjectID: project.ID,
+		Name:      "Legacy key",
+		KeyHash:   "sensitive-hash",
+		Allowed:   []string{"model-b", "model-a", "model-a"},
+		Status:    StatusActive,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := store.db.Create(&stored).Error; err != nil {
+		t.Fatalf("create legacy API key: %v", err)
+	}
+
+	key, ok := store.GetAPIKey(stored.ID)
+	if !ok {
+		t.Fatal("GetAPIKey did not find the stored API key")
+	}
+	if key.KeyHash != "" {
+		t.Fatalf("GetAPIKey exposed key hash %q", key.KeyHash)
+	}
+	if key.ModelAccessMode != ModelAccessModeRestricted {
+		t.Fatalf("model access mode = %q, want %q", key.ModelAccessMode, ModelAccessModeRestricted)
+	}
+	if len(key.Allowed) != 2 || key.Allowed[0] != "model-a" || key.Allowed[1] != "model-b" {
+		t.Fatalf("allowed models = %#v, want sorted unique models", key.Allowed)
+	}
+	if !key.AllowedModels["model-a"] || !key.AllowedModels["model-b"] {
+		t.Fatalf("hydrated allowed model set = %#v", key.AllowedModels)
+	}
+
+	if missing, ok := store.GetAPIKey("key_missing"); ok || !reflect.DeepEqual(missing, APIKey{}) {
+		t.Fatalf("missing lookup = (%#v, %v), want zero value and false", missing, ok)
+	}
+}
+
+type apiKeySingleLookupStore struct {
+	Store
+	key      APIKey
+	getCalls int
+}
+
+func (s *apiKeySingleLookupStore) GetAPIKey(id string) (APIKey, bool) {
+	s.getCalls++
+	if id != s.key.ID {
+		return APIKey{}, false
+	}
+	return s.key, true
+}
+
+func (s *apiKeySingleLookupStore) ListAPIKeys() []APIKey {
+	panic("findAPIKey must not list all API keys")
+}
+
+func TestFindAPIKeyUsesSingleLookupAndPreservesNotFoundError(t *testing.T) {
+	store := &apiKeySingleLookupStore{key: APIKey{ID: "key_single_lookup", Name: "Single lookup"}}
+	server := &Server{store: store}
+
+	key, err := server.findAPIKey(store.key.ID)
+	if err != nil {
+		t.Fatalf("find existing API key: %v", err)
+	}
+	if !reflect.DeepEqual(key, store.key) {
+		t.Fatalf("found API key = %#v, want %#v", key, store.key)
+	}
+	if store.getCalls != 1 {
+		t.Fatalf("GetAPIKey calls = %d, want 1", store.getCalls)
+	}
+
+	_, err = server.findAPIKey("key_missing")
+	httpErr := AsHTTPError(err)
+	if httpErr.Status != 404 || httpErr.Code != "api_key_not_found" || httpErr.Message != "API key not found" {
+		t.Fatalf("missing API key error = %#v", httpErr)
+	}
+}

--- a/backend/internal/server/store_projects.go
+++ b/backend/internal/server/store_projects.go
@@ -501,6 +501,15 @@ func (s *GormStore) ListAPIKeys() []APIKey {
 	return publicKeys(items)
 }
 
+func (s *GormStore) GetAPIKey(id string) (APIKey, bool) {
+	var key APIKey
+	if err := s.db.First(&key, "id = ?", id).Error; err != nil {
+		return APIKey{}, false
+	}
+	hydrateAPIKey(&key)
+	return publicKey(key), true
+}
+
 func (s *GormStore) UpdateAPIKey(id string, patch APIKey) (APIKey, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
## Summary

Replace the API key list-and-scan path in `Server.findAPIKey` with a primary-key store lookup. This avoids loading and hydrating every API key when an admin operation needs one record.

## Related Issue

N/A.

## Changes

- Add `Store.GetAPIKey` and implement it as a primary-key query in `GormStore`.
- Preserve legacy model-access hydration, key-hash redaction, and the existing not-found response.
- Add regression tests for hydration, redaction, missing records, and the single-lookup path.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./internal/server -run 'Test(GetAPIKey|FindAPIKey)' -count=1`
- `go test ./...`
- `go vet ./...`
- `node --test tools/*.test.mjs`
- `node tools/check-doc-translations.mjs`
- `node tools/check-ui-translations.mjs`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- `git diff --check`
- Independent read-only review: no actionable findings.
- `golangci-lint run ./...` was skipped because `golangci-lint` is not installed in the current environment.

## Compatibility, Security, and Operations

No public API, database schema, authorization, configuration, deployment, or rollout changes. Existing API key hydration, key-hash redaction, and `404 api_key_not_found` behavior are preserved. Rollback is a direct revert of this commit.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
