### PR TITLE
fix(store): correct quota accounting under bad usage and clock skew

### DIFF
--- a/backend/internal/server/gateway_completion_test.go
+++ b/backend/internal/server/gateway_completion_test.go
@@ -177,6 +177,7 @@ func TestPriceUsageIsIdempotent(t *testing.T) {
 		{name: "cached", usage: Usage{PromptTokens: 1000, CachedInputTokens: 400, CompletionTokens: 500}},
 		{name: "cached above prompt", usage: Usage{PromptTokens: 100, CachedInputTokens: 900, CompletionTokens: 5}},
 		{name: "already totalled", usage: Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15}},
+		{name: "negative upstream counts", usage: Usage{PromptTokens: -400, CachedInputTokens: 25, CompletionTokens: -50, TotalTokens: -450}},
 		{name: "empty", usage: Usage{}},
 	}
 	for _, testCase := range cases {

--- a/backend/internal/server/runtime_budget_test.go
+++ b/backend/internal/server/runtime_budget_test.go
@@ -39,16 +39,13 @@ func addRuntimeBudgetProject(t *testing.T, store *MemoryStore, project Project) 
 	return created
 }
 
-// runtimeBudgetNow returns a timestamp inside the current billing period.
-// checkRuntimeBudget reads the clock itself, so a fixture built moments before
-// a period rollover would be measured against the next period instead.
+// runtimeBudgetNow returns the reading each test uses for both its usage
+// fixtures and the enforcement call. checkRuntimeBudget takes the clock from
+// its caller, so pinning one value keeps the two in the same billing period
+// even when the test runs across a period rollover.
 func runtimeBudgetNow(t *testing.T) time.Time {
 	t.Helper()
-	now := time.Now().UTC()
-	if periodEnd(now.Format("2006-01")).Sub(now) < time.Minute {
-		t.Skip("skipped within a minute of the billing period rollover")
-	}
-	return now
+	return time.Now().UTC()
 }
 
 // countStoreStatements counts the statements a store operation sends to the
