### PR TITLE
perf(routing): precompute rendezvous scores

### DIFF
--- a/backend/internal/server/cache_locality_test.go
+++ b/backend/internal/server/cache_locality_test.go
@@ -425,6 +425,48 @@ func TestCodexRendezvousStillUsesFNV(t *testing.T) {
 	}
 }
 
+func TestRendezvousSortPrecomputesScores(t *testing.T) {
+	group := []RouteSelection{
+		{Route: ModelRoute{ID: "route_c", Weight: 30}},
+		{Route: ModelRoute{ID: "route_a", Weight: 10}},
+		{Route: ModelRoute{ID: "route_b", Weight: 20}},
+	}
+	scores := map[string]float64{
+		"route_a": 10,
+		"route_b": 20,
+		"route_c": 20,
+	}
+	calls := map[string]int{}
+	sortRouteGroupByRendezvous("affinity-key", group, routeSortID, func(key, identity string, weight int) float64 {
+		if key != "affinity-key" {
+			t.Fatalf("routing key = %q, want affinity-key", key)
+		}
+		calls[identity]++
+		return scores[identity]
+	})
+
+	want := []string{"route_b", "route_c", "route_a"}
+	for index := range group {
+		identity := routeSortID(group[index])
+		if identity != want[index] {
+			t.Fatalf("route at %d = %q, want %q", index, identity, want[index])
+		}
+		if calls[identity] != 1 {
+			t.Fatalf("score calls for %q = %d, want 1", identity, calls[identity])
+		}
+	}
+
+	singletonCalls := 0
+	singleton := []RouteSelection{{Route: ModelRoute{ID: "route_single", Weight: 100}}}
+	sortRouteGroupByRendezvous("affinity-key", singleton, routeSortID, func(string, string, int) float64 {
+		singletonCalls++
+		return 1
+	})
+	if singletonCalls != 0 {
+		t.Fatalf("singleton score calls = %d, want 0", singletonCalls)
+	}
+}
+
 // With the switch off the whole routing path must stay byte-identical to the
 // pre-change behaviour.
 func TestSwitchOffIsByteIdenticalToLegacyRouting(t *testing.T) {

--- a/backend/internal/server/gateway_http.go
+++ b/backend/internal/server/gateway_http.go
@@ -989,14 +989,7 @@ func (s *Server) planRouteOrder(call CallContext, routes []RouteSelection) []Rou
 					identity = cacheDomainID
 					score = weightedCacheDomainScore
 				}
-				sort.SliceStable(group, func(i, j int) bool {
-					left := score(routingKey, identity(group[i]), routeEffectiveWeight(group[i]))
-					right := score(routingKey, identity(group[j]), routeEffectiveWeight(group[j]))
-					if left != right {
-						return left > right
-					}
-					return routeSortID(group[i]) < routeSortID(group[j])
-				})
+				sortRouteGroupByRendezvous(routingKey, group, identity, score)
 				planned = append(planned, group...)
 				priorityGroup = priorityGroup[groupEnd:]
 				continue
@@ -1011,6 +1004,36 @@ func (s *Server) planRouteOrder(call CallContext, routes []RouteSelection) []Rou
 		ordered = ordered[end:]
 	}
 	return planned
+}
+
+type rendezvousRouteRanking struct {
+	routes []RouteSelection
+	scores []float64
+}
+
+func (ranking rendezvousRouteRanking) Len() int { return len(ranking.routes) }
+
+func (ranking rendezvousRouteRanking) Less(i, j int) bool {
+	if ranking.scores[i] != ranking.scores[j] {
+		return ranking.scores[i] > ranking.scores[j]
+	}
+	return routeSortID(ranking.routes[i]) < routeSortID(ranking.routes[j])
+}
+
+func (ranking rendezvousRouteRanking) Swap(i, j int) {
+	ranking.routes[i], ranking.routes[j] = ranking.routes[j], ranking.routes[i]
+	ranking.scores[i], ranking.scores[j] = ranking.scores[j], ranking.scores[i]
+}
+
+func sortRouteGroupByRendezvous(routingKey string, group []RouteSelection, identity func(RouteSelection) string, score func(string, string, int) float64) {
+	if len(group) < 2 {
+		return
+	}
+	scores := make([]float64, len(group))
+	for index := range group {
+		scores[index] = score(routingKey, identity(group[index]), routeEffectiveWeight(group[index]))
+	}
+	sort.Stable(rendezvousRouteRanking{routes: group, scores: scores})
 }
 
 // weightedRendezvousScore scores candidates for Codex session affinity, where

