### PR TITLE
perf(routing): batch route candidate lookups

### DIFF
--- a/backend/internal/server/multi_instance_e2e_test.go
+++ b/backend/internal/server/multi_instance_e2e_test.go
@@ -66,6 +66,12 @@ func TestMultiInstancePostgresE2E(t *testing.T) {
 	t.Run("analytics checkpoints do not serialize replica writes", func(t *testing.T) {
 		testAnalyticsCommitSequence(t, storeA, storeB)
 	})
+	t.Run("route candidates use one read snapshot", func(t *testing.T) {
+		testRouteCandidateReadSnapshot(t, storeA, storeB)
+	})
+	t.Run("adaptive route stats failures remain best effort", func(t *testing.T) {
+		testRouteCandidateStatsFailure(t, storeA)
+	})
 	t.Run("analytics migration preserves legacy time windows", func(t *testing.T) {
 		testPostgresAnalyticsLegacySequenceMigration(t, storeA, config)
 	})
@@ -84,6 +90,144 @@ func TestMultiInstancePostgresE2E(t *testing.T) {
 	t.Run("lost cluster leases cancel guarded work", func(t *testing.T) {
 		testClusterLeaseLossCancelsWork(t, storeA, storeB)
 	})
+}
+
+func testRouteCandidateReadSnapshot(t *testing.T, storeA *GormStore, storeB *GormStore) {
+	t.Helper()
+	suffix := NewID("snapshot")
+	modelName := "route-snapshot-" + suffix
+	providerID := "prv_" + suffix
+	routeID := "route_" + suffix
+	storeA.AddModel(Model{Name: modelName, Modality: "chat", Status: StatusActive})
+	storeA.AddProvider(Provider{
+		ID: providerID, Name: "Route snapshot provider", Type: ProviderMock,
+		Status: StatusActive, Healthy: true,
+	})
+	storeA.AddRoute(ModelRoute{
+		ID: routeID, ModelName: modelName, ProviderID: providerID,
+		ProviderModel: modelName, Priority: 1, Weight: 100, Status: StatusActive,
+	})
+	t.Cleanup(func() {
+		_ = storeA.db.Where("id = ?", routeID).Delete(&ModelRoute{}).Error
+		_ = storeA.db.Where("id = ?", providerID).Delete(&Provider{}).Error
+		_ = storeA.db.Where("name = ?", modelName).Delete(&Model{}).Error
+	})
+
+	routeRead := make(chan struct{}, 1)
+	resume := make(chan struct{})
+	var pauseOnce sync.Once
+	callbackName := "test:route-candidate-snapshot:" + suffix
+	if err := storeA.db.Callback().Query().After("gorm:query").Register(callbackName, func(tx *gorm.DB) {
+		if tx.Statement.Schema == nil || tx.Statement.Schema.Table != "model_routes" {
+			return
+		}
+		pauseOnce.Do(func() {
+			routeRead <- struct{}{}
+			select {
+			case <-resume:
+			case <-time.After(5 * time.Second):
+				tx.AddError(fmt.Errorf("timed out waiting to resume route snapshot query"))
+			}
+		})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := storeA.db.Callback().Query().Remove(callbackName); err != nil {
+			t.Errorf("remove route snapshot callback: %v", err)
+		}
+	}()
+
+	type selectionResult struct {
+		candidates []RouteSelection
+		err        error
+	}
+	result := make(chan selectionResult, 1)
+	go func() {
+		candidates, err := storeA.SelectRouteCandidates(modelName)
+		result <- selectionResult{candidates: candidates, err: err}
+	}()
+	select {
+	case <-routeRead:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the route query")
+	}
+	if err := storeB.db.Model(&Provider{}).Where("id = ?", providerID).Update("healthy", false).Error; err != nil {
+		t.Fatal(err)
+	}
+	close(resume)
+
+	select {
+	case selected := <-result:
+		if selected.err != nil {
+			t.Fatal(selected.err)
+		}
+		if len(selected.candidates) != 1 || selected.candidates[0].Provider.ID != providerID || !selected.candidates[0].Provider.Healthy {
+			t.Fatalf("snapshot candidates = %+v", selected.candidates)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for route candidates")
+	}
+}
+
+func testRouteCandidateStatsFailure(t *testing.T, store *GormStore) {
+	t.Helper()
+	suffix := NewID("stats-failure")
+	modelName := "route-stats-failure-" + suffix
+	providerID := "prv_" + suffix
+	routeID := "route_" + suffix
+	store.AddModel(Model{Name: modelName, Modality: "chat", Status: StatusActive})
+	store.AddProvider(Provider{
+		ID: providerID, Name: "Route stats failure provider", Type: ProviderMock,
+		Status: StatusActive, Healthy: true,
+	})
+	store.AddRoute(ModelRoute{
+		ID: routeID, ModelName: modelName, ProviderID: providerID,
+		ProviderModel: modelName, Priority: 1, Weight: 100,
+		Status: StatusActive, Strategy: RouteStrategyAdaptive,
+	})
+	t.Cleanup(func() {
+		_ = store.db.Where("id = ?", routeID).Delete(&ModelRoute{}).Error
+		_ = store.db.Where("id = ?", providerID).Delete(&Provider{}).Error
+		_ = store.db.Where("name = ?", modelName).Delete(&Model{}).Error
+	})
+
+	callbackName := "test:route-candidate-stats-error:" + suffix
+	resultCallbackName := callbackName + ":result"
+	var statsQueryErr error
+	if err := store.db.Callback().Row().Before("gorm:row").Register(callbackName, func(tx *gorm.DB) {
+		if tx.Statement.Schema != nil && tx.Statement.Schema.Table == "route_attempt_logs" {
+			tx.Statement.Table = "missing_route_attempt_logs_" + suffix
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.Callback().Row().After("gorm:row").Register(resultCallbackName, func(tx *gorm.DB) {
+		if tx.Statement.Schema != nil && tx.Statement.Schema.Table == "route_attempt_logs" {
+			statsQueryErr = tx.Error
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := store.db.Callback().Row().Remove(callbackName); err != nil {
+			t.Errorf("remove route stats error callback: %v", err)
+		}
+		if err := store.db.Callback().Row().Remove(resultCallbackName); err != nil {
+			t.Errorf("remove route stats result callback: %v", err)
+		}
+	}()
+
+	candidates, err := store.SelectRouteCandidates(modelName)
+	if err != nil {
+		t.Fatalf("optional runtime stats failure rejected candidates: %v", err)
+	}
+	if statsQueryErr == nil {
+		t.Fatal("adaptive runtime stats query did not reach the intended database-side failure")
+	}
+	if len(candidates) != 1 || candidates[0].Provider.ID != providerID || candidates[0].Runtime != (RouteRuntimeStats{}) {
+		t.Fatalf("candidates after optional runtime stats failure = %+v", candidates)
+	}
 }
 
 type multiInstanceResponseAdapter struct {

--- a/backend/internal/server/multi_instance_e2e_test.go
+++ b/backend/internal/server/multi_instance_e2e_test.go
@@ -72,6 +72,13 @@ func TestMultiInstancePostgresE2E(t *testing.T) {
 	t.Run("adaptive route stats failures remain best effort", func(t *testing.T) {
 		testRouteCandidateStatsFailure(t, storeA)
 	})
+	t.Run("route candidate lookup errors preserve failover", func(t *testing.T) {
+		for _, target := range []string{"providers", "provider_resources"} {
+			t.Run(target, func(t *testing.T) {
+				testRouteCandidateLookupFailover(t, storeA, target)
+			})
+		}
+	})
 	t.Run("analytics migration preserves legacy time windows", func(t *testing.T) {
 		testPostgresAnalyticsLegacySequenceMigration(t, storeA, config)
 	})
@@ -126,7 +133,7 @@ func testRouteCandidateReadSnapshot(t *testing.T, storeA *GormStore, storeB *Gor
 			select {
 			case <-resume:
 			case <-time.After(5 * time.Second):
-				tx.AddError(fmt.Errorf("timed out waiting to resume route snapshot query"))
+				_ = tx.AddError(fmt.Errorf("timed out waiting to resume route snapshot query"))
 			}
 		})
 	}); err != nil {
@@ -227,6 +234,89 @@ func testRouteCandidateStatsFailure(t *testing.T, store *GormStore) {
 	}
 	if len(candidates) != 1 || candidates[0].Provider.ID != providerID || candidates[0].Runtime != (RouteRuntimeStats{}) {
 		t.Fatalf("candidates after optional runtime stats failure = %+v", candidates)
+	}
+}
+
+func testRouteCandidateLookupFailover(t *testing.T, store *GormStore, target string) {
+	t.Helper()
+	suffix := NewID("lookup-failover")
+	modelName := "route-lookup-failover-" + suffix
+	providers := make([]Provider, 0, 2)
+	resources := make([]ProviderResource, 0, 2)
+	routes := make([]ModelRoute, 0, 2)
+	store.AddModel(Model{Name: modelName, Modality: "chat", Status: StatusActive})
+	for index, label := range []string{"bad", "good"} {
+		provider := store.AddProvider(Provider{
+			ID: "prv_" + label + "_" + suffix, Name: "Route lookup " + label,
+			Type: ProviderMock, Status: StatusActive, Healthy: true,
+		})
+		resource, err := store.AddProviderResource(ProviderResource{
+			ID: "rsrc_" + label + "_" + suffix, ProviderID: provider.ID,
+			Name: "Route lookup " + label, Status: StatusActive, Healthy: true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		providers = append(providers, provider)
+		resources = append(resources, resource)
+		routes = append(routes, store.AddRoute(ModelRoute{
+			ID: "route_" + label + "_" + suffix, ModelName: modelName,
+			ProviderID: provider.ID, ProviderResourceID: resource.ID, ProviderModel: modelName,
+			Priority: index + 1, Weight: 100, Status: StatusActive,
+		}))
+	}
+	t.Cleanup(func() {
+		for _, route := range routes {
+			_ = store.db.Where("id = ?", route.ID).Delete(&ModelRoute{}).Error
+		}
+		for _, resource := range resources {
+			_ = store.db.Where("id = ?", resource.ID).Delete(&ProviderResource{}).Error
+		}
+		for _, provider := range providers {
+			_ = store.db.Where("id = ?", provider.ID).Delete(&Provider{}).Error
+		}
+		_ = store.db.Where("name = ?", modelName).Delete(&Model{}).Error
+	})
+
+	attempts := 0
+	databaseErrors := 0
+	callbackName := "test:route-candidate-lookup-failover:" + suffix
+	resultCallbackName := callbackName + ":result"
+	if err := store.db.Callback().Query().Before("gorm:query").Register(callbackName, func(tx *gorm.DB) {
+		if tx.Statement.Schema != nil && tx.Statement.Schema.Table == target {
+			attempts++
+			if attempts <= 2 {
+				tx.Statement.Table = "missing_" + target + "_" + suffix
+			}
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.Callback().Query().After("gorm:query").Register(resultCallbackName, func(tx *gorm.DB) {
+		if tx.Statement.Schema != nil && tx.Statement.Schema.Table == target && tx.Error != nil {
+			databaseErrors++
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := store.db.Callback().Query().Remove(callbackName); err != nil {
+			t.Errorf("remove route lookup failover callback: %v", err)
+		}
+		if err := store.db.Callback().Query().Remove(resultCallbackName); err != nil {
+			t.Errorf("remove route lookup failover result callback: %v", err)
+		}
+	}()
+
+	candidates, err := store.SelectRouteCandidates(modelName)
+	if err != nil {
+		t.Fatalf("lookup failure rejected unaffected candidates: %v", err)
+	}
+	if attempts != 3 || databaseErrors != 2 {
+		t.Fatalf("lookup attempts/errors = %d/%d, want 3/2", attempts, databaseErrors)
+	}
+	if len(candidates) != 1 || candidates[0].Route.ID != routes[1].ID {
+		t.Fatalf("lookup failover candidates = %+v, want route %s", candidates, routes[1].ID)
 	}
 }
 

--- a/backend/internal/server/store_route_candidates.go
+++ b/backend/internal/server/store_route_candidates.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"database/sql"
+	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -15,16 +17,22 @@ func (s *GormStore) SelectRouteCandidates(modelName string) ([]RouteSelection, e
 	defer s.mu.Unlock()
 
 	var selections []RouteSelection
-	read := func(db *gorm.DB) error {
-		var err error
-		selections, err = s.loadRouteCandidates(db, modelName, time.Now().UTC())
-		return err
+	now := time.Now().UTC()
+	runRead := func(load func(*gorm.DB, string, time.Time) ([]RouteSelection, error)) error {
+		read := func(db *gorm.DB) error {
+			var err error
+			selections, err = load(db, modelName, now)
+			return err
+		}
+		if s.dbDriver == "postgres" {
+			return s.db.Transaction(read, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+		}
+		return read(s.db)
 	}
-	var err error
-	if s.dbDriver == "postgres" {
-		err = s.db.Transaction(read, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
-	} else {
-		err = read(s.db)
+	err := runRead(s.loadRouteCandidates)
+	var batchErr *routeCandidateBatchLookupError
+	if errors.As(err, &batchErr) {
+		err = runRead(s.loadRouteCandidatesIndividually)
 	}
 	if err != nil {
 		return nil, err
@@ -33,6 +41,19 @@ func (s *GormStore) SelectRouteCandidates(modelName string) ([]RouteSelection, e
 		return nil, ErrProviderMissing
 	}
 	return selections, nil
+}
+
+type routeCandidateBatchLookupError struct {
+	target string
+	err    error
+}
+
+func (e *routeCandidateBatchLookupError) Error() string {
+	return fmt.Sprintf("batch load route candidate %s: %v", e.target, e.err)
+}
+
+func (e *routeCandidateBatchLookupError) Unwrap() error {
+	return e.err
 }
 
 func (s *GormStore) loadRouteCandidates(db *gorm.DB, modelName string, now time.Time) ([]RouteSelection, error) {
@@ -46,11 +67,11 @@ func (s *GormStore) loadRouteCandidates(db *gorm.DB, modelName string, now time.
 	providerIDs, explicitResourceIDs, implicitProviderIDs := routeCandidateLookupIDs(routes)
 	providers, err := loadRouteCandidateProviders(db, providerIDs)
 	if err != nil {
-		return nil, err
+		return nil, &routeCandidateBatchLookupError{target: "providers", err: err}
 	}
 	explicitResources, err := loadRouteCandidateResourcesByID(db, explicitResourceIDs)
 	if err != nil {
-		return nil, err
+		return nil, &routeCandidateBatchLookupError{target: "provider resources", err: err}
 	}
 	implicitResources, err := loadRouteCandidateResourcesByProvider(db, implicitProviderIDs, now)
 	if err != nil {
@@ -94,6 +115,96 @@ func (s *GormStore) loadRouteCandidates(db *gorm.DB, modelName string, now time.
 		return nil, err
 	}
 	return selections, nil
+}
+
+func (s *GormStore) loadRouteCandidatesIndividually(db *gorm.DB, modelName string, now time.Time) ([]RouteSelection, error) {
+	var routes []ModelRoute
+	if err := db.Where("model_name = ? AND status = ?", modelName, StatusActive).
+		Order("priority asc, weight desc, created_at asc").
+		Find(&routes).Error; err != nil {
+		return nil, err
+	}
+
+	selections := make([]RouteSelection, 0, len(routes))
+	for _, route := range routes {
+		var provider Provider
+		found, err := s.bestEffortRouteCandidateLookup(db, func() error {
+			return db.First(&provider, "id = ?", route.ProviderID).Error
+		})
+		if err != nil {
+			return nil, err
+		}
+		if !found || provider.Status != StatusActive || !provider.Healthy {
+			continue
+		}
+		if route.ProviderResourceID != "" {
+			var resource ProviderResource
+			found, err := s.bestEffortRouteCandidateLookup(db, func() error {
+				return db.First(&resource, "id = ? AND provider_id = ?", route.ProviderResourceID, provider.ID).Error
+			})
+			if err != nil {
+				return nil, err
+			}
+			if !found || resource.Status != StatusActive || !halfOpenEligible(resource, now) {
+				continue
+			}
+			selections = append(selections, s.routeSelection(provider, &resource, route))
+			continue
+		}
+
+		var resources []ProviderResource
+		query := db.Where("provider_id = ? AND status = ? AND (healthy = ? OR cooldown_until <= ?)",
+			provider.ID, StatusActive, true, now)
+		if group := strings.TrimSpace(route.ResourceGroup); group != "" {
+			query = query.Where("\"group\" = ?", group)
+		}
+		if err := query.Order("priority asc, weight desc, created_at asc, id asc").Find(&resources).Error; err != nil {
+			return nil, err
+		}
+		if len(resources) == 0 {
+			selections = append(selections, s.routeSelection(provider, nil, route))
+			continue
+		}
+		for _, resource := range resources {
+			resourceRoute := route
+			resourceRoute.ProviderResourceID = resource.ID
+			if resource.Weight > 0 {
+				resourceRoute.Weight = resource.Weight
+			}
+			selections = append(selections, s.routeSelection(provider, &resource, resourceRoute))
+		}
+	}
+	if err := s.attachRouteRuntimeStats(db, selections, now); err != nil {
+		return nil, err
+	}
+	return selections, nil
+}
+
+func (s *GormStore) bestEffortRouteCandidateLookup(db *gorm.DB, lookup func() error) (bool, error) {
+	if s.dbDriver != "postgres" {
+		return lookup() == nil, nil
+	}
+	const (
+		createSavepoint   = "SAVEPOINT route_candidate_item_lookup"
+		rollbackSavepoint = "ROLLBACK TO SAVEPOINT route_candidate_item_lookup"
+		releaseSavepoint  = "RELEASE SAVEPOINT route_candidate_item_lookup"
+	)
+	if err := db.Exec(createSavepoint).Error; err != nil {
+		return false, fmt.Errorf("create route candidate item savepoint: %w", err)
+	}
+	if err := lookup(); err != nil {
+		if rollbackErr := db.Exec(rollbackSavepoint).Error; rollbackErr != nil {
+			return false, fmt.Errorf("load route candidate item: %v; rollback savepoint: %w", err, rollbackErr)
+		}
+		if releaseErr := db.Exec(releaseSavepoint).Error; releaseErr != nil {
+			return false, fmt.Errorf("release failed route candidate item savepoint: %w", releaseErr)
+		}
+		return false, nil
+	}
+	if err := db.Exec(releaseSavepoint).Error; err != nil {
+		return false, fmt.Errorf("release route candidate item savepoint: %w", err)
+	}
+	return true, nil
 }
 
 func routeCandidateLookupIDs(routes []ModelRoute) ([]string, []string, []string) {

--- a/backend/internal/server/store_route_candidates.go
+++ b/backend/internal/server/store_route_candidates.go
@@ -1,0 +1,182 @@
+package server
+
+import (
+	"database/sql"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const routeCandidateLookupBatchSize = 500
+
+func (s *GormStore) SelectRouteCandidates(modelName string) ([]RouteSelection, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var selections []RouteSelection
+	read := func(db *gorm.DB) error {
+		var err error
+		selections, err = s.loadRouteCandidates(db, modelName, time.Now().UTC())
+		return err
+	}
+	var err error
+	if s.dbDriver == "postgres" {
+		err = s.db.Transaction(read, &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true})
+	} else {
+		err = read(s.db)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(selections) == 0 {
+		return nil, ErrProviderMissing
+	}
+	return selections, nil
+}
+
+func (s *GormStore) loadRouteCandidates(db *gorm.DB, modelName string, now time.Time) ([]RouteSelection, error) {
+	var routes []ModelRoute
+	if err := db.Where("model_name = ? AND status = ?", modelName, StatusActive).
+		Order("priority asc, weight desc, created_at asc").
+		Find(&routes).Error; err != nil {
+		return nil, err
+	}
+
+	providerIDs, explicitResourceIDs, implicitProviderIDs := routeCandidateLookupIDs(routes)
+	providers, err := loadRouteCandidateProviders(db, providerIDs)
+	if err != nil {
+		return nil, err
+	}
+	explicitResources, err := loadRouteCandidateResourcesByID(db, explicitResourceIDs)
+	if err != nil {
+		return nil, err
+	}
+	implicitResources, err := loadRouteCandidateResourcesByProvider(db, implicitProviderIDs, now)
+	if err != nil {
+		return nil, err
+	}
+
+	selections := make([]RouteSelection, 0, len(routes))
+	for _, route := range routes {
+		provider, ok := providers[route.ProviderID]
+		if !ok || provider.Status != StatusActive || !provider.Healthy {
+			continue
+		}
+		if route.ProviderResourceID != "" {
+			resource, ok := explicitResources[route.ProviderResourceID]
+			if !ok || resource.ProviderID != provider.ID || resource.Status != StatusActive || !halfOpenEligible(resource, now) {
+				continue
+			}
+			selections = append(selections, s.routeSelection(provider, &resource, route))
+			continue
+		}
+
+		group := strings.TrimSpace(route.ResourceGroup)
+		matched := false
+		for _, resource := range implicitResources[provider.ID] {
+			if group != "" && resource.Group != group {
+				continue
+			}
+			matched = true
+			resourceRoute := route
+			resourceRoute.ProviderResourceID = resource.ID
+			if resource.Weight > 0 {
+				resourceRoute.Weight = resource.Weight
+			}
+			selections = append(selections, s.routeSelection(provider, &resource, resourceRoute))
+		}
+		if !matched {
+			selections = append(selections, s.routeSelection(provider, nil, route))
+		}
+	}
+	if err := s.attachRouteRuntimeStats(db, selections, now); err != nil {
+		return nil, err
+	}
+	return selections, nil
+}
+
+func routeCandidateLookupIDs(routes []ModelRoute) ([]string, []string, []string) {
+	providerIDs := make([]string, 0, len(routes))
+	explicitResourceIDs := make([]string, 0, len(routes))
+	implicitProviderIDs := make([]string, 0, len(routes))
+	providersSeen := make(map[string]bool, len(routes))
+	explicitSeen := make(map[string]bool, len(routes))
+	implicitSeen := make(map[string]bool, len(routes))
+	for _, route := range routes {
+		if route.ProviderID != "" && !providersSeen[route.ProviderID] {
+			providersSeen[route.ProviderID] = true
+			providerIDs = append(providerIDs, route.ProviderID)
+		}
+		if route.ProviderResourceID != "" {
+			if !explicitSeen[route.ProviderResourceID] {
+				explicitSeen[route.ProviderResourceID] = true
+				explicitResourceIDs = append(explicitResourceIDs, route.ProviderResourceID)
+			}
+			continue
+		}
+		if route.ProviderID != "" && !implicitSeen[route.ProviderID] {
+			implicitSeen[route.ProviderID] = true
+			implicitProviderIDs = append(implicitProviderIDs, route.ProviderID)
+		}
+	}
+	return providerIDs, explicitResourceIDs, implicitProviderIDs
+}
+
+func loadRouteCandidateProviders(db *gorm.DB, ids []string) (map[string]Provider, error) {
+	providers := make(map[string]Provider, len(ids))
+	err := eachRouteCandidateBatch(ids, func(batch []string) error {
+		var items []Provider
+		if err := db.Where("id IN ?", batch).Find(&items).Error; err != nil {
+			return err
+		}
+		for _, item := range items {
+			providers[item.ID] = item
+		}
+		return nil
+	})
+	return providers, err
+}
+
+func loadRouteCandidateResourcesByID(db *gorm.DB, ids []string) (map[string]ProviderResource, error) {
+	resources := make(map[string]ProviderResource, len(ids))
+	err := eachRouteCandidateBatch(ids, func(batch []string) error {
+		var items []ProviderResource
+		if err := db.Where("id IN ?", batch).Find(&items).Error; err != nil {
+			return err
+		}
+		for _, item := range items {
+			resources[item.ID] = item
+		}
+		return nil
+	})
+	return resources, err
+}
+
+func loadRouteCandidateResourcesByProvider(db *gorm.DB, providerIDs []string, now time.Time) (map[string][]ProviderResource, error) {
+	resources := make(map[string][]ProviderResource, len(providerIDs))
+	err := eachRouteCandidateBatch(providerIDs, func(batch []string) error {
+		var items []ProviderResource
+		if err := db.Where("provider_id IN ? AND status = ? AND (healthy = ? OR cooldown_until <= ?)",
+			batch, StatusActive, true, now).
+			Order("priority asc, weight desc, created_at asc, id asc").
+			Find(&items).Error; err != nil {
+			return err
+		}
+		for _, item := range items {
+			resources[item.ProviderID] = append(resources[item.ProviderID], item)
+		}
+		return nil
+	})
+	return resources, err
+}
+
+func eachRouteCandidateBatch(ids []string, load func([]string) error) error {
+	for start := 0; start < len(ids); start += routeCandidateLookupBatchSize {
+		end := min(start+routeCandidateLookupBatchSize, len(ids))
+		if err := load(ids[start:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/backend/internal/server/store_route_candidates_test.go
+++ b/backend/internal/server/store_route_candidates_test.go
@@ -1,0 +1,293 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+func TestSelectRouteCandidatesBatchesLookupQueries(t *testing.T) {
+	store := NewMemoryStore()
+	seed := func(modelName string, count int) {
+		t.Helper()
+		store.AddModel(Model{Name: modelName, Modality: "chat", Status: StatusActive})
+		providers := make([]Provider, 0, count)
+		resources := make([]ProviderResource, 0, count)
+		routes := make([]ModelRoute, 0, count)
+		for index := 0; index < count; index++ {
+			providerID := fmt.Sprintf("prv_%s_%03d", modelName, index)
+			resourceID := fmt.Sprintf("rsrc_%s_%03d", modelName, index)
+			providers = append(providers, Provider{
+				ID: providerID, Name: providerID, Type: ProviderMock,
+				Status: StatusActive, Healthy: true,
+			})
+			resources = append(resources, ProviderResource{
+				ID: resourceID, ProviderID: providerID, Name: resourceID,
+				Status: StatusActive, Healthy: true,
+			})
+			route := ModelRoute{
+				ID: fmt.Sprintf("route_%s_%03d", modelName, index), ModelName: modelName,
+				ProviderID: providerID, ProviderModel: modelName,
+				Priority: index + 1, Weight: 100, Status: StatusActive,
+			}
+			if index%2 == 0 {
+				route.ProviderResourceID = resourceID
+			}
+			routes = append(routes, route)
+		}
+		if err := store.db.CreateInBatches(&providers, 100).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := store.db.CreateInBatches(&resources, 100).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := store.db.CreateInBatches(&routes, 100).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	seed("batch-small", 2)
+	seed("batch-large", 64)
+	var small, large []RouteSelection
+	smallQueries := countStoreQueries(t, store, func() {
+		var err error
+		small, err = store.SelectRouteCandidates("batch-small")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	largeQueries := countStoreQueries(t, store, func() {
+		var err error
+		large, err = store.SelectRouteCandidates("batch-large")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	if len(small) != 2 || len(large) != 64 {
+		t.Fatalf("candidate counts = %d, %d; want 2, 64", len(small), len(large))
+	}
+	if smallQueries != 4 || largeQueries != smallQueries {
+		t.Fatalf("lookup queries = small:%d large:%d, want four for both", smallQueries, largeQueries)
+	}
+}
+
+func TestSelectRouteCandidatesChunksBatchLookups(t *testing.T) {
+	store := NewMemoryStore()
+	modelName := "chunked-route-lookups"
+	store.AddModel(Model{Name: modelName, Modality: "chat", Status: StatusActive})
+	count := routeCandidateLookupBatchSize + 1
+	providers := make([]Provider, 0, count)
+	resources := make([]ProviderResource, 0, count)
+	routes := make([]ModelRoute, 0, count)
+	for index := 0; index < count; index++ {
+		providerID := fmt.Sprintf("prv_chunk_%03d", index)
+		resourceID := fmt.Sprintf("rsrc_chunk_%03d", index)
+		providers = append(providers, Provider{
+			ID: providerID, Name: providerID, Type: ProviderMock,
+			Status: StatusActive, Healthy: true,
+		})
+		resources = append(resources, ProviderResource{
+			ID: resourceID, ProviderID: providerID, Name: resourceID,
+			Status: StatusActive, Healthy: true,
+		})
+		routes = append(routes, ModelRoute{
+			ID: fmt.Sprintf("route_chunk_%03d", index), ModelName: modelName,
+			ProviderID: providerID, ProviderResourceID: resourceID, ProviderModel: modelName,
+			Priority: index + 1, Weight: 100, Status: StatusActive,
+		})
+	}
+	if err := store.db.CreateInBatches(&providers, 100).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.CreateInBatches(&resources, 100).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.CreateInBatches(&routes, 100).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	var candidates []RouteSelection
+	queries := countStoreQueries(t, store, func() {
+		var err error
+		candidates, err = store.SelectRouteCandidates(modelName)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	if len(candidates) != count {
+		t.Fatalf("candidate count = %d, want %d", len(candidates), count)
+	}
+	if queries != 5 {
+		t.Fatalf("lookup queries = %d, want route query plus two provider and two resource batches", queries)
+	}
+}
+
+func TestSelectRouteCandidatesValidatesResourceOwnershipAndOrdersTies(t *testing.T) {
+	store := NewMemoryStore()
+	modelName := "resource-order-model"
+	store.AddModel(Model{Name: modelName, Modality: "chat", Status: StatusActive})
+	provider := store.AddProvider(Provider{
+		ID: "prv_resource_order", Name: "Resource order", Type: ProviderMock,
+		Status: StatusActive, Healthy: true,
+	})
+	foreignProvider := store.AddProvider(Provider{
+		ID: "prv_resource_foreign", Name: "Foreign resource", Type: ProviderMock,
+		Status: StatusActive, Healthy: true,
+	})
+	createdAt := time.Date(2026, time.August, 16, 0, 0, 0, 0, time.UTC)
+	resources := []ProviderResource{
+		{ID: "rsrc_z", ProviderID: provider.ID, Name: "Z", Status: StatusActive, Healthy: true, Priority: 1, Weight: 100, CreatedAt: createdAt},
+		{ID: "rsrc_a", ProviderID: provider.ID, Name: "A", Status: StatusActive, Healthy: true, Priority: 1, Weight: 100, CreatedAt: createdAt},
+		{ID: "rsrc_foreign", ProviderID: foreignProvider.ID, Name: "Foreign", Status: StatusActive, Healthy: true},
+	}
+	if err := store.db.Create(&resources).Error; err != nil {
+		t.Fatal(err)
+	}
+	routes := []ModelRoute{
+		{ID: "route_foreign", ModelName: modelName, ProviderID: provider.ID, ProviderResourceID: "rsrc_foreign", ProviderModel: modelName, Priority: 1, Weight: 100, Status: StatusActive},
+		{ID: "route_resources", ModelName: modelName, ProviderID: provider.ID, ProviderModel: modelName, Priority: 2, Weight: 100, Status: StatusActive},
+	}
+	if err := store.db.Create(&routes).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	candidates, err := store.SelectRouteCandidates(modelName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("candidate count = %d, want two owned resources", len(candidates))
+	}
+	for index, resourceID := range []string{"rsrc_a", "rsrc_z"} {
+		if candidates[index].Route.ID != "route_resources" || routeResourceID(candidates[index]) != resourceID {
+			t.Fatalf("candidate %d = route %q resource %q, want route_resources/%s",
+				index, candidates[index].Route.ID, routeResourceID(candidates[index]), resourceID)
+		}
+	}
+}
+
+func TestSelectRouteCandidatesPreservesGroupsAndProviderFallback(t *testing.T) {
+	store := NewMemoryStore()
+	modelName := "resource-group-model"
+	store.AddModel(Model{Name: modelName, Modality: "chat", Status: StatusActive})
+	provider := store.AddProvider(Provider{
+		ID: "prv_resource_group", Name: "Resource group", Type: ProviderMock,
+		Status: StatusActive, Healthy: true,
+	})
+	resources := []ProviderResource{
+		{ID: "rsrc_blue", ProviderID: provider.ID, Name: "Blue", Group: "blue", Status: StatusActive, Healthy: true},
+		{ID: "rsrc_green", ProviderID: provider.ID, Name: "Green", Group: "green", Status: StatusActive, Healthy: true},
+	}
+	if err := store.db.Create(&resources).Error; err != nil {
+		t.Fatal(err)
+	}
+	routes := []ModelRoute{
+		{ID: "route_blue", ModelName: modelName, ProviderID: provider.ID, ResourceGroup: " blue ", ProviderModel: modelName, Priority: 1, Weight: 100, Status: StatusActive},
+		{ID: "route_missing_group", ModelName: modelName, ProviderID: provider.ID, ResourceGroup: "missing", ProviderModel: modelName, Priority: 2, Weight: 100, Status: StatusActive},
+	}
+	if err := store.db.Create(&routes).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	candidates, err := store.SelectRouteCandidates(modelName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("candidate count = %d, want grouped resource plus provider fallback", len(candidates))
+	}
+	if candidates[0].Route.ID != "route_blue" || routeResourceID(candidates[0]) != "rsrc_blue" {
+		t.Fatalf("grouped candidate = %+v", candidates[0])
+	}
+	if candidates[1].Route.ID != "route_missing_group" || candidates[1].Resource != nil {
+		t.Fatalf("fallback candidate = %+v", candidates[1])
+	}
+}
+
+func TestSelectRouteCandidatesReturnsBatchLookupErrors(t *testing.T) {
+	store := NewMemoryStore()
+	modelName := "lookup-error-model"
+	store.AddModel(Model{Name: modelName, Modality: "chat", Status: StatusActive})
+	provider := store.AddProvider(Provider{
+		ID: "prv_lookup_error", Name: "Lookup error", Type: ProviderMock,
+		Status: StatusActive, Healthy: true,
+	})
+	store.AddRoute(ModelRoute{
+		ID: "route_lookup_error", ModelName: modelName, ProviderID: provider.ID,
+		ProviderModel: modelName, Priority: 1, Weight: 100, Status: StatusActive,
+	})
+
+	wantErr := errors.New("provider batch lookup failed")
+	callbackName := "test:route-candidate-query-error"
+	if err := store.db.Callback().Query().Before("gorm:query").Register(callbackName, func(tx *gorm.DB) {
+		if tx.Statement.Schema != nil && tx.Statement.Schema.Table == "providers" {
+			tx.AddError(wantErr)
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := store.db.Callback().Query().Remove(callbackName); err != nil {
+			t.Errorf("remove query callback: %v", err)
+		}
+	}()
+
+	if _, err := store.SelectRouteCandidates(modelName); !errors.Is(err, wantErr) {
+		t.Fatalf("SelectRouteCandidates error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestSelectRouteCandidatesIgnoresOptionalRuntimeStatsErrors(t *testing.T) {
+	store := NewMemoryStore()
+	modelName := "runtime-stats-error-model"
+	store.AddModel(Model{Name: modelName, Modality: "chat", Status: StatusActive})
+	provider := store.AddProvider(Provider{
+		ID: "prv_runtime_stats_error", Name: "Runtime stats error", Type: ProviderMock,
+		Status: StatusActive, Healthy: true,
+	})
+	store.AddRoute(ModelRoute{
+		ID: "route_runtime_stats_error", ModelName: modelName, ProviderID: provider.ID,
+		ProviderModel: modelName, Priority: 1, Weight: 100,
+		Status: StatusActive, Strategy: RouteStrategyAdaptive,
+	})
+
+	callbackName := "test:route-runtime-stats-error"
+	resultCallbackName := callbackName + ":result"
+	var statsQueryErr error
+	if err := store.db.Callback().Row().Before("gorm:row").Register(callbackName, func(tx *gorm.DB) {
+		if tx.Statement.Schema != nil && tx.Statement.Schema.Table == "route_attempt_logs" {
+			tx.Statement.Table = "missing_route_attempt_logs"
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.Callback().Row().After("gorm:row").Register(resultCallbackName, func(tx *gorm.DB) {
+		if tx.Statement.Schema != nil && tx.Statement.Schema.Table == "route_attempt_logs" {
+			statsQueryErr = tx.Error
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := store.db.Callback().Row().Remove(callbackName); err != nil {
+			t.Errorf("remove runtime stats error callback: %v", err)
+		}
+		if err := store.db.Callback().Row().Remove(resultCallbackName); err != nil {
+			t.Errorf("remove runtime stats result callback: %v", err)
+		}
+	}()
+
+	candidates, err := store.SelectRouteCandidates(modelName)
+	if err != nil {
+		t.Fatalf("optional runtime stats failure rejected candidates: %v", err)
+	}
+	if statsQueryErr == nil {
+		t.Fatal("runtime stats query did not reach the intended database-side failure")
+	}
+	if len(candidates) != 1 || candidates[0].Provider.ID != provider.ID || candidates[0].Runtime != (RouteRuntimeStats{}) {
+		t.Fatalf("candidates after optional runtime stats failure = %+v", candidates)
+	}
+}

--- a/backend/internal/server/store_route_candidates_test.go
+++ b/backend/internal/server/store_route_candidates_test.go
@@ -207,36 +207,76 @@ func TestSelectRouteCandidatesPreservesGroupsAndProviderFallback(t *testing.T) {
 	}
 }
 
-func TestSelectRouteCandidatesReturnsBatchLookupErrors(t *testing.T) {
-	store := NewMemoryStore()
-	modelName := "lookup-error-model"
-	store.AddModel(Model{Name: modelName, Modality: "chat", Status: StatusActive})
-	provider := store.AddProvider(Provider{
-		ID: "prv_lookup_error", Name: "Lookup error", Type: ProviderMock,
-		Status: StatusActive, Healthy: true,
-	})
-	store.AddRoute(ModelRoute{
-		ID: "route_lookup_error", ModelName: modelName, ProviderID: provider.ID,
-		ProviderModel: modelName, Priority: 1, Weight: 100, Status: StatusActive,
-	})
+func TestSelectRouteCandidatesFallsBackAfterBatchLookupErrors(t *testing.T) {
+	for _, target := range []string{"providers", "provider_resources"} {
+		t.Run(target, func(t *testing.T) {
+			store := NewMemoryStore()
+			modelName := "lookup-error-" + target
+			store.AddModel(Model{Name: modelName, Modality: "chat", Status: StatusActive})
+			badProvider := store.AddProvider(Provider{
+				ID: "prv_lookup_error_bad_" + target, Name: "Lookup error bad", Type: ProviderMock,
+				Status: StatusActive, Healthy: true,
+			})
+			goodProvider := store.AddProvider(Provider{
+				ID: "prv_lookup_error_good_" + target, Name: "Lookup error good", Type: ProviderMock,
+				Status: StatusActive, Healthy: true,
+			})
+			badResource, err := store.AddProviderResource(ProviderResource{
+				ID: "rsrc_lookup_error_bad_" + target, ProviderID: badProvider.ID,
+				Name: "Lookup error bad", Status: StatusActive, Healthy: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			goodResource, err := store.AddProviderResource(ProviderResource{
+				ID: "rsrc_lookup_error_good_" + target, ProviderID: goodProvider.ID,
+				Name: "Lookup error good", Status: StatusActive, Healthy: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for index, route := range []ModelRoute{
+				{ID: "route_lookup_error_bad_" + target, ProviderID: badProvider.ID, ProviderResourceID: badResource.ID},
+				{ID: "route_lookup_error_good_" + target, ProviderID: goodProvider.ID, ProviderResourceID: goodResource.ID},
+			} {
+				route.ModelName = modelName
+				route.ProviderModel = modelName
+				route.Priority = index + 1
+				route.Weight = 100
+				route.Status = StatusActive
+				store.AddRoute(route)
+			}
 
-	wantErr := errors.New("provider batch lookup failed")
-	callbackName := "test:route-candidate-query-error"
-	if err := store.db.Callback().Query().Before("gorm:query").Register(callbackName, func(tx *gorm.DB) {
-		if tx.Statement.Schema != nil && tx.Statement.Schema.Table == "providers" {
-			tx.AddError(wantErr)
-		}
-	}); err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := store.db.Callback().Query().Remove(callbackName); err != nil {
-			t.Errorf("remove query callback: %v", err)
-		}
-	}()
+			wantErr := errors.New(target + " lookup failed")
+			attempts := 0
+			callbackName := "test:route-candidate-query-error:" + target
+			if err := store.db.Callback().Query().Before("gorm:query").Register(callbackName, func(tx *gorm.DB) {
+				if tx.Statement.Schema != nil && tx.Statement.Schema.Table == target {
+					attempts++
+					if attempts <= 2 {
+						_ = tx.AddError(wantErr)
+					}
+				}
+			}); err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				if err := store.db.Callback().Query().Remove(callbackName); err != nil {
+					t.Errorf("remove query callback: %v", err)
+				}
+			}()
 
-	if _, err := store.SelectRouteCandidates(modelName); !errors.Is(err, wantErr) {
-		t.Fatalf("SelectRouteCandidates error = %v, want %v", err, wantErr)
+			candidates, err := store.SelectRouteCandidates(modelName)
+			if err != nil {
+				t.Fatalf("SelectRouteCandidates returned batch lookup error: %v", err)
+			}
+			if attempts != 3 {
+				t.Fatalf("%s lookup attempts = %d, want batch plus two individual attempts", target, attempts)
+			}
+			if len(candidates) != 1 || candidates[0].Route.ID != "route_lookup_error_good_"+target {
+				t.Fatalf("fallback candidates = %+v, want the unaffected route", candidates)
+			}
+		})
 	}
 }
 

--- a/backend/internal/server/store_routing_calls.go
+++ b/backend/internal/server/store_routing_calls.go
@@ -300,72 +300,6 @@ func (s *GormStore) SelectRoute(modelName string) (RouteSelection, error) {
 	return routes[0], nil
 }
 
-func (s *GormStore) SelectRouteCandidates(modelName string) ([]RouteSelection, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	var routes []ModelRoute
-	if err := s.db.Where("model_name = ? AND status = ?", modelName, StatusActive).
-		Order("priority asc, weight desc, created_at asc").
-		Find(&routes).Error; err != nil {
-		return nil, err
-	}
-	now := time.Now().UTC()
-	selections := make([]RouteSelection, 0, len(routes))
-	for _, route := range routes {
-		var provider Provider
-		if err := s.db.First(&provider, "id = ?", route.ProviderID).Error; err != nil {
-			continue
-		}
-		if provider.Status != StatusActive || !provider.Healthy {
-			continue
-		}
-		if route.ProviderResourceID != "" {
-			var resource ProviderResource
-			if err := s.db.First(&resource, "id = ? AND provider_id = ?", route.ProviderResourceID, provider.ID).Error; err != nil {
-				continue
-			}
-			if resource.Status != StatusActive || !halfOpenEligible(resource, now) {
-				continue
-			}
-			selections = append(selections, s.routeSelection(provider, &resource, route))
-			continue
-		}
-
-		var resources []ProviderResource
-		// Unhealthy resources whose cooldown has lapsed are admitted as half-open
-		// candidates. Admission still gates them to a single trial (see
-		// CheckProviderResourceCapacity); this query only makes them reachable, which
-		// is what lets a parked resource ever be retried.
-		query := s.db.Where("provider_id = ? AND status = ? AND (healthy = ? OR cooldown_until <= ?)",
-			provider.ID, StatusActive, true, now)
-		if strings.TrimSpace(route.ResourceGroup) != "" {
-			query = query.Where("\"group\" = ?", strings.TrimSpace(route.ResourceGroup))
-		}
-		if err := query.Order("priority asc, weight desc, created_at asc").
-			Find(&resources).Error; err != nil {
-			return nil, err
-		}
-		if len(resources) == 0 {
-			selections = append(selections, s.routeSelection(provider, nil, route))
-			continue
-		}
-		for _, resource := range resources {
-			resourceRoute := route
-			resourceRoute.ProviderResourceID = resource.ID
-			if resource.Weight > 0 {
-				resourceRoute.Weight = resource.Weight
-			}
-			selections = append(selections, s.routeSelection(provider, &resource, resourceRoute))
-		}
-	}
-	s.attachRouteRuntimeStats(selections, now)
-	if len(selections) == 0 {
-		return nil, ErrProviderMissing
-	}
-	return selections, nil
-}
-
 type routeRuntimeStatsRow struct {
 	RouteID            string
 	ProviderResourceID string
@@ -374,7 +308,7 @@ type routeRuntimeStatsRow struct {
 	LatencyMS          float64
 }
 
-func (s *GormStore) attachRouteRuntimeStats(selections []RouteSelection, now time.Time) {
+func (s *GormStore) attachRouteRuntimeStats(db *gorm.DB, selections []RouteSelection, now time.Time) error {
 	routeIDs := make([]string, 0, len(selections))
 	seen := map[string]bool{}
 	for _, selection := range selections {
@@ -385,11 +319,21 @@ func (s *GormStore) attachRouteRuntimeStats(selections []RouteSelection, now tim
 		routeIDs = append(routeIDs, selection.Route.ID)
 	}
 	if len(routeIDs) == 0 {
-		return
+		return nil
+	}
+
+	const (
+		createSavepoint   = "SAVEPOINT route_candidate_runtime_stats"
+		rollbackSavepoint = "ROLLBACK TO SAVEPOINT route_candidate_runtime_stats"
+	)
+	if s.dbDriver == "postgres" {
+		if err := db.Exec(createSavepoint).Error; err != nil {
+			return fmt.Errorf("create adaptive routing stats savepoint: %w", err)
+		}
 	}
 
 	var rows []routeRuntimeStatsRow
-	err := s.db.Model(&RouteAttemptLog{}).
+	err := db.Model(&RouteAttemptLog{}).
 		Select(`route_id, provider_resource_id, COUNT(*) AS samples,
 			SUM(CASE WHEN status_code >= 200 AND status_code < 400 THEN 1 ELSE 0 END) AS successes,
 			COALESCE(AVG(CASE WHEN status_code >= 200 AND status_code < 400 THEN latency_ms ELSE NULL END), 0) AS latency_ms`).
@@ -397,8 +341,13 @@ func (s *GormStore) attachRouteRuntimeStats(selections []RouteSelection, now tim
 		Group("route_id, provider_resource_id").
 		Scan(&rows).Error
 	if err != nil {
+		if s.dbDriver == "postgres" {
+			if rollbackErr := db.Exec(rollbackSavepoint).Error; rollbackErr != nil {
+				return fmt.Errorf("load adaptive routing observations: %v; rollback savepoint: %w", err, rollbackErr)
+			}
+		}
 		log.Printf("[tokenhub] failed to load adaptive routing observations: %v", err)
-		return
+		return nil
 	}
 	stats := make(map[string]RouteRuntimeStats, len(rows))
 	for _, row := range rows {
@@ -416,6 +365,7 @@ func (s *GormStore) attachRouteRuntimeStats(selections []RouteSelection, now tim
 		selection := &selections[index]
 		selection.Runtime = stats[routeRuntimeStatsKey(selection.Route.ID, routeResourceID(*selection))]
 	}
+	return nil
 }
 
 func routeRuntimeStatsKey(routeID string, resourceID string) string {


### PR DESCRIPTION
## Summary

Eliminate the `SelectRouteCandidates` provider and resource N+1 queries while preserving routing behavior and PostgreSQL read consistency.

## Related Issue

N/A.

## Changes

- Batch provider, explicit-resource, and implicit-resource lookups with bounded 500-ID `IN` query chunks.
- Preserve outer route order, validate explicit resource ownership, and define resource tie-breaking as `priority ASC, weight DESC, created_at ASC, id ASC`.
- Read PostgreSQL route candidates in a read-only repeatable-read transaction.
- Keep optional adaptive runtime-stat failures best-effort by rolling back the failed observation query to a savepoint.
- Add query-count, chunking, ordering, ownership, fallback, error-path, race, and PostgreSQL multi-instance regression coverage.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `gofmt` on all changed Go files.
- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/server -run '^TestSelectRouteCandidates' -count=1`
- `node --test tools/*.test.mjs` (122 tests)
- `node tools/check-doc-translations.mjs`
- `node tools/check-ui-translations.mjs`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- `git diff --check`
- PostgreSQL multi-instance tests compiled locally but were skipped because `TEST_POSTGRES_URL` was not configured; the new subtests are included in the existing CI PostgreSQL suite.
- `golangci-lint` was not run because it is unavailable in the local environment.

## Compatibility, Security, and Operations

No public API, persistence schema, configuration, deployment, or user-visible behavior changes. Explicit resource ownership validation prevents a route from selecting a resource belonging to another provider. The change can be rolled back by reverting this PR.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
