### PR TITLE
perf(server): push usage summary aggregation into SQL

### DIFF
--- a/backend/internal/server/admin_authorization.go
+++ b/backend/internal/server/admin_authorization.go
@@ -269,12 +269,6 @@ func (s *Server) linkProjectQuotaPolicy(quota AdminResource, payload map[string]
 	return err
 }
 
-func (s *Server) usageSummaryForUser(user AdminUser) map[string]any {
-	records := s.filterUsageRecordsForUser(user, s.store.ListUsageRecords())
-	logs := s.filterRequestLogsForUser(user, s.store.ListRequestLogs())
-	return summarizeUsage(records, logs)
-}
-
 func (s *Server) usageBreakdownForUser(user AdminUser) map[string]any {
 	records := s.filterUsageRecordsForUser(user, s.store.ListUsageRecords())
 	projectsByID := indexProjectsByID(s.store.ListProjects())

--- a/backend/internal/server/admin_operations_http.go
+++ b/backend/internal/server/admin_operations_http.go
@@ -679,7 +679,12 @@ func (s *Server) handleAdminUsageSummary(w http.ResponseWriter, r *http.Request)
 	if !ok {
 		return
 	}
-	writeJSON(w, http.StatusOK, s.usageSummaryForUser(user))
+	summary, err := s.usageSummaryForUser(r.Context(), user)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, summary)
 }
 
 func (s *Server) handleAdminUsageBreakdown(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/server/admin_projects_http.go
+++ b/backend/internal/server/admin_projects_http.go
@@ -54,7 +54,11 @@ func (s *Server) handleAdminOverview(w http.ResponseWriter, r *http.Request) {
 			activeRoutes++
 		}
 	}
-	summary := s.usageSummaryForUser(user)
+	summary, err := s.usageSummaryForUser(r.Context(), user)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
 	summary["api_key_count"] = len(s.filterAPIKeysForUser(user, s.store.ListAPIKeys()))
 	summary["route_count"] = len(routes)
 	summary["active_route_count"] = activeRoutes

--- a/backend/internal/server/admin_usage_summary.go
+++ b/backend/internal/server/admin_usage_summary.go
@@ -1,0 +1,62 @@
+package server
+
+import "context"
+
+func (s *Server) usageSummaryForUser(ctx context.Context, user AdminUser) (map[string]any, error) {
+	summary, err := s.store.QueryUsageSummary(ctx, s.usageSummaryQueryForUser(user))
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"request_count":            summary.RequestCount,
+		"usage_record_count":       summary.UsageRecordCount,
+		"input_tokens":             summary.InputTokens,
+		"cached_input_tokens":      summary.CachedInputTokens,
+		"cache_write_input_tokens": summary.CacheWriteTokens,
+		"output_tokens":            summary.OutputTokens,
+		"reasoning_output_tokens":  summary.ReasoningTokens,
+		"total_tokens":             summary.TotalTokens,
+		"estimated_cost_usd":       summary.EstimatedCostUSD,
+		"errors":                   summary.Errors,
+	}, nil
+}
+
+func (s *Server) usageSummaryQueryForUser(user AdminUser) UsageSummaryQuery {
+	if s.canViewGlobalOperations(user) {
+		global := UsageSummaryScope{Global: true}
+		return UsageSummaryQuery{UsageRecords: global, RequestLogs: global}
+	}
+
+	apiKeyIDs := trueMapKeys(s.visibleAPIKeyIDSet(user))
+	usageScope := UsageSummaryScope{
+		AttributedUserIDs: usageAttributedUserIDs(user, s.store.ListAdminUsers()),
+		APIKeyIDs:         apiKeyIDs,
+	}
+	requestScope := UsageSummaryScope{APIKeyIDs: apiKeyIDs}
+	if normalizeAdminRole(user.Role) == "team_leader" {
+		projectIDs := trueMapKeys(s.visibleProjectIDSet(user))
+		usageScope.ProjectIDs = projectIDs
+		requestScope.ProjectIDs = projectIDs
+	}
+	return UsageSummaryQuery{UsageRecords: usageScope, RequestLogs: requestScope}
+}
+
+func usageAttributedUserIDs(user AdminUser, users []AdminUser) []string {
+	if normalizeAdminRole(user.Role) != "team_leader" {
+		if user.ID == "" {
+			return nil
+		}
+		return []string{user.ID}
+	}
+	usersByID := make(map[string]AdminUser, len(users))
+	for _, item := range users {
+		usersByID[item.ID] = item
+	}
+	ids := make([]string, 0, len(users))
+	for _, item := range users {
+		if canAttributeUsageToMember(user, usersByID, item.ID) {
+			ids = append(ids, item.ID)
+		}
+	}
+	return ids
+}