--- a/backend/internal/server/gateway_performance_test.go
+++ b/backend/internal/server/gateway_performance_test.go
@@ -80,6 +80,39 @@ func BenchmarkGatewayGovernanceCosts(b *testing.B) {
 	}
 }
 
+func BenchmarkPlanRouteOrderRendezvous(b *testing.B) {
+	server := &Server{}
+	call := CallContext{
+		RequestID: "req_rendezvous_benchmark",
+		Affinity: &RequestAffinity{
+			Kind:    AffinityKindCodexSession,
+			KeyHash: "rendezvous-benchmark-affinity",
+		},
+	}
+	for _, candidateCount := range []int{1, 8, 32, 128} {
+		b.Run(fmt.Sprintf("Candidates%d", candidateCount), func(b *testing.B) {
+			routes := make([]RouteSelection, candidateCount)
+			for index := range routes {
+				routes[index] = RouteSelection{Route: ModelRoute{
+					ID:       fmt.Sprintf("route_rendezvous_%03d", index),
+					Priority: 1,
+					Weight:   100,
+					Strategy: RouteStrategyBalanced,
+				}}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				planned := server.planRouteOrder(call, routes)
+				if len(planned) != candidateCount {
+					b.Fatalf("planned routes = %d, want %d", len(planned), candidateCount)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkGatewayPayloadAuditRendering(b *testing.B) {
 	for _, size := range []int{256, 32 * 1024} {
 		b.Run(fmt.Sprintf("Bytes%d", size), func(b *testing.B) {


### PR DESCRIPTION
## Summary

The affinity route planner recalculated both candidates' rendezvous scores inside every stable-sort comparator call. This repeated FNV-1a or SHA-256 hashing O(n log n) times even though each score is deterministic for the duration of the sort.

This PR implements PR-7 from the performance review by precomputing each candidate's score once before sorting. Hash computation is reduced to O(n), while the overall stable sort remains O(n log n) and preserves the existing route order exactly.

## Related Issue

N/A.

## Changes

- Precompute rendezvous scores once per route and keep scores aligned with routes during the in-place stable sort.
- Preserve descending score order and the existing `routeSortID` tie-breaker for both Codex session affinity and cache-locality routing.
- Skip scoring and allocation for empty and singleton groups, preserving the previous fast path.
- Add regression coverage that verifies one score calculation per candidate, deterministic tie ordering, and zero calculations for singleton groups.
- Add a focused 1/8/32/128-candidate route-planning benchmark.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...` passed.
- `go vet ./...` passed.
- Focused rendezvous, affinity, sticky-session, and balanced-routing tests passed.
- `node --test tools/*.test.mjs` passed: 122/122 tests.
- Documentation existence, UI translation, environment contract, and source-line checks passed. The local documentation co-change check skipped its diff comparison because no base/head endpoints were supplied, as expected outside CI.
- `git diff --check` passed.
- A fresh read-only review found one singleton-path regression; the fast path was restored, all checks were rerun, and the second review round reported no actionable findings.

`BenchmarkPlanRouteOrderRendezvous`, Apple M4 Pro, median of five runs:

| Candidates | Before | After | Improvement |
| ---: | ---: | ---: | ---: |
| 8 | 9,305 ns/op | 4,428 ns/op | 52.4% |
| 32 | 34,494 ns/op | 16,426 ns/op | 52.4% |
| 128 | 172,474 ns/op | 66,598 ns/op | 61.4% |

Multi-candidate allocations decreased from 10 to 9 allocations per operation. The added singleton case completes in approximately 416 ns/op without computing a rendezvous score.

## Compatibility, Security, and Operations

No API, persistence, configuration, deployment, security, or user-visible behavior changes. Rollout requires no special handling; rollback is a normal revert of this commit.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
