### PR TITLE
refactor(server): route billing and reconciliation by method

### DIFF
--- a/backend/internal/server/admin_billing_method_routing_contract_test.go
+++ b/backend/internal/server/admin_billing_method_routing_contract_test.go
@@ -1,0 +1,409 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+type adminBillingMethodRoute struct {
+	name    string
+	path    string
+	allowed []string
+	allow   string
+}
+
+func TestAdminBillingMethodRoutesPreserveAuthorizationOrder(t *testing.T) {
+	store, app := newMethodRoutingBillingServer(t, "billing-routing-authorization-password")
+	ordinaryToken := createAdminOperationMethodRoutingSession(t, store, "billing-routing-user", "user")
+	securityToken := createAdminOperationMethodRoutingSession(t, store, "billing-routing-security", "security_admin")
+	auditsBefore := len(store.ListAuditEvents())
+
+	for _, route := range adminBillingMethodRoutes() {
+		wrongMethod := unsupportedAdminBillingMethodRoutes(route)[0]
+		for _, auth := range []struct {
+			name       string
+			token      string
+			wantStatus int
+			wantCode   string
+			wantAllow  string
+		}{
+			{name: "no_token", wantStatus: http.StatusUnauthorized, wantCode: "invalid_admin_token"},
+			{name: "ordinary_user", token: ordinaryToken, wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+			{name: "security_admin", token: securityToken, wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+			{name: "admin", token: "dev_admin_token", wantStatus: http.StatusMethodNotAllowed, wantCode: "method_not_allowed", wantAllow: route.allow},
+		} {
+			t.Run(route.name+"/"+auth.name, func(t *testing.T) {
+				response := methodRoutingRequest(app, wrongMethod, route.path, auth.token)
+				assertJSONError(t, response, auth.wantStatus, auth.wantCode)
+				assertAllowHeader(t, response, auth.wantAllow)
+			})
+		}
+	}
+
+	if got := len(store.ListAuditEvents()); got != auditsBefore {
+		t.Fatalf("wrong methods wrote audit events: got %d, want %d", got, auditsBefore)
+	}
+}
+
+func TestAdminBillingMethodRoutesRejectEveryUnsupportedMethod(t *testing.T) {
+	store, app := newMethodRoutingBillingServer(t, "billing-routing-methods-password")
+	auditsBefore := len(store.ListAuditEvents())
+	for _, route := range adminBillingMethodRoutes() {
+		for _, method := range unsupportedAdminBillingMethodRoutes(route) {
+			t.Run(route.name+"/"+method, func(t *testing.T) {
+				response := methodRoutingRequest(app, method, route.path, "dev_admin_token")
+				assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+				assertAllowHeader(t, response, route.allow)
+			})
+		}
+	}
+	if got := len(store.ListAuditEvents()); got != auditsBefore {
+		t.Fatalf("unsupported methods wrote audit events: got %d, want %d", got, auditsBefore)
+	}
+}
+
+func TestAdminBillingMethodRoutesRejectRealHEAD(t *testing.T) {
+	store, app := newMethodRoutingBillingServer(t, "billing-routing-head-password")
+	ordinaryToken := createAdminOperationMethodRoutingSession(t, store, "billing-routing-head-user", "user")
+	securityToken := createAdminOperationMethodRoutingSession(t, store, "billing-routing-head-security", "security_admin")
+	httpServer := httptest.NewServer(app)
+	t.Cleanup(httpServer.Close)
+
+	for _, route := range adminBillingMethodRoutes() {
+		for _, auth := range []struct {
+			name       string
+			token      string
+			wantStatus int
+			wantAllow  string
+		}{
+			{name: "no_token", wantStatus: http.StatusUnauthorized},
+			{name: "ordinary_user", token: ordinaryToken, wantStatus: http.StatusForbidden},
+			{name: "security_admin", token: securityToken, wantStatus: http.StatusForbidden},
+			{name: "admin", token: "dev_admin_token", wantStatus: http.StatusMethodNotAllowed, wantAllow: route.allow},
+		} {
+			t.Run(route.name+"/"+auth.name, func(t *testing.T) {
+				request, err := http.NewRequest(http.MethodHead, httpServer.URL+route.path, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if auth.token != "" {
+					request.Header.Set("authorization", "Bearer "+auth.token)
+				}
+				response, err := httpServer.Client().Do(request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				assertRealHEADResponse(t, response, auth.wantStatus, auth.wantAllow, "application/json", true)
+				_ = response.Body.Close()
+			})
+		}
+	}
+}
+
+func TestAdminBillingMethodRoutesPreserveCORSPreflight(t *testing.T) {
+	_, app := newMethodRoutingBillingServer(t, "billing-routing-cors-password")
+	for _, route := range adminBillingMethodRoutes() {
+		t.Run(route.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodOptions, route.path, nil)
+			request.Header.Set("origin", "https://console.example.com")
+			request.Header.Set("access-control-request-method", route.allowed[0])
+			response := httptest.NewRecorder()
+			app.ServeHTTP(response, request)
+			if response.Code != http.StatusNoContent {
+				t.Fatalf("expected 204, got %d: %s", response.Code, response.Body.String())
+			}
+			if got := response.Header().Get("access-control-allow-methods"); got != "GET,POST,PUT,PATCH,DELETE,OPTIONS" {
+				t.Fatalf("access-control-allow-methods = %q", got)
+			}
+			assertAllowHeader(t, response, "")
+		})
+	}
+}
+
+func TestAdminBillingMethodRoutesPreservePathBoundaries(t *testing.T) {
+	_, app := newMethodRoutingBillingServer(t, "billing-routing-boundaries-password")
+
+	unauthorizedBlank := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/connectors/", "")
+	assertJSONError(t, unauthorizedBlank, http.StatusUnauthorized, "invalid_admin_token")
+	assertAllowHeader(t, unauthorizedBlank, "")
+
+	blank := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/connectors/", "dev_admin_token")
+	assertJSONError(t, blank, http.StatusNotFound, "billing_connector_not_found")
+	assertAllowHeader(t, blank, "")
+
+	unknownAction := methodRoutingRequest(app, http.MethodPost, "/api/admin/billing/connectors/missing/unknown", "dev_admin_token")
+	assertJSONError(t, unknownAction, http.StatusNotFound, "billing_action_not_found")
+	assertAllowHeader(t, unknownAction, "")
+
+	unknownActionWrongMethod := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/connectors/missing/unknown", "dev_admin_token")
+	assertJSONError(t, unknownActionWrongMethod, http.StatusMethodNotAllowed, "method_not_allowed")
+	assertAllowHeader(t, unknownActionWrongMethod, http.MethodPost)
+
+	extraSegment := methodRoutingRequest(app, http.MethodPost, "/api/admin/billing/connectors/missing/test/extra", "dev_admin_token")
+	assertJSONError(t, extraSegment, http.StatusNotFound, "billing_connector_not_found")
+	assertAllowHeader(t, extraSegment, "")
+
+	trailingItem := methodRoutingRequest(app, http.MethodPost, "/api/admin/billing/connectors/missing/", "dev_admin_token")
+	assertJSONError(t, trailingItem, http.StatusMethodNotAllowed, "method_not_allowed")
+	assertAllowHeader(t, trailingItem, "GET, PATCH, DELETE")
+
+	trailingAction := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/connectors/missing/test/", "dev_admin_token")
+	assertJSONError(t, trailingAction, http.StatusMethodNotAllowed, "method_not_allowed")
+	assertAllowHeader(t, trailingAction, http.MethodPost)
+}
+
+func TestAdminBillingMethodRoutesPreserveDynamicPayloadValidation(t *testing.T) {
+	config := ConfigFromEnv()
+	config.AdminToken = "dev_admin_token"
+	config.SecretKey = "billing-method-routing-validation-secret"
+	config.MaxJSONRequestBytes = 1 << 10
+	store := NewMemoryStoreWithConfig(config)
+	connector, err := store.CreateBillingConnector(BillingConnector{
+		ID:      "billing-validation",
+		Name:    "Billing Validation Connector",
+		Type:    BillingConnectorOneAPI,
+		BaseURL: "https://billing.example.test",
+		Status:  StatusActive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := NewWithConfig(store, config).Handler()
+	itemPath := "/api/admin/billing/connectors/" + connector.ID
+
+	for _, test := range []struct {
+		name       string
+		method     string
+		path       string
+		body       string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "patch_malformed_json",
+			method:     http.MethodPatch,
+			path:       itemPath,
+			body:       "{",
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "invalid_billing_connector",
+		},
+		{
+			name:       "patch_payload_too_large",
+			method:     http.MethodPatch,
+			path:       itemPath,
+			body:       `{"name":"` + strings.Repeat("x", 4096) + `"}`,
+			wantStatus: http.StatusRequestEntityTooLarge,
+			wantCode:   "payload_too_large",
+		},
+		{
+			name:       "sync_malformed_json",
+			method:     http.MethodPost,
+			path:       itemPath + "/sync",
+			body:       "{",
+			wantStatus: http.StatusBadRequest,
+			wantCode:   "invalid_billing_sync",
+		},
+		{
+			name:       "sync_payload_too_large",
+			method:     http.MethodPost,
+			path:       itemPath + "/sync",
+			body:       `{"from":"` + strings.Repeat("x", 4096) + `"}`,
+			wantStatus: http.StatusRequestEntityTooLarge,
+			wantCode:   "payload_too_large",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			response := billingMethodRoutingBodyRequest(app, test.method, test.path, test.body, "dev_admin_token")
+			assertJSONError(t, response, test.wantStatus, test.wantCode)
+			assertAllowHeader(t, response, "")
+		})
+	}
+}
+
+func TestAdminBillingMethodRoutesPreserveSuccessfulOperationsAndSideEffects(t *testing.T) {
+	createdAt := time.Now().UTC().Add(-30 * time.Minute)
+	upstream := newBillingMethodRoutingUpstream(t, createdAt)
+	store, app := newMethodRoutingBillingServer(t, "billing-routing-success-password")
+	auditsBefore := len(store.ListAuditEvents())
+
+	createdResponse := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/billing/connectors", map[string]any{
+		"name":     "Method Routing Connector",
+		"type":     BillingConnectorOneAPI,
+		"base_url": upstream.URL,
+		"config": map[string]string{
+			"quota_per_unit": "500000",
+			"max_retries":    "1",
+			"retry_base_ms":  "1",
+		},
+		"credentials": map[string]string{"api_token": "billing-routing-secret"},
+	}, "dev_admin_token")
+	if createdResponse.Code != http.StatusCreated {
+		t.Fatalf("create connector: status=%d body=%s", createdResponse.Code, createdResponse.Body.String())
+	}
+	if strings.Contains(createdResponse.Body.String(), "billing-routing-secret") {
+		t.Fatalf("create response exposed credentials: %s", createdResponse.Body.String())
+	}
+	var connector BillingConnector
+	if err := json.NewDecoder(createdResponse.Body).Decode(&connector); err != nil {
+		t.Fatal(err)
+	}
+
+	listed := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/connectors", "dev_admin_token")
+	if listed.Code != http.StatusOK || !strings.Contains(listed.Body.String(), connector.ID) {
+		t.Fatalf("list connectors: status=%d body=%s", listed.Code, listed.Body.String())
+	}
+	item := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/connectors/"+connector.ID, "dev_admin_token")
+	if item.Code != http.StatusOK || !strings.Contains(item.Body.String(), connector.ID) {
+		t.Fatalf("get connector: status=%d body=%s", item.Code, item.Body.String())
+	}
+	patched := methodRoutingJSONRequest(t, app, http.MethodPatch, "/api/admin/billing/connectors/"+connector.ID, map[string]any{"name": "Method Routing Connector Updated"}, "dev_admin_token")
+	if patched.Code != http.StatusOK || !strings.Contains(patched.Body.String(), "Method Routing Connector Updated") {
+		t.Fatalf("patch connector: status=%d body=%s", patched.Code, patched.Body.String())
+	}
+
+	tested := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/billing/connectors/"+connector.ID+"/test", map[string]any{}, "dev_admin_token")
+	if tested.Code != http.StatusOK || !strings.Contains(tested.Body.String(), `"ok":true`) {
+		t.Fatalf("test connector: status=%d body=%s", tested.Code, tested.Body.String())
+	}
+	synced := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/billing/connectors/"+connector.ID+"/sync", map[string]any{}, "dev_admin_token")
+	if synced.Code != http.StatusOK || !strings.Contains(synced.Body.String(), `"status":"succeeded"`) {
+		t.Fatalf("sync connector: status=%d body=%s", synced.Code, synced.Body.String())
+	}
+
+	records := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/records?connector_id="+url.QueryEscape(connector.ID)+"&limit=1", "dev_admin_token")
+	if records.Code != http.StatusOK || !strings.Contains(records.Body.String(), connector.ID) || strings.Contains(records.Body.String(), "raw_payload") {
+		t.Fatalf("list billing records: status=%d body=%s", records.Code, records.Body.String())
+	}
+	runs := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/sync-runs?connector_id="+url.QueryEscape(connector.ID)+"&limit=1", "dev_admin_token")
+	if runs.Code != http.StatusOK || !strings.Contains(runs.Body.String(), connector.ID) || !strings.Contains(runs.Body.String(), `"trigger":"manual"`) {
+		t.Fatalf("list billing sync runs: status=%d body=%s", runs.Code, runs.Body.String())
+	}
+
+	deleted := methodRoutingRequest(app, http.MethodDelete, "/api/admin/billing/connectors/"+connector.ID, "dev_admin_token")
+	if deleted.Code != http.StatusNoContent {
+		t.Fatalf("delete connector: status=%d body=%s", deleted.Code, deleted.Body.String())
+	}
+	if len(store.ListBillingRecords(connector.ID, 10)) != 1 || len(store.ListBillingSyncRuns(connector.ID, 10)) != 1 {
+		t.Fatal("deleting the connector removed billing records or sync history")
+	}
+	audits := store.ListAuditEvents()
+	if len(audits) != auditsBefore+5 {
+		t.Fatalf("billing operations wrote %d audits, want 5", len(audits)-auditsBefore)
+	}
+	for _, action := range []string{"create", "update", "test", "sync", "delete"} {
+		if !hasMethodRoutingAudit(audits, action, connector.ID) {
+			t.Fatalf("missing %s audit for connector %s", action, connector.ID)
+		}
+	}
+}
+
+func TestAdminBillingMethodRoutesPreserveEncodedAndTrailingIDs(t *testing.T) {
+	upstream := newBillingMethodRoutingUpstream(t, time.Now().UTC().Add(-30*time.Minute))
+	store, app := newMethodRoutingBillingServer(t, "billing-routing-encoded-password")
+	connector, err := store.CreateBillingConnector(BillingConnector{
+		ID:      "billing/encoded",
+		Name:    "Encoded Billing Connector",
+		Type:    BillingConnectorOneAPI,
+		BaseURL: upstream.URL,
+		Status:  StatusActive,
+		Config:  map[string]string{"max_retries": "1", "retry_base_ms": "1"},
+		Credentials: map[string]string{
+			"api_token": "encoded-billing-token",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	encodedID := strings.ReplaceAll(url.PathEscape(connector.ID), "/", "%2F")
+	itemPath := "/api/admin/billing/connectors/" + encodedID
+
+	item := methodRoutingRequest(app, http.MethodGet, itemPath, "dev_admin_token")
+	if item.Code != http.StatusOK || !strings.Contains(item.Body.String(), connector.ID) {
+		t.Fatalf("get encoded connector: status=%d body=%s", item.Code, item.Body.String())
+	}
+	trailingItem := methodRoutingRequest(app, http.MethodGet, itemPath+"/", "dev_admin_token")
+	if trailingItem.Code != http.StatusOK || !strings.Contains(trailingItem.Body.String(), connector.ID) {
+		t.Fatalf("get trailing encoded connector: status=%d body=%s", trailingItem.Code, trailingItem.Body.String())
+	}
+	patched := methodRoutingJSONRequest(t, app, http.MethodPatch, itemPath+"/", map[string]any{"name": "Encoded Billing Connector Updated"}, "dev_admin_token")
+	if patched.Code != http.StatusOK || !strings.Contains(patched.Body.String(), "Encoded Billing Connector Updated") {
+		t.Fatalf("patch trailing encoded connector: status=%d body=%s", patched.Code, patched.Body.String())
+	}
+	tested := methodRoutingJSONRequest(t, app, http.MethodPost, itemPath+"/test/", map[string]any{}, "dev_admin_token")
+	if tested.Code != http.StatusOK || !strings.Contains(tested.Body.String(), `"ok":true`) {
+		t.Fatalf("test trailing encoded connector: status=%d body=%s", tested.Code, tested.Body.String())
+	}
+}
+
+func adminBillingMethodRoutes() []adminBillingMethodRoute {
+	return []adminBillingMethodRoute{
+		{name: "connector_collection", path: "/api/admin/billing/connectors", allowed: []string{http.MethodGet, http.MethodPost}, allow: "GET, POST"},
+		{name: "connector_item", path: "/api/admin/billing/connectors/missing", allowed: []string{http.MethodGet, http.MethodPatch, http.MethodDelete}, allow: "GET, PATCH, DELETE"},
+		{name: "connector_test", path: "/api/admin/billing/connectors/missing/test", allowed: []string{http.MethodPost}, allow: http.MethodPost},
+		{name: "connector_sync", path: "/api/admin/billing/connectors/missing/sync", allowed: []string{http.MethodPost}, allow: http.MethodPost},
+		{name: "billing_records", path: "/api/admin/billing/records", allowed: []string{http.MethodGet}, allow: http.MethodGet},
+		{name: "billing_sync_runs", path: "/api/admin/billing/sync-runs", allowed: []string{http.MethodGet}, allow: http.MethodGet},
+	}
+}
+
+func unsupportedAdminBillingMethodRoutes(route adminBillingMethodRoute) []string {
+	methods := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodTrace, http.MethodConnect}
+	unsupported := make([]string, 0, len(methods))
+	for _, method := range methods {
+		allowed := false
+		for _, candidate := range route.allowed {
+			if candidate == method {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			unsupported = append(unsupported, method)
+		}
+	}
+	return unsupported
+}
+
+func billingMethodRoutingBodyRequest(handler http.Handler, method string, path string, body string, token string) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(method, path, strings.NewReader(body))
+	request.Header.Set("content-type", "application/json")
+	if token != "" {
+		request.Header.Set("authorization", "Bearer "+token)
+	}
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	return response
+}
+
+func newMethodRoutingBillingServer(t *testing.T, password string) (*GormStore, http.Handler) {
+	t.Helper()
+	config := ConfigFromEnv()
+	config.AdminToken = "dev_admin_token"
+	config.BootstrapAdminPassword = password
+	config.SecretKey = "billing-method-routing-secret"
+	store := NewMemoryStoreWithConfig(config)
+	if err := BootstrapBaseDataWithConfig(store, config); err != nil {
+		t.Fatal(err)
+	}
+	return store, NewWithConfig(store, config).Handler()
+}
+
+func newBillingMethodRoutingUpstream(t *testing.T, createdAt time.Time) *httptest.Server {
+	t.Helper()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.Header.Get("authorization") != "Bearer billing-routing-secret" && r.Header.Get("authorization") != "Bearer encoded-billing-token" {
+			http.Error(w, "invalid billing request", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"items":[{"id":"billing-method-route-record","created_at":` + strconv.FormatInt(createdAt.Unix(), 10) + `,"model_name":"deepseek-chat","quota":500000}],"total":1}}`))
+	}))
+	t.Cleanup(upstream.Close)
+	return upstream
+}

--- a/backend/internal/server/admin_billing_routing.go
+++ b/backend/internal/server/admin_billing_routing.go
@@ -1,0 +1,89 @@
+package server
+
+import "net/http"
+
+type adminBillingConnectorHandler func(http.ResponseWriter, *http.Request, AdminUser, string)
+
+func (s *Server) registerBillingRoutes() {
+	billingMethodNotAllowed := func(allowedMethods string) http.HandlerFunc {
+		return s.adminMethodNotAllowed("billing", allowedMethods)
+	}
+	s.registerMethodRoutes("/api/admin/billing/connectors", billingMethodNotAllowed,
+		methodRoute{Method: http.MethodGet, Handler: s.handleAdminBillingConnectorsGet},
+		methodRoute{Method: http.MethodPost, Handler: s.handleAdminBillingConnectorsPost},
+	)
+	s.registerMethodRoutes("/api/admin/billing/connectors/{connector_id}", billingMethodNotAllowed,
+		methodRoute{Method: http.MethodGet, Handler: s.handleAdminBillingConnectorGet},
+		methodRoute{Method: http.MethodPatch, Handler: s.handleAdminBillingConnectorPatch},
+		methodRoute{Method: http.MethodDelete, Handler: s.handleAdminBillingConnectorDelete},
+	)
+	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/billing/connectors/{connector_id}/test", s.handleAdminBillingConnectorTestPost, s.adminMethodNotAllowed("billing", http.MethodPost))
+	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/billing/connectors/{connector_id}/sync", s.handleAdminBillingConnectorSyncPost, s.adminMethodNotAllowed("billing", http.MethodPost))
+	s.mux.HandleFunc("/api/admin/billing/connectors/", s.handleAdminBillingConnectorItem)
+	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/billing/records", s.handleAdminBillingRecordsGet, s.adminMethodNotAllowed("billing", http.MethodGet))
+	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/billing/sync-runs", s.handleAdminBillingSyncRunsGet, s.adminMethodNotAllowed("billing", http.MethodGet))
+	s.registerReconciliationRoutes()
+}
+
+func (s *Server) handleAdminBillingConnectorsGet(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAdmin(w, r, "billing", r.Method)
+	if !ok {
+		return
+	}
+	s.serveAdminBillingConnectorsGet(w, r, user)
+}
+
+func (s *Server) handleAdminBillingConnectorsPost(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAdmin(w, r, "billing", r.Method)
+	if !ok {
+		return
+	}
+	s.serveAdminBillingConnectorsPost(w, r, user)
+}
+
+func (s *Server) handleAdminBillingConnectorGet(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminBillingConnectorRoute(w, r, s.serveAdminBillingConnectorGet)
+}
+
+func (s *Server) handleAdminBillingConnectorPatch(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminBillingConnectorRoute(w, r, s.serveAdminBillingConnectorPatch)
+}
+
+func (s *Server) handleAdminBillingConnectorDelete(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminBillingConnectorRoute(w, r, s.serveAdminBillingConnectorDelete)
+}
+
+func (s *Server) handleAdminBillingConnectorTestPost(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminBillingConnectorRoute(w, r, s.serveAdminBillingConnectorTest)
+}
+
+func (s *Server) handleAdminBillingConnectorSyncPost(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminBillingConnectorRoute(w, r, s.serveAdminBillingConnectorSync)
+}
+
+func (s *Server) handleAdminBillingConnectorRoute(w http.ResponseWriter, r *http.Request, handler adminBillingConnectorHandler) {
+	connectorID := r.PathValue("connector_id")
+	if connectorID == "" {
+		s.handleAdminBillingConnectorItem(w, r)
+		return
+	}
+	user, ok := s.requireAdmin(w, r, "billing", r.Method)
+	if !ok {
+		return
+	}
+	handler(w, r, user, connectorID)
+}
+
+func (s *Server) handleAdminBillingRecordsGet(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r, "billing", r.Method); !ok {
+		return
+	}
+	s.serveAdminBillingRecordsGet(w, r)
+}
+
+func (s *Server) handleAdminBillingSyncRunsGet(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r, "billing", r.Method); !ok {
+		return
+	}
+	s.serveAdminBillingSyncRunsGet(w, r)
+}

--- a/backend/internal/server/admin_reconciliation_method_routing_contract_test.go
+++ b/backend/internal/server/admin_reconciliation_method_routing_contract_test.go
@@ -236,7 +236,7 @@ func TestAdminReconciliationMethodRoutesPreserveStateAndCSV(t *testing.T) {
 		t.Fatalf("run rule: status=%d body=%s", runResponse.Code, runResponse.Body.String())
 	}
 	var run ReconciliationRun
-	if err := json.Unmarshal([]byte(runResponse.Body.String()), &run); err != nil {
+	if err := json.Unmarshal(runResponse.Body.Bytes(), &run); err != nil {
 		t.Fatal(err)
 	}
 	if run.Status != ReconciliationRunSucceeded || run.RuleID != rule.ID {

--- a/backend/internal/server/admin_reconciliation_method_routing_contract_test.go
+++ b/backend/internal/server/admin_reconciliation_method_routing_contract_test.go
@@ -1,0 +1,373 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type adminReconciliationMethodRoute struct {
+	name           string
+	path           string
+	allowed        []string
+	allow          string
+	wantAdminCode  string
+	wantAdminState int
+}
+
+func TestAdminReconciliationMethodRoutesPreserveAuthorizationOrder(t *testing.T) {
+	store, app, _ := newMethodRoutingReconciliationServer(t, 0)
+	ordinaryToken := createAdminOperationMethodRoutingSession(t, store, "reconciliation-routing-user", "user")
+	securityToken := createAdminOperationMethodRoutingSession(t, store, "reconciliation-routing-security", "security_admin")
+	auditsBefore := len(store.ListAuditEvents())
+
+	for _, route := range adminReconciliationMethodRoutes() {
+		wrongMethod := unsupportedAdminReconciliationMethods(route)[0]
+		for _, auth := range []struct {
+			name       string
+			token      string
+			wantStatus int
+			wantCode   string
+			wantAllow  string
+		}{
+			{name: "no_token", wantStatus: http.StatusUnauthorized, wantCode: "invalid_admin_token"},
+			{name: "ordinary_user", token: ordinaryToken, wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+			{name: "security_admin", token: securityToken, wantStatus: http.StatusForbidden, wantCode: "admin_forbidden"},
+			{name: "admin", token: "dev_admin_token", wantStatus: route.wantAdminState, wantCode: route.wantAdminCode, wantAllow: route.allow},
+		} {
+			t.Run(route.name+"/"+auth.name, func(t *testing.T) {
+				response := methodRoutingRequest(app, wrongMethod, route.path, auth.token)
+				assertJSONError(t, response, auth.wantStatus, auth.wantCode)
+				assertAllowHeader(t, response, auth.wantAllow)
+			})
+		}
+	}
+
+	if got := len(store.ListAuditEvents()); got != auditsBefore {
+		t.Fatalf("wrong methods wrote audit events: got %d, want %d", got, auditsBefore)
+	}
+}
+
+func TestAdminReconciliationMethodRoutesRejectEveryUnsupportedMethod(t *testing.T) {
+	_, app, _ := newMethodRoutingReconciliationServer(t, 0)
+	for _, route := range adminReconciliationMethodRoutes() {
+		for _, method := range unsupportedAdminReconciliationMethods(route) {
+			t.Run(route.name+"/"+method, func(t *testing.T) {
+				response := methodRoutingRequest(app, method, route.path, "dev_admin_token")
+				assertJSONError(t, response, route.wantAdminState, route.wantAdminCode)
+				assertAllowHeader(t, response, route.allow)
+			})
+		}
+	}
+}
+
+func TestAdminReconciliationMethodRoutesRejectRealHEAD(t *testing.T) {
+	store, app, _ := newMethodRoutingReconciliationServer(t, 0)
+	ordinaryToken := createAdminOperationMethodRoutingSession(t, store, "reconciliation-head-user", "user")
+	securityToken := createAdminOperationMethodRoutingSession(t, store, "reconciliation-head-security", "security_admin")
+	httpServer := httptest.NewServer(app)
+	t.Cleanup(httpServer.Close)
+
+	for _, route := range adminReconciliationMethodRoutes() {
+		for _, auth := range []struct {
+			name       string
+			token      string
+			wantStatus int
+			wantAllow  string
+		}{
+			{name: "no_token", wantStatus: http.StatusUnauthorized},
+			{name: "ordinary_user", token: ordinaryToken, wantStatus: http.StatusForbidden},
+			{name: "security_admin", token: securityToken, wantStatus: http.StatusForbidden},
+			{name: "admin", token: "dev_admin_token", wantStatus: route.wantAdminState, wantAllow: route.allow},
+		} {
+			t.Run(route.name+"/"+auth.name, func(t *testing.T) {
+				request, err := http.NewRequest(http.MethodHead, httpServer.URL+route.path, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if auth.token != "" {
+					request.Header.Set("authorization", "Bearer "+auth.token)
+				}
+				response, err := httpServer.Client().Do(request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				assertRealHEADResponse(t, response, auth.wantStatus, auth.wantAllow, "application/json", true)
+				_ = response.Body.Close()
+			})
+		}
+	}
+}
+
+func TestAdminReconciliationMethodRoutesPreserveCORSPreflight(t *testing.T) {
+	_, app, _ := newMethodRoutingReconciliationServer(t, 0)
+	for _, route := range adminReconciliationMethodRoutes() {
+		t.Run(route.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodOptions, route.path, nil)
+			request.Header.Set("origin", "https://console.example.com")
+			request.Header.Set("access-control-request-method", route.allowed[0])
+			response := httptest.NewRecorder()
+			app.ServeHTTP(response, request)
+			if response.Code != http.StatusNoContent {
+				t.Fatalf("expected 204, got %d: %s", response.Code, response.Body.String())
+			}
+			if got := response.Header().Get("access-control-allow-methods"); got != "GET,POST,PUT,PATCH,DELETE,OPTIONS" {
+				t.Fatalf("access-control-allow-methods = %q", got)
+			}
+			assertAllowHeader(t, response, "")
+		})
+	}
+}
+
+func TestAdminReconciliationMethodRoutesPreservePathBoundaries(t *testing.T) {
+	_, app, _ := newMethodRoutingReconciliationServer(t, 0)
+
+	unauthorizedRules := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/reconciliation-rules/", "")
+	assertJSONError(t, unauthorizedRules, http.StatusUnauthorized, "invalid_admin_token")
+	assertAllowHeader(t, unauthorizedRules, "")
+	rules := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/reconciliation-rules/", "dev_admin_token")
+	assertJSONError(t, rules, http.StatusNotFound, "reconciliation_rule_not_found")
+	assertAllowHeader(t, rules, "")
+
+	unknownRuleAction := methodRoutingRequest(app, http.MethodPost, "/api/admin/billing/reconciliation-rules/missing/unknown", "dev_admin_token")
+	assertJSONError(t, unknownRuleAction, http.StatusNotFound, "reconciliation_action_not_found")
+	assertAllowHeader(t, unknownRuleAction, "")
+	runWrongMethod := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/reconciliation-rules/missing/run", "dev_admin_token")
+	assertJSONError(t, runWrongMethod, http.StatusNotFound, "reconciliation_action_not_found")
+	assertAllowHeader(t, runWrongMethod, "")
+	extraRuleSegment := methodRoutingRequest(app, http.MethodPost, "/api/admin/billing/reconciliation-rules/missing/run/extra", "dev_admin_token")
+	assertJSONError(t, extraRuleSegment, http.StatusNotFound, "reconciliation_rule_not_found")
+	assertAllowHeader(t, extraRuleSegment, "")
+	trailingRuleItem := methodRoutingRequest(app, http.MethodPost, "/api/admin/billing/reconciliation-rules/missing/", "dev_admin_token")
+	assertJSONError(t, trailingRuleItem, http.StatusMethodNotAllowed, "method_not_allowed")
+	assertAllowHeader(t, trailingRuleItem, "GET, PATCH")
+
+	unauthorizedRuns := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/reconciliations/", "")
+	assertJSONError(t, unauthorizedRuns, http.StatusUnauthorized, "invalid_admin_token")
+	runs := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/reconciliations/", "dev_admin_token")
+	assertJSONError(t, runs, http.StatusNotFound, "reconciliation_run_not_found")
+	unknownRunAction := methodRoutingRequest(app, http.MethodPost, "/api/admin/billing/reconciliations/missing/unknown", "dev_admin_token")
+	assertJSONError(t, unknownRunAction, http.StatusNotFound, "reconciliation_action_not_found")
+	wrongLockMethod := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/reconciliations/missing/lock", "dev_admin_token")
+	assertJSONError(t, wrongLockMethod, http.StatusMethodNotAllowed, "method_not_allowed")
+	assertAllowHeader(t, wrongLockMethod, http.MethodPost)
+	extraRunSegment := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/reconciliations/missing/lock/extra", "dev_admin_token")
+	assertJSONError(t, extraRunSegment, http.StatusNotFound, "reconciliation_run_not_found")
+}
+
+func TestAdminReconciliationMethodRoutesPreservePayloadValidationAndFailureAudits(t *testing.T) {
+	configMax := int64(1 << 10)
+	store, app, connector := newMethodRoutingReconciliationServer(t, configMax)
+	rule := createMethodRoutingReconciliationRule(t, app, connector.ID)
+	rulePath := "/api/admin/billing/reconciliation-rules/" + rule.ID
+
+	malformedPatch := reconciliationMethodRoutingBodyRequest(app, http.MethodPatch, rulePath, "{", "dev_admin_token")
+	assertJSONError(t, malformedPatch, http.StatusBadRequest, "invalid_reconciliation_rule")
+	largePatch := reconciliationMethodRoutingBodyRequest(app, http.MethodPatch, rulePath, `{"name":"`+strings.Repeat("x", 4096)+`"}`, "dev_admin_token")
+	assertJSONError(t, largePatch, http.StatusRequestEntityTooLarge, "payload_too_large")
+
+	malformedRun := reconciliationMethodRoutingBodyRequest(app, http.MethodPost, rulePath+"/run", "{", "dev_admin_token")
+	assertJSONError(t, malformedRun, http.StatusBadRequest, "invalid_reconciliation_run")
+	largeRun := reconciliationMethodRoutingBodyRequest(app, http.MethodPost, rulePath+"/run", `{"period_start":"`+strings.Repeat("x", 4096)+`"}`, "dev_admin_token")
+	assertJSONError(t, largeRun, http.StatusRequestEntityTooLarge, "payload_too_large")
+
+	missingLock := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/billing/reconciliations/missing/lock", map[string]any{}, "dev_admin_token")
+	assertJSONError(t, missingLock, http.StatusNotFound, "reconciliation_run_not_found")
+	missingRecalculate := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/billing/reconciliations/missing/recalculate", map[string]any{}, "dev_admin_token")
+	assertJSONError(t, missingRecalculate, http.StatusNotFound, "reconciliation_run_not_found")
+
+	assertReconciliationMethodRoutingAudit(t, store, "reconcile", "failed", "invalid_reconciliation_run")
+	assertReconciliationMethodRoutingAudit(t, store, "lock", "failed", "reconciliation_run_not_found")
+	assertReconciliationMethodRoutingAudit(t, store, "recalculate", "failed", "reconciliation_run_not_found")
+}
+
+func TestAdminReconciliationMethodRoutesPreserveCreatePayloadValidation(t *testing.T) {
+	store, app, _ := newMethodRoutingReconciliationServer(t, 1<<10)
+	rulesBefore := len(store.ListReconciliationRules())
+	auditsBefore := len(store.ListAuditEvents())
+
+	malformed := reconciliationMethodRoutingBodyRequest(app, http.MethodPost, "/api/admin/billing/reconciliation-rules", "{", "dev_admin_token")
+	assertJSONError(t, malformed, http.StatusBadRequest, "invalid_reconciliation_rule")
+	large := reconciliationMethodRoutingBodyRequest(app, http.MethodPost, "/api/admin/billing/reconciliation-rules", `{"name":"`+strings.Repeat("x", 4096)+`"}`, "dev_admin_token")
+	assertJSONError(t, large, http.StatusRequestEntityTooLarge, "payload_too_large")
+
+	if got := len(store.ListReconciliationRules()); got != rulesBefore {
+		t.Fatalf("invalid create requests wrote reconciliation rules: got %d, want %d", got, rulesBefore)
+	}
+	if got := len(store.ListAuditEvents()); got != auditsBefore {
+		t.Fatalf("invalid create requests wrote audit events: got %d, want %d", got, auditsBefore)
+	}
+}
+
+func TestAdminReconciliationMethodRoutesPreserveStateAndCSV(t *testing.T) {
+	store, app, connector := newMethodRoutingReconciliationServer(t, 0)
+	periodStart := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	createReconciliationBillingRecords(t, store, []BillingRecord{{
+		ID: "billing-routing-reconciliation-record", ConnectorID: connector.ID, ExternalID: "external-routing-record",
+		SourceType: BillingConnectorOneAPI, Model: "routing-model", Currency: "USD", NetAmount: "1",
+		UsageStartAt: periodStart.Add(time.Minute), UsageEndAt: periodStart.Add(2 * time.Minute), ExternalRequestID: "routing-request",
+	}})
+	createReconciliationUsageRecords(t, store, []UsageRecord{{
+		ID: "usage-routing-reconciliation-record", RequestID: "routing-request", ProviderID: BillingConnectorOneAPI,
+		ModelName: "routing-model", ProviderCostUSD: 1, CreatedAt: periodStart.Add(time.Minute),
+	}})
+	rule := createMethodRoutingReconciliationRule(t, app, connector.ID)
+
+	list := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/reconciliation-rules", "dev_admin_token")
+	if list.Code != http.StatusOK || !strings.Contains(list.Body.String(), rule.ID) {
+		t.Fatalf("list rules: status=%d body=%s", list.Code, list.Body.String())
+	}
+	item := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/reconciliation-rules/"+rule.ID, "dev_admin_token")
+	if item.Code != http.StatusOK || !strings.Contains(item.Body.String(), rule.ID) {
+		t.Fatalf("get rule: status=%d body=%s", item.Code, item.Body.String())
+	}
+	patched := methodRoutingJSONRequest(t, app, http.MethodPatch, "/api/admin/billing/reconciliation-rules/"+rule.ID, map[string]any{"name": "Routing Rule Updated"}, "dev_admin_token")
+	if patched.Code != http.StatusOK || !strings.Contains(patched.Body.String(), "Routing Rule Updated") {
+		t.Fatalf("patch rule: status=%d body=%s", patched.Code, patched.Body.String())
+	}
+
+	runResponse := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/billing/reconciliation-rules/"+rule.ID+"/run", map[string]any{
+		"period_start": periodStart.Format(time.RFC3339), "period_end": periodStart.Add(time.Hour).Format(time.RFC3339),
+	}, "dev_admin_token")
+	if runResponse.Code != http.StatusCreated {
+		t.Fatalf("run rule: status=%d body=%s", runResponse.Code, runResponse.Body.String())
+	}
+	var run ReconciliationRun
+	if err := json.Unmarshal([]byte(runResponse.Body.String()), &run); err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != ReconciliationRunSucceeded || run.RuleID != rule.ID {
+		t.Fatalf("unexpected run: %#v", run)
+	}
+
+	runList := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/reconciliations?rule_id="+rule.ID+"&limit=1", "dev_admin_token")
+	if runList.Code != http.StatusOK || !strings.Contains(runList.Body.String(), run.ID) {
+		t.Fatalf("list runs: status=%d body=%s", runList.Code, runList.Body.String())
+	}
+	detail := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/reconciliations/"+run.ID+"?status=matched&limit=1&offset=0", "dev_admin_token")
+	if detail.Code != http.StatusOK || !strings.Contains(detail.Body.String(), run.ID) || !strings.Contains(detail.Body.String(), `"limit":1`) {
+		t.Fatalf("get run detail: status=%d body=%s", detail.Code, detail.Body.String())
+	}
+
+	recalculated := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/billing/reconciliations/"+run.ID+"/recalculate", map[string]any{}, "dev_admin_token")
+	if recalculated.Code != http.StatusOK || !strings.Contains(recalculated.Body.String(), `"status":"succeeded"`) {
+		t.Fatalf("recalculate run: status=%d body=%s", recalculated.Code, recalculated.Body.String())
+	}
+	export := methodRoutingRequest(app, http.MethodGet, "/api/admin/billing/reconciliations/"+run.ID+"/export?status=matched", "dev_admin_token")
+	if export.Code != http.StatusOK || !strings.HasPrefix(export.Header().Get("content-type"), "text/csv") || !strings.Contains(export.Header().Get("content-disposition"), run.ID) || !strings.HasPrefix(export.Body.String(), "\ufeffstatus,") {
+		t.Fatalf("export run: status=%d headers=%v body-prefix=%q", export.Code, export.Header(), export.Body.String()[:minRoutingTestInt(20, len(export.Body.String()))])
+	}
+
+	locked := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/billing/reconciliations/"+run.ID+"/lock", map[string]any{}, "dev_admin_token")
+	if locked.Code != http.StatusOK || !strings.Contains(locked.Body.String(), `"locked_at"`) {
+		t.Fatalf("lock run: status=%d body=%s", locked.Code, locked.Body.String())
+	}
+	blocked := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/billing/reconciliations/"+run.ID+"/recalculate", map[string]any{}, "dev_admin_token")
+	if blocked.Code != http.StatusConflict || !strings.Contains(blocked.Body.String(), "reconciliation_run_locked") {
+		t.Fatalf("recalculate locked run: status=%d body=%s", blocked.Code, blocked.Body.String())
+	}
+	if !hasMethodRoutingAudit(store.ListAuditEvents(), "create", rule.ID) {
+		t.Fatalf("missing create audit for reconciliation rule %s", rule.ID)
+	}
+	assertReconciliationMethodRoutingAudit(t, store, "reconcile", "success", "")
+	assertReconciliationMethodRoutingAudit(t, store, "export", "success", "")
+	assertReconciliationMethodRoutingAudit(t, store, "lock", "success", "")
+}
+
+func adminReconciliationMethodRoutes() []adminReconciliationMethodRoute {
+	return []adminReconciliationMethodRoute{
+		{name: "rule_collection", path: "/api/admin/billing/reconciliation-rules", allowed: []string{http.MethodGet, http.MethodPost}, allow: "GET, POST", wantAdminCode: "method_not_allowed", wantAdminState: http.StatusMethodNotAllowed},
+		{name: "rule_item", path: "/api/admin/billing/reconciliation-rules/missing", allowed: []string{http.MethodGet, http.MethodPatch}, allow: "GET, PATCH", wantAdminCode: "method_not_allowed", wantAdminState: http.StatusMethodNotAllowed},
+		{name: "rule_run", path: "/api/admin/billing/reconciliation-rules/missing/run", allowed: []string{http.MethodPost}, wantAdminCode: "reconciliation_action_not_found", wantAdminState: http.StatusNotFound},
+		{name: "runs_collection", path: "/api/admin/billing/reconciliations", allowed: []string{http.MethodGet}, allow: http.MethodGet, wantAdminCode: "method_not_allowed", wantAdminState: http.StatusMethodNotAllowed},
+		{name: "run_item", path: "/api/admin/billing/reconciliations/missing", allowed: []string{http.MethodGet}, allow: http.MethodGet, wantAdminCode: "method_not_allowed", wantAdminState: http.StatusMethodNotAllowed},
+		{name: "run_lock", path: "/api/admin/billing/reconciliations/missing/lock", allowed: []string{http.MethodPost}, allow: http.MethodPost, wantAdminCode: "method_not_allowed", wantAdminState: http.StatusMethodNotAllowed},
+		{name: "run_recalculate", path: "/api/admin/billing/reconciliations/missing/recalculate", allowed: []string{http.MethodPost}, allow: http.MethodPost, wantAdminCode: "method_not_allowed", wantAdminState: http.StatusMethodNotAllowed},
+		{name: "run_export", path: "/api/admin/billing/reconciliations/missing/export", allowed: []string{http.MethodGet}, allow: http.MethodGet, wantAdminCode: "method_not_allowed", wantAdminState: http.StatusMethodNotAllowed},
+	}
+}
+
+func unsupportedAdminReconciliationMethods(route adminReconciliationMethodRoute) []string {
+	methods := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodTrace, http.MethodConnect}
+	unsupported := make([]string, 0, len(methods))
+	for _, method := range methods {
+		allowed := false
+		for _, candidate := range route.allowed {
+			if candidate == method {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			unsupported = append(unsupported, method)
+		}
+	}
+	return unsupported
+}
+
+func newMethodRoutingReconciliationServer(t *testing.T, maxJSONBytes int64) (*GormStore, http.Handler, BillingConnector) {
+	t.Helper()
+	config := ConfigFromEnv()
+	config.AdminToken = "dev_admin_token"
+	config.BootstrapAdminPassword = "reconciliation-routing-password"
+	config.SecretKey = "reconciliation-method-routing-secret"
+	if maxJSONBytes > 0 {
+		config.MaxJSONRequestBytes = maxJSONBytes
+	}
+	store := NewMemoryStoreWithConfig(config)
+	if err := BootstrapBaseDataWithConfig(store, config); err != nil {
+		t.Fatal(err)
+	}
+	connector := createReconciliationTestConnector(t, store, "reconciliation-routing-connector")
+	return store, NewWithConfig(store, config).Handler(), connector
+}
+
+func createMethodRoutingReconciliationRule(t *testing.T, app http.Handler, connectorID string) ReconciliationRule {
+	t.Helper()
+	response := methodRoutingJSONRequest(t, app, http.MethodPost, "/api/admin/billing/reconciliation-rules", map[string]any{
+		"name": "Method Routing Reconciliation", "connector_id": connectorID, "granularity": ReconciliationGranularityDay,
+		"match_dimensions": []string{"model", "currency"}, "amount_tolerance": "0", "ratio_tolerance": "0", "timezone": "UTC",
+	}, "dev_admin_token")
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create reconciliation rule: status=%d body=%s", response.Code, response.Body.String())
+	}
+	var rule ReconciliationRule
+	if err := json.NewDecoder(response.Body).Decode(&rule); err != nil {
+		t.Fatal(err)
+	}
+	return rule
+}
+
+func reconciliationMethodRoutingBodyRequest(handler http.Handler, method string, path string, body string, token string) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(method, path, strings.NewReader(body))
+	request.Header.Set("content-type", "application/json")
+	if token != "" {
+		request.Header.Set("authorization", "Bearer "+token)
+	}
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	return response
+}
+
+func assertReconciliationMethodRoutingAudit(t *testing.T, store *GormStore, action string, status string, message string) {
+	t.Helper()
+	for _, event := range store.ListAuditEvents() {
+		if event.Action != action || event.ResourceType != "billing_reconciliation" || event.Status != status {
+			continue
+		}
+		if message == "" || event.Message == message {
+			return
+		}
+	}
+	t.Fatalf("missing reconciliation audit action=%s status=%s message=%s", action, status, message)
+}
+
+func minRoutingTestInt(left int, right int) int {
+	if left < right {
+		return left
+	}
+	return right
+}

--- a/backend/internal/server/admin_reconciliation_path_routing_contract_test.go
+++ b/backend/internal/server/admin_reconciliation_path_routing_contract_test.go
@@ -1,0 +1,140 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAdminReconciliationMethodRoutesPreserveTrailingSuccess(t *testing.T) {
+	store, app, connector := newMethodRoutingReconciliationServer(t, 0)
+	rule := createMethodRoutingReconciliationRule(t, app, connector.ID)
+	rulePath := "/api/admin/billing/reconciliation-rules/" + rule.ID
+
+	item := methodRoutingRequest(app, http.MethodGet, rulePath+"/", "dev_admin_token")
+	if item.Code != http.StatusOK || !strings.Contains(item.Body.String(), rule.ID) {
+		t.Fatalf("get trailing rule: status=%d body=%s", item.Code, item.Body.String())
+	}
+	patched := methodRoutingJSONRequest(t, app, http.MethodPatch, rulePath+"/", map[string]any{"name": "Trailing Reconciliation Rule"}, "dev_admin_token")
+	if patched.Code != http.StatusOK || !strings.Contains(patched.Body.String(), "Trailing Reconciliation Rule") {
+		t.Fatalf("patch trailing rule: status=%d body=%s", patched.Code, patched.Body.String())
+	}
+
+	periodStart := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	runResponse := methodRoutingJSONRequest(t, app, http.MethodPost, rulePath+"/run/", map[string]any{
+		"period_start": periodStart.Format(time.RFC3339),
+		"period_end":   periodStart.Add(time.Hour).Format(time.RFC3339),
+	}, "dev_admin_token")
+	if runResponse.Code != http.StatusCreated {
+		t.Fatalf("run trailing rule: status=%d body=%s", runResponse.Code, runResponse.Body.String())
+	}
+	var run ReconciliationRun
+	if err := json.NewDecoder(runResponse.Body).Decode(&run); err != nil {
+		t.Fatal(err)
+	}
+	runPath := "/api/admin/billing/reconciliations/" + run.ID
+
+	detail := methodRoutingRequest(app, http.MethodGet, runPath+"/", "dev_admin_token")
+	if detail.Code != http.StatusOK || !strings.Contains(detail.Body.String(), run.ID) {
+		t.Fatalf("get trailing run: status=%d body=%s", detail.Code, detail.Body.String())
+	}
+	recalculated := methodRoutingJSONRequest(t, app, http.MethodPost, runPath+"/recalculate/", map[string]any{}, "dev_admin_token")
+	if recalculated.Code != http.StatusOK || !strings.Contains(recalculated.Body.String(), `"status":"succeeded"`) {
+		t.Fatalf("recalculate trailing run: status=%d body=%s", recalculated.Code, recalculated.Body.String())
+	}
+	exported := methodRoutingRequest(app, http.MethodGet, runPath+"/export/", "dev_admin_token")
+	if exported.Code != http.StatusOK || !strings.HasPrefix(exported.Header().Get("content-type"), "text/csv") {
+		t.Fatalf("export trailing run: status=%d headers=%v body=%s", exported.Code, exported.Header(), exported.Body.String())
+	}
+	locked := methodRoutingJSONRequest(t, app, http.MethodPost, runPath+"/lock/", map[string]any{}, "dev_admin_token")
+	if locked.Code != http.StatusOK || !strings.Contains(locked.Body.String(), `"locked_at"`) {
+		t.Fatalf("lock trailing run: status=%d body=%s", locked.Code, locked.Body.String())
+	}
+	blocked := methodRoutingJSONRequest(t, app, http.MethodPost, runPath+"/recalculate/", map[string]any{}, "dev_admin_token")
+	assertJSONError(t, blocked, http.StatusConflict, "reconciliation_run_locked")
+
+	for _, action := range []string{"update", "reconcile", "recalculate", "export", "lock"} {
+		if !hasReconciliationPathRoutingAudit(store.ListAuditEvents(), action) {
+			t.Fatalf("missing %s audit for trailing reconciliation route", action)
+		}
+	}
+}
+
+func TestAdminReconciliationMethodRoutesPreserveEncodedPathFailures(t *testing.T) {
+	store, app, connector := newMethodRoutingReconciliationServer(t, 0)
+	rule := createMethodRoutingReconciliationRule(t, app, connector.ID)
+	storedRule, err := store.GetReconciliationRule(rule.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storedRule.ID = "reconciliation/encoded-rule"
+	storedRule.Name = "Encoded Reconciliation Rule"
+	storedRule.CreatedAt = time.Time{}
+	storedRule.UpdatedAt = time.Time{}
+	storedRule.LastRunAt = nil
+	storedRule.NextRunAt = nil
+	if _, err := store.CreateReconciliationRule(storedRule); err != nil {
+		t.Fatal(err)
+	}
+
+	encodedRulePath := "/api/admin/billing/reconciliation-rules/" + url.PathEscape(storedRule.ID)
+	for _, test := range []struct {
+		name       string
+		method     string
+		path       string
+		wantCode   string
+		wantStatus int
+	}{
+		{name: "allowed item method", method: http.MethodGet, path: encodedRulePath, wantCode: "reconciliation_action_not_found", wantStatus: http.StatusNotFound},
+		{name: "head item method", method: http.MethodHead, path: encodedRulePath, wantCode: "reconciliation_action_not_found", wantStatus: http.StatusNotFound},
+		{name: "wrong item method", method: http.MethodDelete, path: encodedRulePath, wantCode: "reconciliation_action_not_found", wantStatus: http.StatusNotFound},
+		{name: "run method", method: http.MethodPost, path: encodedRulePath + "/run", wantCode: "reconciliation_rule_not_found", wantStatus: http.StatusNotFound},
+	} {
+		t.Run("rule/"+test.name, func(t *testing.T) {
+			response := methodRoutingRequest(app, test.method, test.path, "dev_admin_token")
+			assertJSONError(t, response, test.wantStatus, test.wantCode)
+			assertAllowHeader(t, response, "")
+		})
+	}
+
+	encodedRun := ReconciliationRun{ID: "reconciliation/encoded-run", RuleID: rule.ID, Status: ReconciliationRunSucceeded}
+	if err := store.db.Create(&encodedRun).Error; err != nil {
+		t.Fatal(err)
+	}
+	encodedRunPath := "/api/admin/billing/reconciliations/" + url.PathEscape(encodedRun.ID)
+	for _, test := range []struct {
+		name       string
+		method     string
+		path       string
+		wantCode   string
+		wantStatus int
+	}{
+		{name: "allowed item method", method: http.MethodGet, path: encodedRunPath, wantCode: "reconciliation_action_not_found", wantStatus: http.StatusNotFound},
+		{name: "head item method", method: http.MethodHead, path: encodedRunPath, wantCode: "reconciliation_action_not_found", wantStatus: http.StatusNotFound},
+		{name: "wrong item method", method: http.MethodDelete, path: encodedRunPath, wantCode: "reconciliation_action_not_found", wantStatus: http.StatusNotFound},
+		{name: "lock method", method: http.MethodPost, path: encodedRunPath + "/lock", wantCode: "reconciliation_run_not_found", wantStatus: http.StatusNotFound},
+		{name: "wrong lock method", method: http.MethodGet, path: encodedRunPath + "/lock", wantCode: "reconciliation_run_not_found", wantStatus: http.StatusNotFound},
+	} {
+		t.Run("run/"+test.name, func(t *testing.T) {
+			response := methodRoutingRequest(app, test.method, test.path, "dev_admin_token")
+			assertJSONError(t, response, test.wantStatus, test.wantCode)
+			assertAllowHeader(t, response, "")
+		})
+	}
+
+	unauthorized := methodRoutingRequest(app, http.MethodDelete, encodedRunPath, "")
+	assertJSONError(t, unauthorized, http.StatusUnauthorized, "invalid_admin_token")
+	assertAllowHeader(t, unauthorized, "")
+}
+
+func hasReconciliationPathRoutingAudit(events []AuditEvent, action string) bool {
+	for _, event := range events {
+		if event.Action == action && (event.ResourceType == "reconciliation_rule" || event.ResourceType == "billing_reconciliation") {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/server/admin_reconciliation_routing.go
+++ b/backend/internal/server/admin_reconciliation_routing.go
@@ -1,0 +1,132 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+)
+
+type adminReconciliationRuleHandler func(http.ResponseWriter, *http.Request, AdminUser, string)
+type adminReconciliationRunHandler func(http.ResponseWriter, *http.Request, AdminUser, string)
+
+func (s *Server) registerReconciliationRoutes() {
+	reconciliationMethodNotAllowed := func(allowedMethods string) http.HandlerFunc {
+		return s.adminMethodNotAllowed("billing", allowedMethods)
+	}
+	s.registerMethodRoutes("/api/admin/billing/reconciliation-rules", reconciliationMethodNotAllowed,
+		methodRoute{Method: http.MethodGet, Handler: s.handleAdminReconciliationRulesGet},
+		methodRoute{Method: http.MethodPost, Handler: s.handleAdminReconciliationRulesPost},
+	)
+	s.registerMethodRoutes("/api/admin/billing/reconciliation-rules/{rule_id}", s.adminReconciliationRuleMethodNotAllowed,
+		methodRoute{Method: http.MethodGet, Handler: s.handleAdminReconciliationRuleGet},
+		methodRoute{Method: http.MethodPatch, Handler: s.handleAdminReconciliationRulePatch},
+	)
+	// The legacy nested handler deliberately reports a non-POST /run as a 404.
+	// Register only the successful method so its fallback retains that contract.
+	s.registerDynamicMethodRoute(http.MethodPost, "/api/admin/billing/reconciliation-rules/{rule_id}/run", s.handleAdminReconciliationRuleRunPost)
+	s.mux.HandleFunc("/api/admin/billing/reconciliation-rules/", s.handleAdminReconciliationRuleItem)
+	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/billing/reconciliations", s.handleAdminReconciliationsGet, s.adminMethodNotAllowed("billing", http.MethodGet))
+	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/billing/reconciliations/{run_id}", s.handleAdminReconciliationGet, s.adminReconciliationRunMethodNotAllowed(http.MethodGet))
+	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/billing/reconciliations/{run_id}/lock", s.handleAdminReconciliationLockPost, s.adminReconciliationRunMethodNotAllowed(http.MethodPost))
+	s.registerSingleMethodRoute(http.MethodPost, "/api/admin/billing/reconciliations/{run_id}/recalculate", s.handleAdminReconciliationRecalculatePost, s.adminReconciliationRunMethodNotAllowed(http.MethodPost))
+	s.registerSingleMethodRoute(http.MethodGet, "/api/admin/billing/reconciliations/{run_id}/export", s.handleAdminReconciliationExportGet, s.adminReconciliationRunMethodNotAllowed(http.MethodGet))
+	s.mux.HandleFunc("/api/admin/billing/reconciliations/", s.handleAdminReconciliationItem)
+}
+
+func (s *Server) adminReconciliationRuleMethodNotAllowed(allowedMethods string) http.HandlerFunc {
+	reject := s.adminMethodNotAllowed("billing", allowedMethods)
+	return func(w http.ResponseWriter, r *http.Request) {
+		if ruleID := r.PathValue("rule_id"); ruleID == "" || strings.Contains(ruleID, "/") {
+			s.handleAdminReconciliationRuleItem(w, r)
+			return
+		}
+		reject(w, r)
+	}
+}
+
+func (s *Server) adminReconciliationRunMethodNotAllowed(allowedMethods string) http.HandlerFunc {
+	reject := s.adminMethodNotAllowed("billing", allowedMethods)
+	return func(w http.ResponseWriter, r *http.Request) {
+		if runID := r.PathValue("run_id"); runID == "" || strings.Contains(runID, "/") {
+			s.handleAdminReconciliationItem(w, r)
+			return
+		}
+		reject(w, r)
+	}
+}
+
+func (s *Server) handleAdminReconciliationRulesGet(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAdmin(w, r, "billing", r.Method)
+	if !ok {
+		return
+	}
+	s.serveAdminReconciliationRulesGet(w, r, user)
+}
+
+func (s *Server) handleAdminReconciliationRulesPost(w http.ResponseWriter, r *http.Request) {
+	user, ok := s.requireAdmin(w, r, "billing", r.Method)
+	if !ok {
+		return
+	}
+	s.serveAdminReconciliationRulesPost(w, r, user)
+}
+
+func (s *Server) handleAdminReconciliationRuleGet(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminReconciliationRuleRoute(w, r, s.serveAdminReconciliationRuleGet)
+}
+
+func (s *Server) handleAdminReconciliationRulePatch(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminReconciliationRuleRoute(w, r, s.serveAdminReconciliationRulePatch)
+}
+
+func (s *Server) handleAdminReconciliationRuleRunPost(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminReconciliationRuleRoute(w, r, s.serveAdminReconciliationRuleRun)
+}
+
+func (s *Server) handleAdminReconciliationRuleRoute(w http.ResponseWriter, r *http.Request, handler adminReconciliationRuleHandler) {
+	ruleID := r.PathValue("rule_id")
+	if ruleID == "" || strings.Contains(ruleID, "/") {
+		s.handleAdminReconciliationRuleItem(w, r)
+		return
+	}
+	user, ok := s.requireAdmin(w, r, "billing", r.Method)
+	if !ok {
+		return
+	}
+	handler(w, r, user, ruleID)
+}
+
+func (s *Server) handleAdminReconciliationsGet(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requireAdmin(w, r, "billing", r.Method); !ok {
+		return
+	}
+	s.serveAdminReconciliationsGet(w, r)
+}
+
+func (s *Server) handleAdminReconciliationGet(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminReconciliationRoute(w, r, s.serveAdminReconciliationGet)
+}
+
+func (s *Server) handleAdminReconciliationLockPost(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminReconciliationRoute(w, r, s.serveAdminReconciliationLock)
+}
+
+func (s *Server) handleAdminReconciliationRecalculatePost(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminReconciliationRoute(w, r, s.serveAdminReconciliationRecalculate)
+}
+
+func (s *Server) handleAdminReconciliationExportGet(w http.ResponseWriter, r *http.Request) {
+	s.handleAdminReconciliationRoute(w, r, s.serveAdminReconciliationExport)
+}
+
+func (s *Server) handleAdminReconciliationRoute(w http.ResponseWriter, r *http.Request, handler adminReconciliationRunHandler) {
+	runID := r.PathValue("run_id")
+	if runID == "" || strings.Contains(runID, "/") {
+		s.handleAdminReconciliationItem(w, r)
+		return
+	}
+	user, ok := s.requireAdmin(w, r, "billing", r.Method)
+	if !ok {
+		return
+	}
+	handler(w, r, user, runID)
+}

--- a/backend/internal/server/billing_http.go
+++ b/backend/internal/server/billing_http.go
@@ -8,53 +8,38 @@ import (
 	"time"
 )
 
-func (s *Server) registerBillingRoutes() {
-	s.mux.HandleFunc("/api/admin/billing/connectors", s.handleAdminBillingConnectors)
-	s.mux.HandleFunc("/api/admin/billing/connectors/", s.handleAdminBillingConnectorItem)
-	s.mux.HandleFunc("/api/admin/billing/records", s.handleAdminBillingRecords)
-	s.mux.HandleFunc("/api/admin/billing/sync-runs", s.handleAdminBillingSyncRuns)
-	s.registerReconciliationRoutes()
-}
-
 func (s *Server) StartBillingScheduler() {
 	s.billing.StartScheduler(30 * time.Second)
 	s.reconciliation.StartScheduler(30 * time.Second)
 	s.credentialRefresh.StartScheduler(providerCredentialRefreshInterval)
 }
 
-func (s *Server) handleAdminBillingConnectors(w http.ResponseWriter, r *http.Request) {
-	user, ok := s.requireAdmin(w, r, "billing", r.Method)
-	if !ok {
+func (s *Server) serveAdminBillingConnectorsGet(w http.ResponseWriter, _ *http.Request, _ AdminUser) {
+	writeJSON(w, http.StatusOK, map[string]any{"data": s.store.ListBillingConnectors()})
+}
+
+func (s *Server) serveAdminBillingConnectorsPost(w http.ResponseWriter, r *http.Request, user AdminUser) {
+	var request BillingConnectorRequest
+	if err := s.decodeJSON(w, r, &request); err != nil {
+		if isPayloadTooLarge(err) {
+			writeError(w, r, err)
+			return
+		}
+		writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_billing_connector", "Invalid billing connector payload"))
 		return
 	}
-	switch r.Method {
-	case http.MethodGet:
-		writeJSON(w, http.StatusOK, map[string]any{"data": s.store.ListBillingConnectors()})
-	case http.MethodPost:
-		var request BillingConnectorRequest
-		if err := s.decodeJSON(w, r, &request); err != nil {
-			if isPayloadTooLarge(err) {
-				writeError(w, r, err)
-				return
-			}
-			writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_billing_connector", "Invalid billing connector payload"))
-			return
-		}
-		connector, err := billingConnectorFromRequest(request)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		created, err := s.store.CreateBillingConnector(connector)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "create", "billing_connector", created.ID, nil, created)
-		writeJSON(w, http.StatusCreated, created)
-	default:
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+	connector, err := billingConnectorFromRequest(request)
+	if err != nil {
+		writeError(w, r, err)
+		return
 	}
+	created, err := s.store.CreateBillingConnector(connector)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "create", "billing_connector", created.ID, nil, created)
+	writeJSON(w, http.StatusCreated, created)
 }
 
 func (s *Server) handleAdminBillingConnectorItem(w http.ResponseWriter, r *http.Request) {
@@ -63,126 +48,132 @@ func (s *Server) handleAdminBillingConnectorItem(w http.ResponseWriter, r *http.
 		return
 	}
 	parts := splitEscapedAdminPath(r.URL.EscapedPath(), "/api/admin/billing/connectors/")
-	id := parts[0]
-	if id == "" || len(parts) > 2 {
+	if len(parts) == 0 || parts[0] == "" || len(parts) > 2 {
 		writeError(w, r, NewHTTPError(http.StatusNotFound, "billing_connector_not_found", "Billing connector not found"))
 		return
 	}
+	id := parts[0]
 	if len(parts) == 2 {
 		s.handleAdminBillingConnectorAction(w, r, user, id, parts[1])
 		return
 	}
 	switch r.Method {
 	case http.MethodGet:
-		connector, err := s.store.GetBillingConnector(id, false)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		writeJSON(w, http.StatusOK, connector)
+		s.serveAdminBillingConnectorGet(w, r, user, id)
 	case http.MethodPatch:
-		before, err := s.store.GetBillingConnector(id, false)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		var request BillingConnectorPatchRequest
-		if err := s.decodeJSON(w, r, &request); err != nil {
-			if isPayloadTooLarge(err) {
-				writeError(w, r, err)
-				return
-			}
-			writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_billing_connector", "Invalid billing connector payload"))
-			return
-		}
-		patch, err := billingConnectorPatch(request, before)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		updated, err := s.store.UpdateBillingConnector(id, patch)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "update", "billing_connector", id, before, updated)
-		writeJSON(w, http.StatusOK, updated)
+		s.serveAdminBillingConnectorPatch(w, r, user, id)
 	case http.MethodDelete:
-		before, err := s.store.GetBillingConnector(id, false)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		if err := s.store.DeleteBillingConnector(id); err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "delete", "billing_connector", id, before, nil)
-		w.WriteHeader(http.StatusNoContent)
+		s.serveAdminBillingConnectorDelete(w, r, user, id)
 	default:
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+		jsonMethodNotAllowed("GET, PATCH, DELETE")(w, r)
 	}
+}
+
+func (s *Server) serveAdminBillingConnectorGet(w http.ResponseWriter, r *http.Request, _ AdminUser, connectorID string) {
+	connector, err := s.store.GetBillingConnector(connectorID, false)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, connector)
+}
+
+func (s *Server) serveAdminBillingConnectorPatch(w http.ResponseWriter, r *http.Request, user AdminUser, connectorID string) {
+	before, err := s.store.GetBillingConnector(connectorID, false)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	var request BillingConnectorPatchRequest
+	if err := s.decodeJSON(w, r, &request); err != nil {
+		if isPayloadTooLarge(err) {
+			writeError(w, r, err)
+			return
+		}
+		writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_billing_connector", "Invalid billing connector payload"))
+		return
+	}
+	patch, err := billingConnectorPatch(request, before)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	updated, err := s.store.UpdateBillingConnector(connectorID, patch)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "update", "billing_connector", connectorID, before, updated)
+	writeJSON(w, http.StatusOK, updated)
+}
+
+func (s *Server) serveAdminBillingConnectorDelete(w http.ResponseWriter, r *http.Request, user AdminUser, connectorID string) {
+	before, err := s.store.GetBillingConnector(connectorID, false)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	if err := s.store.DeleteBillingConnector(connectorID); err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "delete", "billing_connector", connectorID, before, nil)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) handleAdminBillingConnectorAction(w http.ResponseWriter, r *http.Request, user AdminUser, connectorID string, action string) {
 	if r.Method != http.MethodPost {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+		jsonMethodNotAllowed(http.MethodPost)(w, r)
 		return
 	}
 	switch action {
 	case "test":
-		result, err := s.billing.Test(r.Context(), connectorID)
-		if err != nil {
-			httpErr := AsHTTPError(err)
-			s.recordAdminAuditWithStatus(r, user, "test", "billing_connector", connectorID, BillingSyncFailed, httpErr.Code, nil, map[string]any{"error_code": httpErr.Code})
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "test", "billing_connector", connectorID, nil, result)
-		writeJSON(w, http.StatusOK, result)
+		s.serveAdminBillingConnectorTest(w, r, user, connectorID)
 	case "sync":
-		var request BillingSyncRequest
-		if err := s.decodeJSONOptional(w, r, &request); err != nil {
-			if isPayloadTooLarge(err) {
-				writeError(w, r, err)
-				return
-			}
-			writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_billing_sync", "Invalid billing sync payload"))
-			return
-		}
-		run, err := s.billing.Sync(r.Context(), connectorID, request, "manual")
-		if err != nil {
-			httpErr := AsHTTPError(err)
-			s.recordAdminAuditWithStatus(r, user, "sync", "billing_connector", connectorID, BillingSyncFailed, httpErr.Code, nil, run)
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "sync", "billing_connector", connectorID, nil, run)
-		writeJSON(w, http.StatusOK, run)
+		s.serveAdminBillingConnectorSync(w, r, user, connectorID)
 	default:
 		writeError(w, r, NewHTTPError(http.StatusNotFound, "billing_action_not_found", "Billing connector action not found"))
 	}
 }
 
-func (s *Server) handleAdminBillingRecords(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r, "billing", r.Method); !ok {
+func (s *Server) serveAdminBillingConnectorTest(w http.ResponseWriter, r *http.Request, user AdminUser, connectorID string) {
+	result, err := s.billing.Test(r.Context(), connectorID)
+	if err != nil {
+		httpErr := AsHTTPError(err)
+		s.recordAdminAuditWithStatus(r, user, "test", "billing_connector", connectorID, BillingSyncFailed, httpErr.Code, nil, map[string]any{"error_code": httpErr.Code})
+		writeError(w, r, err)
 		return
 	}
-	if r.Method != http.MethodGet {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+	s.recordAdminAudit(r, user, "test", "billing_connector", connectorID, nil, result)
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) serveAdminBillingConnectorSync(w http.ResponseWriter, r *http.Request, user AdminUser, connectorID string) {
+	var request BillingSyncRequest
+	if err := s.decodeJSONOptional(w, r, &request); err != nil {
+		if isPayloadTooLarge(err) {
+			writeError(w, r, err)
+			return
+		}
+		writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_billing_sync", "Invalid billing sync payload"))
 		return
 	}
+	run, err := s.billing.Sync(r.Context(), connectorID, request, "manual")
+	if err != nil {
+		httpErr := AsHTTPError(err)
+		s.recordAdminAuditWithStatus(r, user, "sync", "billing_connector", connectorID, BillingSyncFailed, httpErr.Code, nil, run)
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "sync", "billing_connector", connectorID, nil, run)
+	writeJSON(w, http.StatusOK, run)
+}
+
+func (s *Server) serveAdminBillingRecordsGet(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"data": s.store.ListBillingRecords(r.URL.Query().Get("connector_id"), billingListLimit(r))})
 }
 
-func (s *Server) handleAdminBillingSyncRuns(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r, "billing", r.Method); !ok {
-		return
-	}
-	if r.Method != http.MethodGet {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
-		return
-	}
+func (s *Server) serveAdminBillingSyncRunsGet(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"data": s.store.ListBillingSyncRuns(r.URL.Query().Get("connector_id"), billingListLimit(r))})
 }
 

--- a/backend/internal/server/reconciliation_http.go
+++ b/backend/internal/server/reconciliation_http.go
@@ -8,41 +8,27 @@ import (
 	"strings"
 )
 
-func (s *Server) registerReconciliationRoutes() {
-	s.mux.HandleFunc("/api/admin/billing/reconciliation-rules", s.handleAdminReconciliationRules)
-	s.mux.HandleFunc("/api/admin/billing/reconciliation-rules/", s.handleAdminReconciliationRuleItem)
-	s.mux.HandleFunc("/api/admin/billing/reconciliations", s.handleAdminReconciliations)
-	s.mux.HandleFunc("/api/admin/billing/reconciliations/", s.handleAdminReconciliationItem)
+func (s *Server) serveAdminReconciliationRulesGet(w http.ResponseWriter, _ *http.Request, _ AdminUser) {
+	writeJSON(w, http.StatusOK, map[string]any{"data": newReconciliationRuleResponses(s.store.ListReconciliationRules())})
 }
 
-func (s *Server) handleAdminReconciliationRules(w http.ResponseWriter, r *http.Request) {
-	user, ok := s.requireAdmin(w, r, "billing", r.Method)
-	if !ok {
-		return
-	}
-	switch r.Method {
-	case http.MethodGet:
-		writeJSON(w, http.StatusOK, map[string]any{"data": newReconciliationRuleResponses(s.store.ListReconciliationRules())})
-	case http.MethodPost:
-		var request ReconciliationRuleRequest
-		if err := s.decodeJSON(w, r, &request); err != nil {
-			if isPayloadTooLarge(err) {
-				writeError(w, r, err)
-				return
-			}
-			writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_reconciliation_rule", "Invalid reconciliation rule payload"))
-			return
-		}
-		rule, err := s.reconciliation.CreateRule(request, user.ID)
-		if err != nil {
+func (s *Server) serveAdminReconciliationRulesPost(w http.ResponseWriter, r *http.Request, user AdminUser) {
+	var request ReconciliationRuleRequest
+	if err := s.decodeJSON(w, r, &request); err != nil {
+		if isPayloadTooLarge(err) {
 			writeError(w, r, err)
 			return
 		}
-		s.recordAdminAudit(r, user, "create", "reconciliation_rule", rule.ID, nil, reconciliationRuleAuditSnapshot(rule))
-		writeJSON(w, http.StatusCreated, newReconciliationRuleResponse(rule))
-	default:
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+		writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_reconciliation_rule", "Invalid reconciliation rule payload"))
+		return
 	}
+	rule, err := s.reconciliation.CreateRule(request, user.ID)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "create", "reconciliation_rule", rule.ID, nil, reconciliationRuleAuditSnapshot(rule))
+	writeJSON(w, http.StatusCreated, newReconciliationRuleResponse(rule))
 }
 
 func (s *Server) handleAdminReconciliationRuleItem(w http.ResponseWriter, r *http.Request) {
@@ -60,71 +46,76 @@ func (s *Server) handleAdminReconciliationRuleItem(w http.ResponseWriter, r *htt
 			writeError(w, r, NewHTTPError(http.StatusNotFound, "reconciliation_action_not_found", "Reconciliation action not found"))
 			return
 		}
-		var request ReconciliationRunRequest
-		if err := s.decodeJSON(w, r, &request); err != nil {
-			httpErr := NewHTTPError(http.StatusBadRequest, "invalid_reconciliation_run", "Invalid reconciliation run payload")
-			if isPayloadTooLarge(err) {
-				httpErr = AsHTTPError(err)
-			}
-			s.recordAdminAuditWithStatus(r, user, "reconcile", "billing_reconciliation", parts[0], "failed", httpErr.Code, nil, map[string]any{"rule_id": parts[0], "error_code": httpErr.Code})
-			writeError(w, r, httpErr)
-			return
-		}
-		run, err := s.reconciliation.Run(r.Context(), parts[0], request, "manual", user.ID)
-		if err != nil {
-			httpErr := AsHTTPError(err)
-			resourceID := parts[0]
-			after := any(map[string]any{"rule_id": parts[0], "error_code": httpErr.Code})
-			if run.ID != "" {
-				resourceID = run.ID
-				after = reconciliationAuditSnapshot(run)
-			}
-			s.recordAdminAuditWithStatus(r, user, "reconcile", "billing_reconciliation", resourceID, "failed", httpErr.Code, nil, after)
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "reconcile", "billing_reconciliation", run.ID, nil, reconciliationAuditSnapshot(run))
-		writeJSON(w, http.StatusCreated, newReconciliationRunResponse(run))
+		s.serveAdminReconciliationRuleRun(w, r, user, parts[0])
 		return
 	}
 	switch r.Method {
 	case http.MethodGet:
-		rule, err := s.store.GetReconciliationRule(parts[0])
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		writeJSON(w, http.StatusOK, newReconciliationRuleResponse(rule))
+		s.serveAdminReconciliationRuleGet(w, r, user, parts[0])
 	case http.MethodPatch:
-		var request ReconciliationRulePatchRequest
-		if err := s.decodeJSON(w, r, &request); err != nil {
-			if isPayloadTooLarge(err) {
-				writeError(w, r, err)
-				return
-			}
-			writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_reconciliation_rule", "Invalid reconciliation rule payload"))
-			return
-		}
-		before, updated, err := s.reconciliation.UpdateRule(parts[0], request, user.ID)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "update", "reconciliation_rule", updated.ID, reconciliationRuleAuditSnapshot(before), reconciliationRuleAuditSnapshot(updated))
-		writeJSON(w, http.StatusOK, newReconciliationRuleResponse(updated))
+		s.serveAdminReconciliationRulePatch(w, r, user, parts[0])
 	default:
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+		jsonMethodNotAllowed("GET, PATCH")(w, r)
 	}
 }
 
-func (s *Server) handleAdminReconciliations(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAdmin(w, r, "billing", r.Method); !ok {
+func (s *Server) serveAdminReconciliationRuleGet(w http.ResponseWriter, r *http.Request, _ AdminUser, ruleID string) {
+	rule, err := s.store.GetReconciliationRule(ruleID)
+	if err != nil {
+		writeError(w, r, err)
 		return
 	}
-	if r.Method != http.MethodGet {
-		writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+	writeJSON(w, http.StatusOK, newReconciliationRuleResponse(rule))
+}
+
+func (s *Server) serveAdminReconciliationRulePatch(w http.ResponseWriter, r *http.Request, user AdminUser, ruleID string) {
+	var request ReconciliationRulePatchRequest
+	if err := s.decodeJSON(w, r, &request); err != nil {
+		if isPayloadTooLarge(err) {
+			writeError(w, r, err)
+			return
+		}
+		writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_reconciliation_rule", "Invalid reconciliation rule payload"))
 		return
 	}
+	before, updated, err := s.reconciliation.UpdateRule(ruleID, request, user.ID)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "update", "reconciliation_rule", updated.ID, reconciliationRuleAuditSnapshot(before), reconciliationRuleAuditSnapshot(updated))
+	writeJSON(w, http.StatusOK, newReconciliationRuleResponse(updated))
+}
+
+func (s *Server) serveAdminReconciliationRuleRun(w http.ResponseWriter, r *http.Request, user AdminUser, ruleID string) {
+	var request ReconciliationRunRequest
+	if err := s.decodeJSON(w, r, &request); err != nil {
+		httpErr := NewHTTPError(http.StatusBadRequest, "invalid_reconciliation_run", "Invalid reconciliation run payload")
+		if isPayloadTooLarge(err) {
+			httpErr = AsHTTPError(err)
+		}
+		s.recordAdminAuditWithStatus(r, user, "reconcile", "billing_reconciliation", ruleID, "failed", httpErr.Code, nil, map[string]any{"rule_id": ruleID, "error_code": httpErr.Code})
+		writeError(w, r, httpErr)
+		return
+	}
+	run, err := s.reconciliation.Run(r.Context(), ruleID, request, "manual", user.ID)
+	if err != nil {
+		httpErr := AsHTTPError(err)
+		resourceID := ruleID
+		after := any(map[string]any{"rule_id": ruleID, "error_code": httpErr.Code})
+		if run.ID != "" {
+			resourceID = run.ID
+			after = reconciliationAuditSnapshot(run)
+		}
+		s.recordAdminAuditWithStatus(r, user, "reconcile", "billing_reconciliation", resourceID, "failed", httpErr.Code, nil, after)
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "reconcile", "billing_reconciliation", run.ID, nil, reconciliationAuditSnapshot(run))
+	writeJSON(w, http.StatusCreated, newReconciliationRunResponse(run))
+}
+
+func (s *Server) serveAdminReconciliationsGet(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"data": newReconciliationRunResponses(s.store.ListReconciliationRuns(r.URL.Query().Get("rule_id"), reconciliationListLimit(r, 100, 500)))})
 }
 
@@ -141,81 +132,97 @@ func (s *Server) handleAdminReconciliationItem(w http.ResponseWriter, r *http.Re
 	runID := parts[0]
 	if len(parts) == 1 {
 		if r.Method != http.MethodGet {
-			writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+			jsonMethodNotAllowed(http.MethodGet)(w, r)
 			return
 		}
-		run, err := s.store.GetReconciliationRun(runID)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		limit := reconciliationListLimit(r, 100, 500)
-		offset := reconciliationListOffset(r)
-		items, total := s.store.ListReconciliationItems(runID, r.URL.Query().Get("status"), limit, offset)
-		writeJSON(w, http.StatusOK, newReconciliationDetailResponse(ReconciliationDetail{Run: run, Items: items, Total: total, Limit: limit, Offset: offset}))
+		s.serveAdminReconciliationGet(w, r, user, runID)
 		return
 	}
 	switch parts[1] {
 	case "lock":
 		if r.Method != http.MethodPost {
-			writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+			jsonMethodNotAllowed(http.MethodPost)(w, r)
 			return
 		}
-		before, err := s.store.GetReconciliationRun(runID)
-		if err != nil {
-			httpErr := AsHTTPError(err)
-			s.recordAdminAuditWithStatus(r, user, "lock", "billing_reconciliation", runID, "failed", httpErr.Code, nil, map[string]any{"id": runID, "error_code": httpErr.Code})
-			writeError(w, r, err)
-			return
-		}
-		run, err := s.store.LockReconciliationRun(runID, user.ID)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "lock", "billing_reconciliation", run.ID, reconciliationAuditSnapshot(before), reconciliationAuditSnapshot(run))
-		writeJSON(w, http.StatusOK, newReconciliationRunResponse(run))
+		s.serveAdminReconciliationLock(w, r, user, runID)
 	case "recalculate":
 		if r.Method != http.MethodPost {
-			writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+			jsonMethodNotAllowed(http.MethodPost)(w, r)
 			return
 		}
-		before, err := s.store.GetReconciliationRun(runID)
-		if err != nil {
-			httpErr := AsHTTPError(err)
-			s.recordAdminAuditWithStatus(r, user, "recalculate", "billing_reconciliation", runID, "failed", httpErr.Code, nil, map[string]any{"id": runID, "error_code": httpErr.Code})
-			writeError(w, r, err)
-			return
-		}
-		run, err := s.reconciliation.Recalculate(r.Context(), runID)
-		if err != nil {
-			httpErr := AsHTTPError(err)
-			after := any(map[string]any{"id": runID, "error_code": httpErr.Code})
-			if run.ID != "" {
-				after = reconciliationAuditSnapshot(run)
-			}
-			s.recordAdminAuditWithStatus(r, user, "recalculate", "billing_reconciliation", runID, "failed", httpErr.Code, reconciliationAuditSnapshot(before), after)
-			writeError(w, r, err)
-			return
-		}
-		s.recordAdminAudit(r, user, "recalculate", "billing_reconciliation", run.ID, reconciliationAuditSnapshot(before), reconciliationAuditSnapshot(run))
-		writeJSON(w, http.StatusOK, newReconciliationRunResponse(run))
+		s.serveAdminReconciliationRecalculate(w, r, user, runID)
 	case "export":
 		if r.Method != http.MethodGet {
-			writeError(w, r, NewHTTPError(http.StatusMethodNotAllowed, "method_not_allowed", "Method not allowed"))
+			jsonMethodNotAllowed(http.MethodGet)(w, r)
 			return
 		}
-		run, err := s.store.GetReconciliationRun(runID)
-		if err != nil {
-			writeError(w, r, err)
-			return
-		}
-		status := strings.TrimSpace(r.URL.Query().Get("status"))
-		s.recordAdminAudit(r, user, "export", "billing_reconciliation", run.ID, nil, reconciliationAuditSnapshot(run))
-		s.writeReconciliationCSV(w, run, status)
+		s.serveAdminReconciliationExport(w, r, user, runID)
 	default:
 		writeError(w, r, NewHTTPError(http.StatusNotFound, "reconciliation_action_not_found", "Reconciliation action not found"))
 	}
+}
+
+func (s *Server) serveAdminReconciliationGet(w http.ResponseWriter, r *http.Request, _ AdminUser, runID string) {
+	run, err := s.store.GetReconciliationRun(runID)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	limit := reconciliationListLimit(r, 100, 500)
+	offset := reconciliationListOffset(r)
+	items, total := s.store.ListReconciliationItems(runID, r.URL.Query().Get("status"), limit, offset)
+	writeJSON(w, http.StatusOK, newReconciliationDetailResponse(ReconciliationDetail{Run: run, Items: items, Total: total, Limit: limit, Offset: offset}))
+}
+
+func (s *Server) serveAdminReconciliationLock(w http.ResponseWriter, r *http.Request, user AdminUser, runID string) {
+	before, err := s.store.GetReconciliationRun(runID)
+	if err != nil {
+		httpErr := AsHTTPError(err)
+		s.recordAdminAuditWithStatus(r, user, "lock", "billing_reconciliation", runID, "failed", httpErr.Code, nil, map[string]any{"id": runID, "error_code": httpErr.Code})
+		writeError(w, r, err)
+		return
+	}
+	run, err := s.store.LockReconciliationRun(runID, user.ID)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "lock", "billing_reconciliation", run.ID, reconciliationAuditSnapshot(before), reconciliationAuditSnapshot(run))
+	writeJSON(w, http.StatusOK, newReconciliationRunResponse(run))
+}
+
+func (s *Server) serveAdminReconciliationRecalculate(w http.ResponseWriter, r *http.Request, user AdminUser, runID string) {
+	before, err := s.store.GetReconciliationRun(runID)
+	if err != nil {
+		httpErr := AsHTTPError(err)
+		s.recordAdminAuditWithStatus(r, user, "recalculate", "billing_reconciliation", runID, "failed", httpErr.Code, nil, map[string]any{"id": runID, "error_code": httpErr.Code})
+		writeError(w, r, err)
+		return
+	}
+	run, err := s.reconciliation.Recalculate(r.Context(), runID)
+	if err != nil {
+		httpErr := AsHTTPError(err)
+		after := any(map[string]any{"id": runID, "error_code": httpErr.Code})
+		if run.ID != "" {
+			after = reconciliationAuditSnapshot(run)
+		}
+		s.recordAdminAuditWithStatus(r, user, "recalculate", "billing_reconciliation", runID, "failed", httpErr.Code, reconciliationAuditSnapshot(before), after)
+		writeError(w, r, err)
+		return
+	}
+	s.recordAdminAudit(r, user, "recalculate", "billing_reconciliation", run.ID, reconciliationAuditSnapshot(before), reconciliationAuditSnapshot(run))
+	writeJSON(w, http.StatusOK, newReconciliationRunResponse(run))
+}
+
+func (s *Server) serveAdminReconciliationExport(w http.ResponseWriter, r *http.Request, user AdminUser, runID string) {
+	run, err := s.store.GetReconciliationRun(runID)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	status := strings.TrimSpace(r.URL.Query().Get("status"))
+	s.recordAdminAudit(r, user, "export", "billing_reconciliation", run.ID, nil, reconciliationAuditSnapshot(run))
+	s.writeReconciliationCSV(w, run, status)
 }
 
 func pathPartsAfter(path string, prefix string) []string {


### PR DESCRIPTION
## Summary

Route the billing connector and reconciliation APIs through method-aware patterns while preserving their existing authentication, authorization, validation, and business behavior.

## Related Issue

Related #145

## Changes

### Billing routes

- `GET|POST /api/admin/billing/connectors`
- `GET|PATCH|DELETE /api/admin/billing/connectors/{connector_id}`
- `POST /api/admin/billing/connectors/{connector_id}/test`
- `POST /api/admin/billing/connectors/{connector_id}/sync`
- `GET /api/admin/billing/records`
- `GET /api/admin/billing/sync-runs`

### Reconciliation routes

- `GET|POST /api/admin/billing/reconciliation-rules`
- `GET|PATCH /api/admin/billing/reconciliation-rules/{rule_id}`
- `POST /api/admin/billing/reconciliation-rules/{rule_id}/run`
- `GET /api/admin/billing/reconciliations`
- `GET /api/admin/billing/reconciliations/{run_id}`
- `POST /api/admin/billing/reconciliations/{run_id}/lock`
- `POST /api/admin/billing/reconciliations/{run_id}/recalculate`
- `GET /api/admin/billing/reconciliations/{run_id}/export`

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `cd backend && go test ./internal/server -run 'TestAdmin(Billing|Reconciliation)MethodRoutes' -count=1` passed.
- `cd backend && go test -race ./internal/server -run 'TestReconciliation' -count=1` passed.
- `cd backend && go test ./...` passed.
- `cd backend && go vet ./...` passed.
- `node --test tools/*.test.mjs` passed.
- `node tools/check-doc-translations.mjs` passed.
- `node tools/check-ui-translations.mjs`passed.
- `node tools/check-env-contract.mjs` passed.
- `node tools/check-source-lines.mjs` passed.
- `git diff --check` passed.
- Frontend type checking and builds were skipped because this PR does not change frontend code.

## Compatibility, Security, and Operations

Existing paths, successful methods, authentication and RBAC order, JSON error bodies, status codes, CORS behavior, real HEAD rejection, validation order, business side effects, audit writes, list queries, and CSV output remain unchanged. Existing encoded-path and trailing-slash behavior is also preserved.

After authorization, wrong-method responses now include accurate `Allow` headers. No credentials, data schemas, configuration, deployment, rollout, migration, or special rollback steps are affected.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.