--- a/backend/internal/server/admin_usage_summary_test.go
+++ b/backend/internal/server/admin_usage_summary_test.go
@@ -1,10 +1,17 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 func TestAdminUsageSummaryIncludesCacheWriteAndReasoningTokens(t *testing.T) {
@@ -51,5 +58,361 @@ func TestAdminUsageSummaryIncludesCacheWriteAndReasoningTokens(t *testing.T) {
 		if value != expected {
 			t.Fatalf("usage summary %q = %v, want %v", key, value, expected)
 		}
+	}
+}
+
+func TestUsageSummarySQLMatchesLegacyPermissions(t *testing.T) {
+	store := NewMemoryStore()
+	for _, teamID := range []string{"team_summary_a", "team_summary_b"} {
+		store.CreateResource("teams", AdminResource{ID: teamID, Name: teamID, Status: StatusActive})
+	}
+	admin := createUsageSummaryUser(t, store, AdminUser{ID: "usr_summary_admin", Role: "admin"})
+	security := createUsageSummaryUser(t, store, AdminUser{ID: "usr_summary_security", Role: "security_admin"})
+	leader := createUsageSummaryUser(t, store, AdminUser{ID: "usr_summary_leader", Role: "team_leader", TeamID: "team_summary_a"})
+	member := createUsageSummaryUser(t, store, AdminUser{ID: "usr_summary_member", Role: "user", TeamID: "team_summary_a"})
+	additionalTeamMember := createUsageSummaryUser(t, store, AdminUser{
+		ID: "usr_summary_additional_member", Role: "user", TeamID: "team_summary_b", TeamIDs: []string{"team_summary_a"},
+	})
+	user := createUsageSummaryUser(t, store, AdminUser{ID: "usr_summary_user", Role: "user"})
+	other := createUsageSummaryUser(t, store, AdminUser{ID: "usr_summary_other", Role: "user", TeamID: "team_summary_b"})
+
+	teamProject := store.CreateProject(Project{ID: "prj_summary_team", Name: "Team Summary", TeamID: leader.TeamID})
+	sharedProject := store.CreateProject(Project{ID: "prj_summary_shared", Name: "Shared Summary", OwnerUserID: other.ID})
+	otherProject := store.CreateProject(Project{ID: "prj_summary_other", Name: "Other Summary", TeamID: other.TeamID})
+	store.CreateResource("project-members", AdminResource{
+		ID: "member_summary_user_viewer", Name: "Summary User Viewer", Status: StatusActive,
+		Fields: map[string]any{"project_id": sharedProject.ID, "user_id": user.ID, "role": "viewer"},
+	})
+
+	userKey := createUsageSummaryKey(t, store, APIKey{ID: "key_summary_user", ProjectID: sharedProject.ID, OwnerUserID: user.ID})
+	sharedOtherKey := createUsageSummaryKey(t, store, APIKey{ID: "key_summary_shared_other", ProjectID: sharedProject.ID, OwnerUserID: other.ID})
+	teamKey := createUsageSummaryKey(t, store, APIKey{ID: "key_summary_team", ProjectID: teamProject.ID, OwnerUserID: member.ID})
+	otherKey := createUsageSummaryKey(t, store, APIKey{ID: "key_summary_other", ProjectID: otherProject.ID, OwnerUserID: other.ID})
+
+	now := time.Date(2026, time.August, 16, 12, 0, 0, 0, time.UTC)
+	records := []UsageRecord{
+		usageSummaryRecord("usage_summary_user_attr", otherProject.ID, otherKey.ID, user.ID, 10, now),
+		usageSummaryRecord("usage_summary_user_key", sharedProject.ID, userKey.ID, "", 20, now),
+		usageSummaryRecord("usage_summary_shared_other", sharedProject.ID, sharedOtherKey.ID, "", 30, now),
+		usageSummaryRecord("usage_summary_team_missing_key", teamProject.ID, "key_summary_deleted", "", 40, now),
+		usageSummaryRecord("usage_summary_team_member_attr", otherProject.ID, otherKey.ID, member.ID, 50, now),
+		usageSummaryRecord("usage_summary_team_overlap", teamProject.ID, teamKey.ID, additionalTeamMember.ID, 60, now),
+		usageSummaryRecord("usage_summary_other", otherProject.ID, otherKey.ID, other.ID, 70, now),
+		usageSummaryRecord("usage_summary_empty_scope", "", "", "", 80, now),
+	}
+	if err := store.db.Create(&records).Error; err != nil {
+		t.Fatal(err)
+	}
+	logs := []RequestLog{
+		usageSummaryLog("log_summary_user_key", sharedProject.ID, userKey.ID, "", http.StatusOK, now),
+		usageSummaryLog("log_summary_user_attr", otherProject.ID, otherKey.ID, user.ID, http.StatusBadGateway, now),
+		usageSummaryLog("log_summary_shared_other", sharedProject.ID, sharedOtherKey.ID, "", http.StatusBadGateway, now),
+		usageSummaryLog("log_summary_team_missing_key", teamProject.ID, "key_summary_deleted", "", http.StatusBadGateway, now),
+		usageSummaryLog("log_summary_team_member_attr", otherProject.ID, otherKey.ID, member.ID, http.StatusBadGateway, now),
+		usageSummaryLog("log_summary_team_overlap", teamProject.ID, teamKey.ID, additionalTeamMember.ID, http.StatusOK, now),
+		usageSummaryLog("log_summary_other", otherProject.ID, otherKey.ID, other.ID, http.StatusBadGateway, now),
+		usageSummaryLog("log_summary_empty_scope", "", "", "", http.StatusBadGateway, now),
+		usageSummaryLog("log_summary_playground", "admin_playground", userKey.ID, user.ID, http.StatusBadGateway, now),
+	}
+	if err := store.db.Create(&logs).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	server := New(store)
+	tests := []struct {
+		name              string
+		user              AdminUser
+		wantUsageRecords  int64
+		wantRequestCount  int64
+		wantRequestErrors int64
+	}{
+		{name: "admin", user: admin, wantUsageRecords: 8, wantRequestCount: 8, wantRequestErrors: 6},
+		{name: "security admin", user: security, wantUsageRecords: 8, wantRequestCount: 8, wantRequestErrors: 6},
+		{name: "team leader", user: leader, wantUsageRecords: 3, wantRequestCount: 2, wantRequestErrors: 1},
+		{name: "user", user: user, wantUsageRecords: 2, wantRequestCount: 1, wantRequestErrors: 0},
+		{name: "no visible records", user: AdminUser{ID: "usr_summary_nobody", Role: "user"}, wantUsageRecords: 0, wantRequestCount: 0, wantRequestErrors: 0},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			legacy := summarizeUsage(
+				server.filterUsageRecordsForUser(test.user, store.ListUsageRecords()),
+				server.filterRequestLogsForUser(test.user, store.ListRequestLogs()),
+			)
+			actual, err := server.usageSummaryForUser(t.Context(), test.user)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertUsageSummaryEqual(t, actual, legacy)
+			if got := int64(usageSummaryNumber(t, actual["usage_record_count"])); got != test.wantUsageRecords {
+				t.Fatalf("usage_record_count = %d, want %d", got, test.wantUsageRecords)
+			}
+			if got := int64(usageSummaryNumber(t, actual["request_count"])); got != test.wantRequestCount {
+				t.Fatalf("request_count = %d, want %d", got, test.wantRequestCount)
+			}
+			if got := int64(usageSummaryNumber(t, actual["errors"])); got != test.wantRequestErrors {
+				t.Fatalf("errors = %d, want %d", got, test.wantRequestErrors)
+			}
+		})
+	}
+}
+
+func TestQueryUsageSummaryEmptyScopesReturnZero(t *testing.T) {
+	store := NewMemoryStore()
+	if err := store.db.Create(&UsageRecord{ID: "usage_summary_hidden", InputTokens: 10, CreatedAt: time.Now().UTC()}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.Create(&RequestLog{ID: "log_summary_hidden", StatusCode: http.StatusBadGateway, CreatedAt: time.Now().UTC()}).Error; err != nil {
+		t.Fatal(err)
+	}
+	summary, err := store.QueryUsageSummary(t.Context(), UsageSummaryQuery{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary != (UsageSummary{}) {
+		t.Fatalf("empty scopes returned %+v, want zero summary", summary)
+	}
+}
+
+func TestQueryUsageSummaryAcceptsLargePermissionScopes(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Now().UTC()
+	if err := store.db.Create(&UsageRecord{
+		ID: "usage_summary_large_scope", AttributedUserID: "usr_large_match", ProjectID: "prj_large_match",
+		APIKeyID: "key_large_match", InputTokens: 10, CreatedAt: now,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.Create(&RequestLog{
+		ID: "log_summary_large_scope", ProjectID: "prj_large_match", APIKeyID: "key_large_match",
+		StatusCode: http.StatusBadGateway, CreatedAt: now,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	const scopeSize = 33000
+	ids := make([]string, scopeSize)
+	for index := range ids {
+		ids[index] = fmt.Sprintf("scope_%d", index)
+	}
+	ids[scopeSize-3] = "usr_large_match"
+	ids[scopeSize-2] = "prj_large_match"
+	ids[scopeSize-1] = "key_large_match"
+	summary, err := store.QueryUsageSummary(t.Context(), UsageSummaryQuery{
+		UsageRecords: UsageSummaryScope{AttributedUserIDs: ids, ProjectIDs: ids, APIKeyIDs: ids},
+		RequestLogs:  UsageSummaryScope{ProjectIDs: ids, APIKeyIDs: ids},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.UsageRecordCount != 1 || summary.RequestCount != 1 || summary.Errors != 1 || summary.InputTokens != 10 {
+		t.Fatalf("large permission scope summary = %+v", summary)
+	}
+}
+
+func TestBackfillUsageRecordAttributionNormalization(t *testing.T) {
+	store := NewMemoryStore()
+	if err := store.db.Delete(&ClusterTaskState{}, "name = ?", usageAttributionNormalizationTask).Error; err != nil {
+		t.Fatal(err)
+	}
+	rawAttribution := "\t\u00a0usr_backfill_summary\u3000\n"
+	if err := store.db.Exec(
+		"INSERT INTO usage_records (id, attributed_user_id, input_tokens, created_at) VALUES (?, ?, ?, ?)",
+		"usage_summary_backfill", rawAttribution, 17, time.Now().UTC(),
+	).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := backfillUsageRecordAttributionNormalization(store.db); err != nil {
+		t.Fatal(err)
+	}
+	var record UsageRecord
+	if err := store.db.First(&record, "id = ?", "usage_summary_backfill").Error; err != nil {
+		t.Fatal(err)
+	}
+	if record.AttributedUserID != "usr_backfill_summary" {
+		t.Fatalf("normalized attribution = %q", record.AttributedUserID)
+	}
+	summary, err := store.QueryUsageSummary(t.Context(), UsageSummaryQuery{
+		UsageRecords: UsageSummaryScope{AttributedUserIDs: []string{"usr_backfill_summary"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.UsageRecordCount != 1 || summary.InputTokens != 17 {
+		t.Fatalf("backfilled attribution summary = %+v", summary)
+	}
+	queries := countStoreQueries(t, store, func() {
+		if err := backfillUsageRecordAttributionNormalization(store.db); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if queries != 1 {
+		t.Fatalf("completed normalization issued %d queries, want only the task-state lookup", queries)
+	}
+}
+
+func TestUsageSummarySQLiteQueryUsesScopeIndexes(t *testing.T) {
+	store := NewMemoryStore()
+	dryDB := store.db.Session(&gorm.Session{DryRun: true})
+	scoped, err := applyUsageSummaryScope(dryDB.Model(&UsageRecord{}), store.dbDriver, UsageSummaryScope{
+		AttributedUserIDs: []string{"usr_plan"},
+		ProjectIDs:        []string{"prj_plan"},
+		APIKeyIDs:         []string{"key_plan"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var aggregate struct{ Count int64 }
+	statement := scoped.Select("COUNT(*) AS count").Find(&aggregate).Statement
+	if statement.SQL.Len() == 0 {
+		t.Fatal("dry-run summary query did not produce SQL")
+	}
+	var plan []struct{ Detail string }
+	if err := store.db.Raw("EXPLAIN QUERY PLAN "+statement.SQL.String(), statement.Vars...).Scan(&plan).Error; err != nil {
+		t.Fatal(err)
+	}
+	details := make([]string, 0, len(plan))
+	for _, row := range plan {
+		details = append(details, row.Detail)
+	}
+	joined := strings.Join(details, "\n")
+	if strings.Contains(joined, "SCAN usage_records") {
+		t.Fatalf("scoped summary query scans usage history instead of using indexes:\n%s", joined)
+	}
+	for _, indexName := range []string{
+		"idx_usage_records_attributed_user_id",
+		"idx_usage_records_project_id",
+		"idx_usage_records_api_key_id",
+	} {
+		if !strings.Contains(joined, indexName) {
+			t.Fatalf("query plan does not use %s:\n%s", indexName, joined)
+		}
+	}
+}
+
+func TestUsageSummaryHandlersReportQueryFailure(t *testing.T) {
+	store := NewMemoryStore()
+	app := New(failingUsageSummaryStore{Store: store}).Handler()
+	for _, path := range []string{"/api/admin/usage/summary", "/api/admin/overview"} {
+		t.Run(path, func(t *testing.T) {
+			response := doJSON(t, app, http.MethodGet, path, nil, "")
+			if response.Code != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want 500: %s", response.Code, response.Body)
+			}
+		})
+	}
+}
+
+func BenchmarkUsageSummaryAggregation(b *testing.B) {
+	store := NewMemoryStore()
+	sqlDB, err := store.db.DB()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = sqlDB.Close() })
+	now := time.Date(2026, time.August, 16, 12, 0, 0, 0, time.UTC)
+	const historySize = 5000
+	records := make([]UsageRecord, historySize)
+	logs := make([]RequestLog, historySize)
+	for index := 0; index < historySize; index++ {
+		records[index] = usageSummaryRecord(fmt.Sprintf("usage_bench_%d", index), "prj_bench", "key_bench", "usr_bench", int64(index%100), now)
+		logs[index] = usageSummaryLog(fmt.Sprintf("log_bench_%d", index), "prj_bench", "key_bench", "usr_bench", http.StatusOK, now)
+	}
+	if err := store.db.CreateInBatches(&records, 100).Error; err != nil {
+		b.Fatal(err)
+	}
+	if err := store.db.CreateInBatches(&logs, 100).Error; err != nil {
+		b.Fatal(err)
+	}
+	query := UsageSummaryQuery{
+		UsageRecords: UsageSummaryScope{Global: true},
+		RequestLogs:  UsageSummaryScope{Global: true},
+	}
+	b.Run("sql_aggregate", func(b *testing.B) {
+		b.ReportAllocs()
+		for index := 0; index < b.N; index++ {
+			if _, err := store.QueryUsageSummary(b.Context(), query); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("legacy_in_memory", func(b *testing.B) {
+		b.ReportAllocs()
+		for index := 0; index < b.N; index++ {
+			_ = summarizeUsage(store.ListUsageRecords(), store.ListRequestLogs())
+		}
+	})
+}
+
+type failingUsageSummaryStore struct {
+	Store
+}
+
+func (failingUsageSummaryStore) QueryUsageSummary(context.Context, UsageSummaryQuery) (UsageSummary, error) {
+	return UsageSummary{}, errors.New("forced usage summary failure")
+}
+
+func createUsageSummaryUser(t *testing.T, store *GormStore, user AdminUser) AdminUser {
+	t.Helper()
+	user.Username = user.ID
+	user.Email = user.ID + "@tokenhub.local"
+	user.Status = StatusActive
+	created, err := store.CreateAdminUser(user, "summary123456")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return created
+}
+
+func createUsageSummaryKey(t *testing.T, store *GormStore, key APIKey) APIKey {
+	t.Helper()
+	key.Name = key.ID
+	key.Status = StatusActive
+	created, _, err := store.CreateAPIKey(key.ProjectID, key, "thk_"+key.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return created
+}
+
+func usageSummaryRecord(id string, projectID string, apiKeyID string, attributedUserID string, base int64, createdAt time.Time) UsageRecord {
+	return UsageRecord{
+		ID: id, RequestID: "req_" + id, ProjectID: projectID, APIKeyID: apiKeyID, AttributedUserID: attributedUserID,
+		InputTokens: base, CachedInputTokens: base + 1, CacheWriteTokens: base + 2, OutputTokens: base + 3,
+		ReasoningTokens: base + 4, TotalTokens: base + 5, CostUSD: float64(base) / 100, CreatedAt: createdAt,
+	}
+}
+
+func usageSummaryLog(id string, projectID string, apiKeyID string, attributedUserID string, statusCode int, createdAt time.Time) RequestLog {
+	return RequestLog{
+		ID: id, RequestID: "req_" + id, ProjectID: projectID, APIKeyID: apiKeyID,
+		AttributedUserID: attributedUserID, StatusCode: statusCode, CreatedAt: createdAt,
+	}
+}
+
+func assertUsageSummaryEqual(t *testing.T, actual map[string]any, expected map[string]any) {
+	t.Helper()
+	for _, key := range []string{
+		"request_count", "usage_record_count", "input_tokens", "cached_input_tokens", "cache_write_input_tokens",
+		"output_tokens", "reasoning_output_tokens", "total_tokens", "estimated_cost_usd", "errors",
+	} {
+		actualNumber := usageSummaryNumber(t, actual[key])
+		expectedNumber := usageSummaryNumber(t, expected[key])
+		if math.Abs(actualNumber-expectedNumber) > 1e-12 {
+			t.Fatalf("%s = %v, want %v", key, actual[key], expected[key])
+		}
+	}
+}
+
+func usageSummaryNumber(t *testing.T, value any) float64 {
+	t.Helper()
+	switch number := value.(type) {
+	case int:
+		return float64(number)
+	case int64:
+		return float64(number)
+	case float64:
+		return number
+	default:
+		t.Fatalf("summary value %#v has unsupported type %T", value, value)
+		return 0
 	}
 }

--- a/backend/internal/server/store.go
+++ b/backend/internal/server/store.go
@@ -199,6 +199,7 @@ type Store interface {
 	ListImageAssets(jobID string) []ImageAsset
 	GetImageAsset(id string) (ImageAsset, bool)
 	ListUsageRecords() []UsageRecord
+	QueryUsageSummary(ctx context.Context, query UsageSummaryQuery) (UsageSummary, error)
 	CreateAnalyticsCredential(credential AnalyticsCredential, rawSecret string) (AnalyticsCredential, string, error)
 	ListAnalyticsCredentials() []AnalyticsCredential
 	RevokeAnalyticsCredential(id string) (AnalyticsCredential, error)

--- a/backend/internal/server/store_database.go
+++ b/backend/internal/server/store_database.go
@@ -264,6 +264,9 @@ func NewStoreWithDialect(databaseURL string, config Config) (*GormStore, error) 
 		if err := backfillTeamRelationships(db); err != nil {
 			return err
 		}
+		if err := backfillUsageRecordAttributionNormalization(db); err != nil {
+			return err
+		}
 		if err := backfillRequestLogAttribution(db, driver); err != nil {
 			return err
 		}
@@ -531,6 +534,84 @@ UPDATE request_logs
 		}
 		return nil
 	})
+}
+
+const (
+	usageAttributionNormalizationTask     = "schema:normalize-usage-attribution"
+	usageAttributionNormalizationRevision = 1
+	usageAttributionNormalizationBatch    = 200
+)
+
+type usageAttributionNormalizationRecord struct {
+	ID               string
+	AttributedUserID string
+}
+
+func backfillUsageRecordAttributionNormalization(db *gorm.DB) error {
+	var state ClusterTaskState
+	err := db.First(&state, "name = ?", usageAttributionNormalizationTask).Error
+	if err == nil && state.Revision >= usageAttributionNormalizationRevision {
+		return nil
+	}
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+
+	cursor := ""
+	for {
+		var records []usageAttributionNormalizationRecord
+		query := db.Table("usage_records").Select("id", "attributed_user_id").Order("id ASC").Limit(usageAttributionNormalizationBatch)
+		if cursor != "" {
+			query = query.Where("id > ?", cursor)
+		}
+		if err := query.Scan(&records).Error; err != nil {
+			return fmt.Errorf("scan usage attribution normalization batch: %w", err)
+		}
+		if len(records) == 0 {
+			break
+		}
+		cursor = records[len(records)-1].ID
+		if err := normalizeUsageRecordAttributionBatch(db, records); err != nil {
+			return err
+		}
+		if len(records) < usageAttributionNormalizationBatch {
+			break
+		}
+	}
+
+	state = ClusterTaskState{
+		Name:        usageAttributionNormalizationTask,
+		Revision:    usageAttributionNormalizationRevision,
+		CompletedAt: time.Now().UTC(),
+	}
+	if err := db.Clauses(clause.OnConflict{UpdateAll: true}).Create(&state).Error; err != nil {
+		return fmt.Errorf("record usage attribution normalization: %w", err)
+	}
+	return nil
+}
+
+func normalizeUsageRecordAttributionBatch(db *gorm.DB, records []usageAttributionNormalizationRecord) error {
+	caseParts := make([]string, 0, len(records))
+	caseArgs := make([]any, 0, len(records)*2)
+	ids := make([]string, 0, len(records))
+	for _, record := range records {
+		normalized := strings.TrimSpace(record.AttributedUserID)
+		if normalized == record.AttributedUserID {
+			continue
+		}
+		caseParts = append(caseParts, "WHEN ? THEN ?")
+		caseArgs = append(caseArgs, record.ID, normalized)
+		ids = append(ids, record.ID)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	expression := "CASE id " + strings.Join(caseParts, " ") + " ELSE attributed_user_id END"
+	if err := db.Model(&UsageRecord{}).Where("id IN ?", ids).
+		UpdateColumn("attributed_user_id", gorm.Expr(expression, caseArgs...)).Error; err != nil {
+		return fmt.Errorf("normalize usage attribution batch: %w", err)
+	}
+	return nil
 }
 
 func backfillRequestLogAttribution(db *gorm.DB, driver string) error {

--- a/backend/internal/server/store_usage_summary.go
+++ b/backend/internal/server/store_usage_summary.go
@@ -1,0 +1,141 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+type UsageSummaryScope struct {
+	Global            bool
+	AttributedUserIDs []string
+	ProjectIDs        []string
+	APIKeyIDs         []string
+}
+
+type UsageSummaryQuery struct {
+	UsageRecords UsageSummaryScope
+	RequestLogs  UsageSummaryScope
+}
+
+type UsageSummary struct {
+	RequestCount      int64
+	UsageRecordCount  int64
+	InputTokens       int64
+	CachedInputTokens int64
+	CacheWriteTokens  int64
+	OutputTokens      int64
+	ReasoningTokens   int64
+	TotalTokens       int64
+	EstimatedCostUSD  float64
+	Errors            int64
+}
+
+func (s *GormStore) QueryUsageSummary(ctx context.Context, query UsageSummaryQuery) (UsageSummary, error) {
+	var usage struct {
+		UsageRecordCount  int64
+		InputTokens       int64
+		CachedInputTokens int64
+		CacheWriteTokens  int64
+		OutputTokens      int64
+		ReasoningTokens   int64
+		TotalTokens       int64
+		EstimatedCostUSD  float64
+	}
+	usageQuery, err := applyUsageSummaryScope(s.db.WithContext(ctx).Model(&UsageRecord{}), s.dbDriver, query.UsageRecords)
+	if err != nil {
+		return UsageSummary{}, err
+	}
+	if err := usageQuery.Select(
+		"COUNT(*) AS usage_record_count, " +
+			"COALESCE(SUM(input_tokens), 0) AS input_tokens, " +
+			"COALESCE(SUM(cached_input_tokens), 0) AS cached_input_tokens, " +
+			"COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens, " +
+			"COALESCE(SUM(output_tokens), 0) AS output_tokens, " +
+			"COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens, " +
+			"COALESCE(SUM(total_tokens), 0) AS total_tokens, " +
+			"COALESCE(SUM(cost_usd), 0) AS estimated_cost_usd",
+	).Scan(&usage).Error; err != nil {
+		return UsageSummary{}, err
+	}
+
+	var requests struct {
+		RequestCount int64
+		Errors       int64
+	}
+	requestQuery, err := applyUsageSummaryScope(s.db.WithContext(ctx).Model(&RequestLog{}), s.dbDriver, query.RequestLogs)
+	if err != nil {
+		return UsageSummary{}, err
+	}
+	if err := requestQuery.Select(
+		"COALESCE(SUM(CASE WHEN COALESCE(project_id, '') <> ? THEN 1 ELSE 0 END), 0) AS request_count, "+
+			"COALESCE(SUM(CASE WHEN COALESCE(project_id, '') <> ? AND status_code >= 400 THEN 1 ELSE 0 END), 0) AS errors",
+		"admin_playground",
+		"admin_playground",
+	).Scan(&requests).Error; err != nil {
+		return UsageSummary{}, err
+	}
+
+	return UsageSummary{
+		RequestCount:      requests.RequestCount,
+		UsageRecordCount:  usage.UsageRecordCount,
+		InputTokens:       usage.InputTokens,
+		CachedInputTokens: usage.CachedInputTokens,
+		CacheWriteTokens:  usage.CacheWriteTokens,
+		OutputTokens:      usage.OutputTokens,
+		ReasoningTokens:   usage.ReasoningTokens,
+		TotalTokens:       usage.TotalTokens,
+		EstimatedCostUSD:  usage.EstimatedCostUSD,
+		Errors:            requests.Errors,
+	}, nil
+}
+
+func applyUsageSummaryScope(db *gorm.DB, driver string, scope UsageSummaryScope) (*gorm.DB, error) {
+	if scope.Global {
+		return db, nil
+	}
+	conditions := make([]string, 0, 3)
+	args := make([]any, 0, 4)
+	if len(scope.AttributedUserIDs) > 0 {
+		condition, conditionArgs, err := usageSummaryMembershipCondition(driver, "attributed_user_id", scope.AttributedUserIDs)
+		if err != nil {
+			return nil, err
+		}
+		conditions = append(conditions, condition)
+		args = append(args, conditionArgs...)
+	}
+	if len(scope.ProjectIDs) > 0 {
+		condition, conditionArgs, err := usageSummaryMembershipCondition(driver, "project_id", scope.ProjectIDs)
+		if err != nil {
+			return nil, err
+		}
+		conditions = append(conditions, condition)
+		args = append(args, conditionArgs...)
+	}
+	if len(scope.APIKeyIDs) > 0 {
+		condition, conditionArgs, err := usageSummaryMembershipCondition(driver, "api_key_id", scope.APIKeyIDs)
+		if err != nil {
+			return nil, err
+		}
+		conditions = append(conditions, condition)
+		args = append(args, conditionArgs...)
+	}
+	if len(conditions) == 0 {
+		return db.Where("1 = 0"), nil
+	}
+	return db.Where("("+strings.Join(conditions, " OR ")+")", args...), nil
+}
+
+func usageSummaryMembershipCondition(driver string, column string, values []string) (string, []any, error) {
+	encoded, err := json.Marshal(values)
+	if err != nil {
+		return "", nil, err
+	}
+	jsonValues := string(encoded)
+	if driver == "postgres" {
+		return column + " IN (SELECT value FROM jsonb_array_elements_text(CAST(? AS jsonb)))", []any{jsonValues}, nil
+	}
+	return column + " IN (SELECT value FROM json_each(?))", []any{jsonValues}, nil
+}


### PR DESCRIPTION
## Summary

Move the admin usage summary from full-history in-memory aggregation to permission-scoped SQL aggregation. This keeps response size and application allocations constant as usage history grows while preserving the existing role-based visibility rules.

## Related Issue

N/A.

## Changes

- Build distinct UsageRecord and RequestLog scopes for platform administrators, security administrators, team leaders, and users.
- Aggregate usage counts, token fields, estimated cost, billable requests, and errors directly in SQL.
- Pass large permission sets as one JSON array per dimension using SQLite `json_each` or PostgreSQL `jsonb_array_elements_text`, avoiding bind-parameter limits.
- Normalize legacy whitespace-padded usage attribution once through a versioned, retryable batch migration so the existing attribution index remains usable.
- Return an internal server error when summary aggregation fails instead of returning a misleading zero summary.
- Add permission-parity, empty-scope, large-scope, migration, query-plan, failure-path, and benchmark coverage.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...`
- `go vet ./...`
- `go test ./internal/server -run '^$' -bench '^BenchmarkUsageSummaryAggregation$' -benchtime=3x -count=1`
  - SQL aggregate: approximately 0.69 ms/op and 19 KB/op for 5,000 usage records plus 5,000 request logs.
  - Previous in-memory aggregate: approximately 40.3 ms/op and 25.3 MB/op.
- `node --test tools/*.test.mjs`
- `node tools/check-doc-translations.mjs` (existence check passed; co-change check skipped locally because no base/head endpoints were available)
- `node tools/check-ui-translations.mjs`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- `git diff --check`
- PostgreSQL integration execution was not run because `TEST_POSTGRES_URL` was not configured.

## Compatibility, Security, and Operations

The admin summary JSON contract and all `/v1` endpoints remain unchanged. UsageRecord and RequestLog keep their existing, intentionally different permission predicates; parity tests compare the SQL result with the previous in-memory filters. The startup migration only trims attribution values that the previous authorization path already compared after `strings.TrimSpace`, records a monotonic completion revision, and processes rows in bounded batches. No environment, deployment, frontend, SDK, or model catalog changes are required. Rollback is a code revert; normalized attribution values remain semantically equivalent to the previous authorization behavior.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