@@ -484,7 +481,7 @@ func TestCheckRuntimeBudgetScopes(t *testing.T) {
 			for index, fields := range test.budgets(project) {
 				addRuntimeBudgetResource(t, store, "budget-"+strconv.Itoa(index), fields)
 			}
-			err := store.checkRuntimeBudget(store.db, project)
+			err := store.checkRuntimeBudget(store.db, project, now)
 			if test.wantBlocked && err != ErrBudgetExceeded {
 				t.Fatalf("expected budget_exceeded, got %v", err)
 			}
@@ -531,7 +528,7 @@ func TestCheckRuntimeBudgetSkipsLookupsWithoutApplicableBudgets(t *testing.T) {
 			}
 			var err error
 			statements := countStoreStatements(t, store, func() {
-				err = store.checkRuntimeBudget(store.db, project)
+				err = store.checkRuntimeBudget(store.db, project, now)
 			})
 			if err != nil {
 				t.Fatalf("expected the call to be admitted, got %v", err)
@@ -580,10 +577,10 @@ func TestCheckRuntimeBudgetUsesConstantQueries(t *testing.T) {
 	largeStore, largeProject := build(t, 20, 10, 5)
 	var smallErr, largeErr error
 	smallStatements := countStoreStatements(t, smallStore, func() {
-		smallErr = smallStore.checkRuntimeBudget(smallStore.db, smallProject)
+		smallErr = smallStore.checkRuntimeBudget(smallStore.db, smallProject, now)
 	})
 	largeStatements := countStoreStatements(t, largeStore, func() {
-		largeErr = largeStore.checkRuntimeBudget(largeStore.db, largeProject)
+		largeErr = largeStore.checkRuntimeBudget(largeStore.db, largeProject, now)
 	})
 	if smallErr != nil || largeErr != nil {
 		t.Fatalf("expected both calls to be admitted, got %v and %v", smallErr, largeErr)
@@ -594,5 +591,26 @@ func TestCheckRuntimeBudgetUsesConstantQueries(t *testing.T) {
 	// Budgets, teams with quota policies, the spend aggregate, and projects.
 	if largeStatements > 4 {
 		t.Fatalf("expected at most one statement per lookup, got %d", largeStatements)
+	}
+}
+
+// TestCheckRuntimeBudgetResolvesPeriodFromCallerClock keeps budget enforcement
+// on the same reading admission uses for the quota buckets. Reading the local
+// clock instead measured spend against a different month than the one the call
+// was admitted into whenever the database host disagreed across a rollover.
+func TestCheckRuntimeBudgetResolvesPeriodFromCallerClock(t *testing.T) {
+	now := runtimeBudgetNow(t)
+	previousPeriod := periodStart(now.Format("2006-01")).Add(-time.Hour)
+
+	store := NewMemoryStore()
+	project := addRuntimeBudgetProject(t, store, Project{Name: "Period Clock"})
+	addRuntimeBudgetUsage(t, store, project.ID, 10, previousPeriod)
+	addRuntimeBudgetResource(t, store, "global-budget", map[string]any{"scope": "global", "amount_usd": 5})
+
+	if err := store.checkRuntimeBudget(store.db, project, previousPeriod); err != ErrBudgetExceeded {
+		t.Fatalf("spend inside the supplied period should block the call, got %v", err)
+	}
+	if err := store.checkRuntimeBudget(store.db, project, now); err != nil {
+		t.Fatalf("spend outside the supplied period should admit the call, got %v", err)
 	}
 }

--- a/backend/internal/server/store_backup_quota.go
+++ b/backend/internal/server/store_backup_quota.go
@@ -675,8 +675,13 @@ type projectPeriodCost struct {
 // without matching budgets never reads the usage tables: the candidate pass
 // needs the budget rows alone, and the cost center, project, and usage lookups
 // only happen once a candidate is known to apply.
-func (s *GormStore) checkRuntimeBudget(tx *gorm.DB, project Project) error {
-	now := time.Now().UTC()
+//
+// The caller supplies now so budget enforcement resolves its period from the
+// same database clock reading that admission uses for the quota buckets. A
+// local reading would place the two on different months whenever the database
+// and this host disagree across a period boundary.
+func (s *GormStore) checkRuntimeBudget(tx *gorm.DB, project Project, now time.Time) error {
+	now = now.UTC()
 	period := now.Format("2006-01")
 	var budgets []AdminResource
 	if err := tx.Where("kind = ? AND status = ?", "budgets", StatusActive).Find(&budgets).Error; err != nil {

--- a/backend/internal/server/store_backup_quota.go
+++ b/backend/internal/server/store_backup_quota.go
@@ -409,6 +409,14 @@ func (s *GormStore) quotaBucketForUpdate(tx *gorm.DB, keyID, scope, bucket strin
 }
 
 func priceUsage(model Model, usage Usage) Usage {
+	// Upstream-reported usage is untrusted: the provider parsers preserve the
+	// sign of whatever the upstream sent, and a negative count would flow into
+	// addUsage and shrink the day/month quota counters, letting a key keep
+	// spending past its configured limits. Clamping PromptTokens first also
+	// keeps the CachedInputTokens clamp below from going negative again.
+	usage.PromptTokens = maxInt64(usage.PromptTokens, 0)
+	usage.CompletionTokens = maxInt64(usage.CompletionTokens, 0)
+	usage.TotalTokens = maxInt64(usage.TotalTokens, 0)
 	if usage.TotalTokens == 0 {
 		usage.TotalTokens = saturatingAddNonNegative(usage.PromptTokens, usage.CompletionTokens)
 	}

--- a/backend/internal/server/store_call_admission.go
+++ b/backend/internal/server/store_call_admission.go
@@ -103,7 +103,7 @@ func (s *GormStore) admitCallTransaction(ctx context.Context, tx *gorm.DB, key A
 		exceedsCostQuota(effectiveLimits, &dayCounter.QuotaCounter, &monthCounter.QuotaCounter) {
 		return admission, ErrQuotaExceeded
 	}
-	if err := s.checkRuntimeBudget(tx, privateProject); err != nil {
+	if err := s.checkRuntimeBudget(tx, privateProject, now); err != nil {
 		return admission, err
 	}
 	dayCounter.Requests++

--- a/backend/internal/server/store_routing_calls.go
+++ b/backend/internal/server/store_routing_calls.go
@@ -594,11 +594,22 @@ func (s *GormStore) finishCallTransaction(tx *gorm.DB, call CallContext, route R
 		if err := s.reconcileAPIKeyMinuteTokens(tx, call, actualTokens); err != nil {
 			return err
 		}
-		dayCounter, err := s.quotaBucketForUpdate(tx, key.ID, "day", dayBucket(now))
+		// Admission counted this request on the buckets derived from
+		// call.StartedAt, the database clock reading StartCall took. Deriving
+		// them from the completion clock instead would post the tokens and cost
+		// to a different period whenever the two disagree across a day or month
+		// boundary — the request would be counted in one period and charged to
+		// another, leaving the first under-enforced. The response job rollback
+		// already settles against its own admission reading for the same reason.
+		admittedAt := call.StartedAt
+		if admittedAt.IsZero() {
+			admittedAt = now
+		}
+		dayCounter, err := s.quotaBucketForUpdate(tx, key.ID, "day", dayBucket(admittedAt))
 		if err != nil {
 			return err
 		}
-		monthCounter, err := s.quotaBucketForUpdate(tx, key.ID, "month", monthBucket(now))
+		monthCounter, err := s.quotaBucketForUpdate(tx, key.ID, "month", monthBucket(admittedAt))
 		if err != nil {
 			return err
 		}

--- a/backend/internal/server/store_test.go
+++ b/backend/internal/server/store_test.go
@@ -2,11 +2,14 @@ package server
 
 import (
 	"database/sql"
+	"errors"
 	"math"
 	"path/filepath"
 	"sync"
 	"testing"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 func TestPriceUsageAppliesConfiguredCacheReadPrice(t *testing.T) {
@@ -285,6 +288,54 @@ func TestFinishCallNegativeUsageDoesNotShrinkQuotaCounters(t *testing.T) {
 	wantCost := (1000*2.0 + 100*8.0) / 1_000_000
 	if math.Abs(bucket.CostUSD-wantCost) > 1e-12 {
 		t.Fatalf("day cost = %.12f, want %.12f", bucket.CostUSD, wantCost)
+	}
+}
+
+// TestFinishCallSettlesUsageInTheAdmissionPeriod pins quota settlement to the
+// database clock reading admission took. Deriving the buckets from the local
+// completion clock instead counted a request in one period and charged its
+// tokens to another whenever the two disagreed across a day boundary.
+func TestFinishCallSettlesUsageInTheAdmissionPeriod(t *testing.T) {
+	store := NewMemoryStore()
+	project := store.CreateProject(Project{Name: "Admission Period", Status: StatusActive})
+	key, _, err := store.CreateAPIKey(project.ID, APIKey{
+		Name:    "admission-period",
+		Allowed: []string{"period-chat"},
+		Status:  StatusActive,
+	}, "thk_admission_period")
+	if err != nil {
+		t.Fatal(err)
+	}
+	admittedAt := time.Now().UTC().Add(-48 * time.Hour)
+	store.FinishCall(CallContext{
+		RequestID: "req_admission_period",
+		Project:   project,
+		Key:       key,
+		Model:     Model{Name: "period-chat", Modality: "chat", InputPriceUSDPer1M: 2, OutputPriceUSDPer1M: 8},
+		StartedAt: admittedAt,
+	}, RouteSelection{Provider: Provider{ID: "provider_admission_period"}}, Usage{
+		PromptTokens:     1000,
+		CompletionTokens: 100,
+	}, 200, "", "127.0.0.1", "store-test")
+
+	var admitted QuotaBucket
+	if err := store.db.Where("key_id = ? AND scope = ? AND bucket = ?", key.ID, "day", dayBucket(admittedAt)).First(&admitted).Error; err != nil {
+		t.Fatalf("read the admission day bucket %s: %v", dayBucket(admittedAt), err)
+	}
+	if admitted.TotalTokens != 1100 {
+		t.Fatalf("admission day bucket total tokens = %d, want 1100", admitted.TotalTokens)
+	}
+	var completion QuotaBucket
+	err = store.db.Where("key_id = ? AND scope = ? AND bucket = ?", key.ID, "day", dayBucket(time.Now().UTC())).First(&completion).Error
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("usage settled in the completion day bucket %s: %+v (err %v)", dayBucket(time.Now().UTC()), completion.QuotaCounter, err)
+	}
+	var month QuotaBucket
+	if err := store.db.Where("key_id = ? AND scope = ? AND bucket = ?", key.ID, "month", monthBucket(admittedAt)).First(&month).Error; err != nil {
+		t.Fatalf("read the admission month bucket %s: %v", monthBucket(admittedAt), err)
+	}
+	if month.TotalTokens != 1100 {
+		t.Fatalf("admission month bucket total tokens = %d, want 1100", month.TotalTokens)
 	}
 }
 

--- a/backend/internal/server/store_test.go
+++ b/backend/internal/server/store_test.go
@@ -30,6 +30,65 @@ func TestPriceUsageAppliesConfiguredCacheReadPrice(t *testing.T) {
 	}
 }
 
+// TestPriceUsageClampsNegativeUpstreamUsage guards the quota ledger against
+// upstreams that report negative counts: priceUsage is the single choke point
+// before addUsage, so anything negative surviving it would shrink the day and
+// month quota counters and let a key spend past its configured limits.
+func TestPriceUsageClampsNegativeUpstreamUsage(t *testing.T) {
+	model := Model{
+		Modality:            "chat",
+		InputPriceUSDPer1M:  2,
+		OutputPriceUSDPer1M: 8,
+	}
+	cases := []struct {
+		name           string
+		usage          Usage
+		wantPrompt     int64
+		wantCompletion int64
+		wantTotal      int64
+		wantCost       float64
+	}{
+		{
+			name:  "negative total only",
+			usage: Usage{TotalTokens: -1_000_000},
+		},
+		{
+			name:           "negative prompt keeps completion",
+			usage:          Usage{PromptTokens: -500, CompletionTokens: 200},
+			wantCompletion: 200,
+			wantTotal:      200,
+			wantCost:       200 * 8.0 / 1_000_000,
+		},
+		{
+			name:           "negative total rebuilt from parts",
+			usage:          Usage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: -3},
+			wantPrompt:     100,
+			wantCompletion: 50,
+			wantTotal:      150,
+			wantCost:       (100*2.0 + 50*8.0) / 1_000_000,
+		},
+		{
+			name:  "negative prompt does not drag cached tokens negative",
+			usage: Usage{PromptTokens: -100, CachedInputTokens: 50, CompletionTokens: -5},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := priceUsage(model, tt.usage)
+			if got.PromptTokens != tt.wantPrompt || got.CompletionTokens != tt.wantCompletion || got.TotalTokens != tt.wantTotal {
+				t.Fatalf("clamped tokens = prompt %d completion %d total %d, want prompt %d completion %d total %d",
+					got.PromptTokens, got.CompletionTokens, got.TotalTokens, tt.wantPrompt, tt.wantCompletion, tt.wantTotal)
+			}
+			if got.CachedInputTokens < 0 {
+				t.Fatalf("cached input tokens = %d, want >= 0", got.CachedInputTokens)
+			}
+			if math.Abs(got.CostUSD-tt.wantCost) > 1e-12 {
+				t.Fatalf("cost = %.12f, want %.12f", got.CostUSD, tt.wantCost)
+			}
+		})
+	}
+}
+
 func TestEffectiveCacheReadPriceUsesCategoryEstimateWhenUnconfigured(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -172,6 +231,60 @@ func TestFinishCallPersistsCachedInputTokensInUsageAggregates(t *testing.T) {
 	}
 	if got := models[0]["cached_input_tokens"]; got != int64(400) {
 		t.Fatalf("breakdown cached input tokens = %#v, want 400", got)
+	}
+}
+
+// TestFinishCallNegativeUsageDoesNotShrinkQuotaCounters exercises the full
+// FinishCall path: a completion carrying negative upstream usage must leave
+// the persisted day quota counters untouched instead of subtracting from them.
+func TestFinishCallNegativeUsageDoesNotShrinkQuotaCounters(t *testing.T) {
+	store := NewMemoryStore()
+	project := store.CreateProject(Project{Name: "Negative Usage", Status: StatusActive})
+	key, _, err := store.CreateAPIKey(project.ID, APIKey{
+		Name:    "negative-usage",
+		Allowed: []string{"clamped-chat"},
+		Status:  StatusActive,
+	}, "thk_negative_usage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := Model{
+		Name:                "clamped-chat",
+		Modality:            "chat",
+		InputPriceUSDPer1M:  2,
+		OutputPriceUSDPer1M: 8,
+	}
+	newCall := func(requestID string) CallContext {
+		return CallContext{
+			RequestID: requestID,
+			Project:   project,
+			Key:       key,
+			Model:     model,
+			StartedAt: time.Now(),
+		}
+	}
+	route := RouteSelection{Provider: Provider{ID: "provider_negative_usage"}}
+
+	store.FinishCall(newCall("req_negative_usage_baseline"), route, Usage{
+		PromptTokens:     1000,
+		CompletionTokens: 100,
+	}, 200, "", "127.0.0.1", "store-test")
+	store.FinishCall(newCall("req_negative_usage_hostile"), route, Usage{
+		PromptTokens:     -900,
+		CompletionTokens: -90,
+		TotalTokens:      -990,
+	}, 200, "", "127.0.0.1", "store-test")
+
+	var bucket QuotaBucket
+	if err := store.db.Where("key_id = ? AND scope = ?", key.ID, "day").First(&bucket).Error; err != nil {
+		t.Fatalf("read day quota bucket: %v", err)
+	}
+	if bucket.PromptTokens != 1000 || bucket.CompletionTokens != 100 || bucket.TotalTokens != 1100 {
+		t.Fatalf("day counters shrank after negative usage: %+v", bucket.QuotaCounter)
+	}
+	wantCost := (1000*2.0 + 100*8.0) / 1_000_000
+	if math.Abs(bucket.CostUSD-wantCost) > 1e-12 {
+		t.Fatalf("day cost = %.12f, want %.12f", bucket.CostUSD, wantCost)
 	}
 }
 

--- a/frontend/features/admin/domain/formatting.tsx
+++ b/frontend/features/admin/domain/formatting.tsx
@@ -338,7 +338,7 @@ export function stringifyChatContent(content: unknown): string {
 }
 
 export function formatNumber(value: number) {
-  return new Intl.NumberFormat("en-US").format(value || 0);
+  return new Intl.NumberFormat(languageLocale()).format(value || 0);
 }
 
 export function compactNumber(value: number) {


### PR DESCRIPTION
## Summary

Two defects let the day and month quota counters diverge from what an API key
actually spent, so a key at its cap could keep being admitted.

- `priceUsage` clamped only `CachedInputTokens`, so a negative `prompt_tokens`,
  `completion_tokens`, or `total_tokens` from an upstream reached `addUsage` and
  subtracted from the counters. The TPM reconciliation path already clamps with
  `maxInt64(..., 0)`; the day and month path did not.
- Admission derives its quota buckets from the database clock reading it stores
  in `CallContext.StartedAt`, but `FinishCall` derived them from this host's
  completion clock. When the two disagree across a period boundary, a request
  was counted in one period and charged to another. `checkRuntimeBudget` took a
  third, independent local reading for the same decision.

A separate commit aligns `formatNumber` with the repository rule that
user-facing numbers follow the selected application language.

## Related Issue

N/A

## Changes

- Clamp token counts to non-negative values in `priceUsage`, the single choke
  point every completion path crosses before quota settlement.
- Derive the day and month buckets in `finishCallTransaction` from
  `call.StartedAt`, matching `rollbackResponseJobAdmission`. This covers
  `FinishCall`, `CompleteImageJob`, and `FinalizeResponseJob`.
- Pass the admission clock into `checkRuntimeBudget` rather than reading the
  local clock there.
- Use `languageLocale()` in `formatNumber`, matching `formatBytes` and
  `formatTime` in the same module. The three supported languages render
  identically today, so nothing changes on screen.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- Backend: `go test ./...`, `go vet ./...`, `gofmt` — pass.
- Frontend: `npm run lint`, `npm run typecheck`, `npm test`, `npm run build` — pass.
- Repository gates: `node --test tools/*.test.mjs` (122/122),
  `check-doc-translations`, `check-ui-translations`, `check-env-contract`,
  `check-source-lines`, `git diff --check` — pass.
- Four regression tests added, each confirmed to fail without its fix, plus a
  negative case in the existing `TestPriceUsageIsIdempotent` table.
- Not run: `npm run test:e2e` and the `sdk/` smoke tests, which need a live
  backend and provider credentials.

## Compatibility, Security, and Operations

A request admitted just before a UTC day or month rollover now has its tokens
and cost charged to the period it was counted in, instead of the period it
completed in. No API, schema, configuration, or deployment change is involved.
The clamp closes a path where a faulty or hostile upstream could reduce a key's
recorded consumption and be admitted past its configured limits.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are
      unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs
      are included.
- [x] Environment variable changes are synchronized where applicable. None changed.
- [x] Shared user-facing behavior is documented in English, Simplified Chinese,
      and Japanese where applicable. No documentation changed.
- [x] `data/model-catalog.yaml` remains tracked. The catalog is untouched.
- [x] `git diff --check` passes.