### PR TITLE
fix(frontend): isolate provider account OAuth callbacks

### DIFF
--- a/frontend/features/admin/core/session.tsx
+++ b/frontend/features/admin/core/session.tsx
@@ -78,7 +78,7 @@ export function parseProviderAccountOAuthResult(source: string, allowGenericToke
     result.id_token = firstParam(params, marked ? ["account_id_token", "id_token"] : ["account_id_token"]);
     result.session_id = firstParam(params, ["provider_account_oauth_session_id", "account_oauth_session_id", "session_id"]);
     result.state = firstParam(params, ["provider_account_oauth_state", "account_oauth_state", "state"]);
-    result.error = firstParam(params, ["provider_account_oauth_error", "oauth_error", "error"]);
+    result.error = firstParam(params, marked ? ["provider_account_oauth_error", "oauth_error", "error"] : ["provider_account_oauth_error"]);
     result.account_email = firstParam(params, ["account_email", "email", "login", "username"]);
     result.account_id = firstParam(params, ["account_id", "sub", "user_id"]);
     result.organization_id = firstParam(params, ["organization_id", "org_id"]);
@@ -86,7 +86,7 @@ export function parseProviderAccountOAuthResult(source: string, allowGenericToke
     result.token_type = firstParam(params, ["token_type"]);
     result.expires_at = firstParam(params, ["expires_at", "token_expires_at"]);
     result.scopes = firstParam(params, ["scope", "scopes"]);
-    result.authorization_code = firstParam(params, ["code", "authorization_code"]);
+    result.authorization_code = marked ? firstParam(params, ["code", "authorization_code"]) : "";
     if (result.error) return result;
     if (result.access_token || result.refresh_token || result.id_token) return result;
     if (result.authorization_code) return result;


### PR DESCRIPTION
## Summary

Fix an issue where signing in by scanning the DingTalk QR code unexpectedly opens the Create Provider dialog after the administrator reaches the console.

The DingTalk OAuth callback uses generic parameters such as `code`, `state`, and `error`. These parameters could be incorrectly interpreted as a Provider account OAuth callback, causing the Provider creation wizard to open automatically.

## Related Issue

N/A.

## Changes

- Require an explicit Provider account OAuth marker before accepting generic OAuth error parameters.
- Require the same marker before accepting generic authorization codes.
- Preserve generic callback parsing for marked callbacks and manual Provider account callback input.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm test`
- `git diff --check`

## Compatibility, Security, and Operations

No API, persistence, configuration, or deployment changes. Marked Provider account callbacks and manual callback parsing remain supported.

## Checklist

- [x] The PR title and body are written in English.
- [ ] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.