### PR TITLE
refactor(billing): extract domain module

### DIFF
--- a/backend/internal/billing/service.go
+++ b/backend/internal/billing/service.go
@@ -1,0 +1,323 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Service struct {
+	store         Store
+	adapters      map[string]Adapter
+	mu            sync.Mutex
+	active        map[string]bool
+	schedulerMu   sync.Mutex
+	schedulerStop context.CancelFunc
+	schedulerDone chan struct{}
+}
+
+type syncCheckpoint struct {
+	From   time.Time `json:"from"`
+	To     time.Time `json:"to"`
+	Cursor string    `json:"cursor"`
+}
+
+// NewService creates a billing synchronizer from a persistence port and the
+// concrete upstream adapters supplied by the composition root.
+func NewService(store Store, adapters map[string]Adapter) *Service {
+	if adapters == nil {
+		adapters = map[string]Adapter{}
+	}
+	return &Service{store: store, adapters: adapters, active: map[string]bool{}}
+}
+
+func (s *Service) RunDue(ctx context.Context, now time.Time) []SyncRun {
+	connectors := s.store.ListDueBillingConnectors(now, 25)
+	runs := make([]SyncRun, 0, len(connectors))
+	for _, connector := range connectors {
+		run, err := s.Sync(ctx, connector.ID, SyncRequest{}, "scheduled")
+		if run.ID == "" && err != nil {
+			_, code, message := errorDetails(err)
+			run = SyncRun{ConnectorID: connector.ID, Trigger: "scheduled", Status: SyncFailed, ErrorCode: code, ErrorMessage: message}
+		}
+		s.store.RecordScheduledBillingAudit(run)
+		runs = append(runs, run)
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	return runs
+}
+
+func (s *Service) StartScheduler(interval time.Duration) {
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	s.schedulerMu.Lock()
+	defer s.schedulerMu.Unlock()
+	if s.schedulerStop != nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s.schedulerStop = cancel
+	s.schedulerDone = make(chan struct{})
+	go func() {
+		defer close(s.schedulerDone)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case now := <-ticker.C:
+				s.RunDue(ctx, now.UTC())
+			}
+		}
+	}()
+}
+
+func (s *Service) Shutdown(ctx context.Context) error {
+	s.schedulerMu.Lock()
+	stop := s.schedulerStop
+	done := s.schedulerDone
+	s.schedulerMu.Unlock()
+	if stop == nil {
+		return nil
+	}
+	stop()
+	select {
+	case <-done:
+		s.schedulerMu.Lock()
+		s.schedulerStop = nil
+		s.schedulerDone = nil
+		s.schedulerMu.Unlock()
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *Service) Test(ctx context.Context, connectorID string) (map[string]any, error) {
+	connector, err := s.store.GetBillingConnector(connectorID, true)
+	if err != nil {
+		return nil, err
+	}
+	adapter, ok := s.adapters[connector.Type]
+	if !ok {
+		return nil, NewError(ErrorInvalidInput, "billing_adapter_missing", "Billing connector adapter is not registered")
+	}
+	now := time.Now().UTC()
+	page, _, err := fetchPageWithRetry(ctx, configInt(connector.Config, "max_retries", 3, 1, 8), time.Duration(configInt(connector.Config, "retry_base_ms", 250, 1, 5000))*time.Millisecond, func() (FetchPage, error) {
+		return adapter.Fetch(ctx, connector, FetchRequest{From: now.Add(-time.Hour), To: now, PageSize: 1})
+	})
+	if err != nil {
+		return nil, normalizeError(err)
+	}
+	return map[string]any{"ok": true, "connector_id": connector.ID, "connector_type": connector.Type, "sample_records": len(page.Records)}, nil
+}
+
+func (s *Service) Sync(ctx context.Context, connectorID string, requested SyncRequest, trigger string) (SyncRun, error) {
+	if !s.begin(connectorID) {
+		return SyncRun{}, NewError(ErrorConflict, "billing_sync_in_progress", "A billing sync is already running for this connector")
+	}
+	defer s.end(connectorID)
+	connector, err := s.store.GetBillingConnector(connectorID, true)
+	if err != nil {
+		return SyncRun{}, err
+	}
+	if connector.Status != StatusActive {
+		return SyncRun{}, NewError(ErrorConflict, "billing_connector_disabled", "Disabled billing connectors cannot be synchronized")
+	}
+	adapter, ok := s.adapters[connector.Type]
+	if !ok {
+		return SyncRun{}, NewError(ErrorInvalidInput, "billing_adapter_missing", "Billing connector adapter is not registered")
+	}
+	from, to, cursor, err := resolveSyncRange(connector, requested, time.Now().UTC())
+	if err != nil {
+		return SyncRun{}, err
+	}
+	run, err := s.store.StartBillingSyncRun(SyncRun{ConnectorID: connector.ID, Trigger: defaultString(trigger, "manual"), Status: SyncRunning, RangeStart: from, RangeEnd: to, CursorStart: cursor})
+	if err != nil {
+		return SyncRun{}, err
+	}
+	pageSize := configInt(connector.Config, "page_size", 100, 1, 1000)
+	maxRetries := configInt(connector.Config, "max_retries", 3, 1, 8)
+	retryBase := time.Duration(configInt(connector.Config, "retry_base_ms", 250, 1, 5000)) * time.Millisecond
+	requestsPerSecond := configInt(connector.Config, "rate_limit_per_second", 0, 0, 1000)
+	var lastRequest time.Time
+	for pageIndex := 0; pageIndex < 10000; pageIndex++ {
+		page, attempts, fetchErr := fetchPageWithRetry(ctx, maxRetries, retryBase, func() (FetchPage, error) {
+			if requestsPerSecond > 0 && !lastRequest.IsZero() {
+				minimumGap := time.Second / time.Duration(requestsPerSecond)
+				if wait := minimumGap - time.Since(lastRequest); wait > 0 {
+					timer := time.NewTimer(wait)
+					defer timer.Stop()
+					select {
+					case <-ctx.Done():
+						return FetchPage{}, ctx.Err()
+					case <-timer.C:
+					}
+				}
+			}
+			lastRequest = time.Now()
+			return adapter.Fetch(ctx, connector, FetchRequest{From: from, To: to, Cursor: cursor, PageSize: pageSize})
+		})
+		run.Attempts += attempts
+		if fetchErr != nil {
+			return s.failRun(run, fetchErr)
+		}
+		checkpoint, marshalErr := json.Marshal(syncCheckpoint{From: from, To: to, Cursor: page.NextCursor})
+		if marshalErr != nil {
+			return s.failRun(run, marshalErr)
+		}
+		inserted, updated, persistErr := s.store.SaveBillingPage(connector.ID, string(checkpoint), page.Records)
+		if persistErr != nil {
+			return s.failRun(run, persistErr)
+		}
+		run.PagesFetched++
+		run.RecordsSeen += len(page.Records)
+		run.RecordsInserted += inserted
+		run.RecordsUpdated += updated
+		run.CursorEnd = page.NextCursor
+		if page.NextCursor == "" {
+			run.Status = SyncSucceeded
+			run.ErrorCode = ""
+			run.ErrorMessage = ""
+			return s.store.FinishBillingSyncRun(run)
+		}
+		if page.NextCursor == cursor {
+			return s.failRun(run, NewError(ErrorUpstream, "billing_cursor_stalled", "Billing source returned a cursor that did not advance"))
+		}
+		cursor = page.NextCursor
+	}
+	return s.failRun(run, NewError(ErrorUpstream, "billing_page_limit_exceeded", "Billing sync exceeded the maximum page count"))
+}
+
+func (s *Service) failRun(run SyncRun, err error) (SyncRun, error) {
+	run.Status = SyncFailed
+	err = normalizeError(err)
+	_, code, message := errorDetails(err)
+	run.ErrorCode = code
+	run.ErrorMessage = message
+	finished, finishErr := s.store.FinishBillingSyncRun(run)
+	if finishErr != nil {
+		return run, finishErr
+	}
+	return finished, err
+}
+
+func (s *Service) begin(connectorID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.active[connectorID] {
+		return false
+	}
+	s.active[connectorID] = true
+	return true
+}
+
+func (s *Service) end(connectorID string) { s.mu.Lock(); delete(s.active, connectorID); s.mu.Unlock() }
+
+func resolveSyncRange(connector Connector, requested SyncRequest, now time.Time) (time.Time, time.Time, string, error) {
+	if requested.From.IsZero() && requested.To.IsZero() && strings.TrimSpace(connector.Checkpoint) != "" {
+		var checkpoint syncCheckpoint
+		if err := json.Unmarshal([]byte(connector.Checkpoint), &checkpoint); err == nil && !checkpoint.From.IsZero() && !checkpoint.To.IsZero() {
+			return checkpoint.From.UTC(), checkpoint.To.UTC(), checkpoint.Cursor, nil
+		}
+	}
+	to := requested.To.UTC()
+	if requested.To.IsZero() {
+		to = now.UTC()
+	}
+	from := requested.From.UTC()
+	if requested.From.IsZero() {
+		if connector.LastSyncedThrough != nil {
+			from = connector.LastSyncedThrough.UTC()
+		} else {
+			from = to.Add(-24 * time.Hour)
+		}
+	}
+	if !from.Before(to) {
+		return time.Time{}, time.Time{}, "", NewError(ErrorInvalidInput, "invalid_billing_range", "from must be earlier than to")
+	}
+	if to.After(now.Add(5 * time.Minute)) {
+		return time.Time{}, time.Time{}, "", NewError(ErrorInvalidInput, "invalid_billing_range", "to cannot be in the future")
+	}
+	return from, to, "", nil
+}
+
+type retryInfo interface {
+	Retryable() bool
+	RetryAfter() time.Duration
+}
+
+func fetchPageWithRetry(ctx context.Context, maxAttempts int, baseDelay time.Duration, fetch func() (FetchPage, error)) (FetchPage, int, error) {
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		page, err := fetch()
+		if err == nil {
+			return page, attempt, nil
+		}
+		lastErr = err
+		if attempt == maxAttempts || !retryable(err) {
+			return FetchPage{}, attempt, err
+		}
+		delay := baseDelay * time.Duration(1<<(attempt-1))
+		var upstream retryInfo
+		if errors.As(err, &upstream) && upstream.RetryAfter() > delay {
+			delay = upstream.RetryAfter()
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return FetchPage{}, attempt, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return FetchPage{}, maxAttempts, lastErr
+}
+
+func retryable(err error) bool {
+	var info retryInfo
+	if errors.As(err, &info) {
+		return info.Retryable()
+	}
+	if kind, _, _, ok := ErrorInfo(err); ok {
+		return kind == ErrorUpstream
+	}
+	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
+}
+
+func normalizeError(err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return NewError(ErrorTimeout, "billing_sync_timeout", "Billing sync timed out")
+	}
+	return err
+}
+
+func errorDetails(err error) (int, string, string) {
+	if _, code, message, ok := ErrorInfo(err); ok {
+		return 0, code, message
+	}
+	return 0, "internal_error", err.Error()
+}
+func configInt(config map[string]string, key string, fallback, minimum, maximum int) int {
+	value, err := strconv.Atoi(strings.TrimSpace(config[key]))
+	if err != nil || value < minimum || value > maximum {
+		return fallback
+	}
+	return value
+}
+func defaultString(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+func (run SyncRun) String() string { return fmt.Sprintf("%s:%s", run.ConnectorID, run.Status) }

--- a/backend/internal/billing/service_test.go
+++ b/backend/internal/billing/service_test.go
@@ -1,0 +1,398 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type fakeBillingStore struct {
+	connector Connector
+	started   SyncRun
+	finished  SyncRun
+	pages     []Record
+	check     string
+	due       []Connector
+	audits    []SyncRun
+	startErr  error
+	saveErr   error
+	finishErr error
+	getErr    error
+}
+
+func (f *fakeBillingStore) CreateBillingConnector(connector Connector) (Connector, error) {
+	f.connector = connector
+	return connector, nil
+}
+func (f *fakeBillingStore) ListBillingConnectors() []Connector { return []Connector{f.connector} }
+func (f *fakeBillingStore) GetBillingConnector(id string, _ bool) (Connector, error) {
+	if f.getErr != nil {
+		return Connector{}, f.getErr
+	}
+	if id != f.connector.ID {
+		return Connector{}, errors.New("connector not found")
+	}
+	return f.connector, nil
+}
+func (f *fakeBillingStore) UpdateBillingConnector(_ string, connector Connector) (Connector, error) {
+	f.connector = connector
+	return connector, nil
+}
+func (f *fakeBillingStore) DeleteBillingConnector(_ string) error { return nil }
+func (f *fakeBillingStore) StartBillingSyncRun(run SyncRun) (SyncRun, error) {
+	if f.startErr != nil {
+		return SyncRun{}, f.startErr
+	}
+	run.ID = "run-1"
+	run.StartedAt = time.Now().UTC()
+	f.started = run
+	return run, nil
+}
+func (f *fakeBillingStore) SaveBillingPage(_ string, checkpoint string, records []Record) (int, int, error) {
+	if f.saveErr != nil {
+		return 0, 0, f.saveErr
+	}
+	f.check = checkpoint
+	f.pages = append(f.pages, records...)
+	return len(records), 0, nil
+}
+func (f *fakeBillingStore) FinishBillingSyncRun(run SyncRun) (SyncRun, error) {
+	f.finished = run
+	if f.finishErr != nil {
+		return SyncRun{}, f.finishErr
+	}
+	return run, nil
+}
+func (f *fakeBillingStore) ListBillingRecords(_ string, _ int) []Record { return f.pages }
+func (f *fakeBillingStore) ListBillingSyncRuns(_ string, _ int) []SyncRun {
+	return []SyncRun{f.finished}
+}
+func (f *fakeBillingStore) ListDueBillingConnectors(_ time.Time, _ int) []Connector { return f.due }
+func (f *fakeBillingStore) RecordScheduledBillingAudit(run SyncRun)                 { f.audits = append(f.audits, run) }
+
+type fakeBillingAdapter struct {
+	pages  []FetchPage
+	calls  int
+	errors []error
+	fetch  func(context.Context, Connector, FetchRequest) (FetchPage, error)
+}
+
+func (a *fakeBillingAdapter) Fetch(ctx context.Context, connector Connector, request FetchRequest) (FetchPage, error) {
+	if a.fetch != nil {
+		return a.fetch(ctx, connector, request)
+	}
+	index := a.calls
+	a.calls++
+	if index < len(a.errors) && a.errors[index] != nil {
+		return FetchPage{}, a.errors[index]
+	}
+	if index >= len(a.pages) {
+		return FetchPage{}, errors.New("unexpected page")
+	}
+	return a.pages[index], nil
+}
+
+type retryableBillingError struct{}
+
+func (retryableBillingError) Error() string             { return "temporary upstream failure" }
+func (retryableBillingError) Retryable() bool           { return true }
+func (retryableBillingError) RetryAfter() time.Duration { return 0 }
+func (retryableBillingError) StatusCode() int           { return http.StatusBadGateway }
+func (retryableBillingError) ErrorCode() string         { return "temporary_failure" }
+func (retryableBillingError) ErrorMessage() string      { return "temporary upstream failure" }
+func (retryableBillingError) ErrorKind() ErrorKind      { return ErrorUpstream }
+
+func TestServiceSyncPersistsAllPages(t *testing.T) {
+	store := &fakeBillingStore{connector: Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: StatusActive}}
+	adapter := &fakeBillingAdapter{pages: []FetchPage{
+		{Records: []Record{{ExternalID: "record-1"}}, NextCursor: "next"},
+		{Records: []Record{{ExternalID: "record-2"}}},
+	}}
+	service := NewService(store, map[string]Adapter{ConnectorOneAPI: adapter})
+
+	run, err := service.Sync(context.Background(), "conn-1", SyncRequest{From: time.Now().Add(-time.Hour), To: time.Now()}, "manual")
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if run.Status != SyncSucceeded || run.PagesFetched != 2 || run.RecordsInserted != 2 {
+		t.Fatalf("unexpected completed run: %+v", run)
+	}
+	if len(store.pages) != 2 || store.check == "" {
+		t.Fatalf("expected persisted pages and checkpoint, pages=%d checkpoint=%q", len(store.pages), store.check)
+	}
+}
+
+func TestServiceSyncRetriesRetryableAdapterErrors(t *testing.T) {
+	store := &fakeBillingStore{connector: Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: StatusActive, Config: map[string]string{"max_retries": "2", "retry_base_ms": "1"}}}
+	adapter := &fakeBillingAdapter{
+		errors: []error{retryableBillingError{}},
+		pages:  []FetchPage{{}, {Records: []Record{{ExternalID: "record-1"}}}},
+	}
+	service := NewService(store, map[string]Adapter{ConnectorOneAPI: adapter})
+
+	run, err := service.Sync(context.Background(), "conn-1", SyncRequest{From: time.Now().Add(-time.Hour), To: time.Now()}, "manual")
+	if err != nil {
+		t.Fatalf("sync failed after retry: %v", err)
+	}
+	if adapter.calls != 2 || run.Attempts != 2 || run.Status != SyncSucceeded {
+		t.Fatalf("expected one retry and successful run, calls=%d attempts=%d run=%+v", adapter.calls, run.Attempts, run)
+	}
+}
+
+func TestServiceSyncRecordsRetryExhaustion(t *testing.T) {
+	store := &fakeBillingStore{connector: Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: StatusActive, Config: map[string]string{"max_retries": "3", "retry_base_ms": "1"}}}
+	adapter := &fakeBillingAdapter{errors: []error{retryableBillingError{}, retryableBillingError{}, retryableBillingError{}}}
+	service := NewService(store, map[string]Adapter{ConnectorOneAPI: adapter})
+
+	run, err := service.Sync(context.Background(), "conn-1", SyncRequest{From: time.Now().Add(-time.Hour), To: time.Now()}, "manual")
+	assertBillingError(t, err, ErrorUpstream, "temporary_failure")
+	if adapter.calls != 3 || run.Attempts != 3 || run.Status != SyncFailed || store.finished.ErrorCode != "temporary_failure" {
+		t.Fatalf("retry exhaustion was not recorded: calls=%d run=%+v finished=%+v", adapter.calls, run, store.finished)
+	}
+}
+
+func TestServiceSyncRejectsConcurrentRun(t *testing.T) {
+	store := &fakeBillingStore{connector: Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: StatusActive}}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	adapter := &fakeBillingAdapter{fetch: func(context.Context, Connector, FetchRequest) (FetchPage, error) {
+		close(entered)
+		<-release
+		return FetchPage{}, nil
+	}}
+	service := NewService(store, map[string]Adapter{ConnectorOneAPI: adapter})
+	result := make(chan error, 1)
+	go func() {
+		_, err := service.Sync(context.Background(), "conn-1", SyncRequest{From: time.Now().Add(-time.Hour), To: time.Now()}, "manual")
+		result <- err
+	}()
+	<-entered
+	_, err := service.Sync(context.Background(), "conn-1", SyncRequest{From: time.Now().Add(-time.Hour), To: time.Now()}, "manual")
+	assertBillingError(t, err, ErrorConflict, "billing_sync_in_progress")
+	close(release)
+	if err := <-result; err != nil {
+		t.Fatalf("first sync failed: %v", err)
+	}
+}
+
+func TestServiceSyncRecordsStartAndFinishFailures(t *testing.T) {
+	request := SyncRequest{From: time.Now().Add(-time.Hour), To: time.Now()}
+	t.Run("start", func(t *testing.T) {
+		failure := errors.New("cannot start run")
+		store := &fakeBillingStore{connector: Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: StatusActive}, startErr: failure}
+		service := NewService(store, map[string]Adapter{ConnectorOneAPI: &fakeBillingAdapter{}})
+		_, err := service.Sync(context.Background(), "conn-1", request, "manual")
+		if !errors.Is(err, failure) || store.finished.ID != "" {
+			t.Fatalf("unexpected start failure: err=%v finished=%+v", err, store.finished)
+		}
+	})
+	t.Run("finish", func(t *testing.T) {
+		failure := errors.New("cannot finish run")
+		store := &fakeBillingStore{connector: Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: StatusActive}, finishErr: failure}
+		service := NewService(store, map[string]Adapter{ConnectorOneAPI: &fakeBillingAdapter{pages: []FetchPage{{}}}})
+		_, err := service.Sync(context.Background(), "conn-1", request, "manual")
+		if !errors.Is(err, failure) || store.finished.Status != SyncSucceeded {
+			t.Fatalf("unexpected finish failure: err=%v finished=%+v", err, store.finished)
+		}
+	})
+}
+
+func TestServiceSyncStopsAtPageLimit(t *testing.T) {
+	store := &fakeBillingStore{connector: Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: StatusActive}}
+	adapter := &fakeBillingAdapter{fetch: func(_ context.Context, _ Connector, request FetchRequest) (FetchPage, error) {
+		return FetchPage{NextCursor: request.Cursor + "x"}, nil
+	}}
+	service := NewService(store, map[string]Adapter{ConnectorOneAPI: adapter})
+
+	run, err := service.Sync(context.Background(), "conn-1", SyncRequest{From: time.Now().Add(-time.Hour), To: time.Now()}, "manual")
+	assertBillingError(t, err, ErrorUpstream, "billing_page_limit_exceeded")
+	if run.Status != SyncFailed || run.PagesFetched != 10000 || store.finished.ErrorCode != "billing_page_limit_exceeded" {
+		t.Fatalf("page limit was not recorded: run=%+v finished=%+v", run, store.finished)
+	}
+}
+
+func TestServiceTestProbesConnectorThroughAdapter(t *testing.T) {
+	store := &fakeBillingStore{connector: Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: StatusActive}}
+	var request FetchRequest
+	adapter := &fakeBillingAdapter{fetch: func(_ context.Context, _ Connector, got FetchRequest) (FetchPage, error) {
+		request = got
+		return FetchPage{Records: []Record{{ExternalID: "sample"}}}, nil
+	}}
+	service := NewService(store, map[string]Adapter{ConnectorOneAPI: adapter})
+
+	result, err := service.Test(context.Background(), "conn-1")
+	if err != nil {
+		t.Fatalf("connector probe failed: %v", err)
+	}
+	if result["ok"] != true || result["sample_records"] != 1 || request.PageSize != 1 {
+		t.Fatalf("unexpected probe result=%#v request=%+v", result, request)
+	}
+}
+
+func TestServiceRejectsDisabledAndUnknownConnectors(t *testing.T) {
+	tests := []struct {
+		name      string
+		connector Connector
+		adapters  map[string]Adapter
+		wantKind  ErrorKind
+		wantCode  string
+	}{
+		{
+			name:      "disabled",
+			connector: Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: "disabled"},
+			adapters:  map[string]Adapter{ConnectorOneAPI: &fakeBillingAdapter{}},
+			wantKind:  ErrorConflict,
+			wantCode:  "billing_connector_disabled",
+		},
+		{
+			name:      "unknown adapter",
+			connector: Connector{ID: "conn-1", Type: "missing", Status: StatusActive},
+			adapters:  map[string]Adapter{},
+			wantKind:  ErrorInvalidInput,
+			wantCode:  "billing_adapter_missing",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := NewService(&fakeBillingStore{connector: test.connector}, test.adapters)
+			_, err := service.Sync(context.Background(), "conn-1", SyncRequest{From: time.Now().Add(-time.Hour), To: time.Now()}, "manual")
+			assertBillingError(t, err, test.wantKind, test.wantCode)
+		})
+	}
+}
+
+func TestServiceRejectsInvalidRanges(t *testing.T) {
+	store := &fakeBillingStore{connector: Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: StatusActive}}
+	service := NewService(store, map[string]Adapter{ConnectorOneAPI: &fakeBillingAdapter{}})
+	now := time.Now().UTC()
+	for _, requested := range []SyncRequest{
+		{From: now, To: now.Add(-time.Minute)},
+		{From: now.Add(-time.Hour), To: now.Add(10 * time.Minute)},
+	} {
+		_, err := service.Sync(context.Background(), "conn-1", requested, "manual")
+		assertBillingError(t, err, ErrorInvalidInput, "invalid_billing_range")
+	}
+	if store.started.ID != "" {
+		t.Fatalf("invalid range started a sync run: %+v", store.started)
+	}
+}
+
+func TestServiceResumesFromCheckpoint(t *testing.T) {
+	from := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	to := from.Add(time.Hour)
+	checkpoint, err := json.Marshal(syncCheckpoint{From: from, To: to, Cursor: "resume-2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &fakeBillingStore{connector: Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: StatusActive, Checkpoint: string(checkpoint)}}
+	var request FetchRequest
+	adapter := &fakeBillingAdapter{fetch: func(_ context.Context, _ Connector, got FetchRequest) (FetchPage, error) {
+		request = got
+		return FetchPage{}, nil
+	}}
+	service := NewService(store, map[string]Adapter{ConnectorOneAPI: adapter})
+
+	run, err := service.Sync(context.Background(), "conn-1", SyncRequest{}, "manual")
+	if err != nil || run.Status != SyncSucceeded {
+		t.Fatalf("checkpoint sync failed: run=%+v err=%v", run, err)
+	}
+	if request.Cursor != "resume-2" || !request.From.Equal(from) || !request.To.Equal(to) || store.started.CursorStart != "resume-2" {
+		t.Fatalf("checkpoint was not forwarded: request=%+v started=%+v", request, store.started)
+	}
+}
+
+func TestServiceFailsOnStalledCursor(t *testing.T) {
+	store := &fakeBillingStore{connector: Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: StatusActive}}
+	adapter := &fakeBillingAdapter{pages: []FetchPage{{NextCursor: "next"}, {NextCursor: "next"}}}
+	service := NewService(store, map[string]Adapter{ConnectorOneAPI: adapter})
+
+	run, err := service.Sync(context.Background(), "conn-1", SyncRequest{From: time.Now().Add(-time.Hour), To: time.Now()}, "manual")
+	assertBillingError(t, err, ErrorUpstream, "billing_cursor_stalled")
+	if run.Status != SyncFailed || run.ErrorCode != "billing_cursor_stalled" || run.PagesFetched != 2 {
+		t.Fatalf("unexpected stalled run: %+v", run)
+	}
+}
+
+func TestServiceMarksPersistenceFailure(t *testing.T) {
+	store := &fakeBillingStore{
+		connector: Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: StatusActive},
+		saveErr:   errors.New("database unavailable"),
+	}
+	service := NewService(store, map[string]Adapter{ConnectorOneAPI: &fakeBillingAdapter{pages: []FetchPage{{}}}})
+
+	run, err := service.Sync(context.Background(), "conn-1", SyncRequest{From: time.Now().Add(-time.Hour), To: time.Now()}, "manual")
+	if err == nil || err.Error() != "database unavailable" {
+		t.Fatalf("expected persistence error, got %v", err)
+	}
+	if run.Status != SyncFailed || run.ErrorCode != "internal_error" || store.finished.Status != SyncFailed {
+		t.Fatalf("persistence failure was not recorded: run=%+v finished=%+v", run, store.finished)
+	}
+}
+
+func TestServiceMapsCancellationToTimeout(t *testing.T) {
+	store := &fakeBillingStore{connector: Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: StatusActive}}
+	adapter := &fakeBillingAdapter{fetch: func(ctx context.Context, _ Connector, _ FetchRequest) (FetchPage, error) {
+		return FetchPage{}, ctx.Err()
+	}}
+	service := NewService(store, map[string]Adapter{ConnectorOneAPI: adapter})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	run, err := service.Sync(ctx, "conn-1", SyncRequest{From: time.Now().Add(-time.Hour), To: time.Now()}, "manual")
+	assertBillingError(t, err, ErrorTimeout, "billing_sync_timeout")
+	if run.Status != SyncFailed || run.ErrorCode != "billing_sync_timeout" {
+		t.Fatalf("cancellation was not recorded: %+v", run)
+	}
+}
+
+func TestServiceRunDueRecordsScheduledAudit(t *testing.T) {
+	connector := Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: StatusActive}
+	store := &fakeBillingStore{connector: connector, due: []Connector{connector}}
+	service := NewService(store, map[string]Adapter{ConnectorOneAPI: &fakeBillingAdapter{pages: []FetchPage{{}}}})
+
+	runs := service.RunDue(context.Background(), time.Now().UTC())
+	if len(runs) != 1 || runs[0].Trigger != "scheduled" || runs[0].Status != SyncSucceeded {
+		t.Fatalf("unexpected due runs: %+v", runs)
+	}
+	if len(store.audits) != 1 || store.audits[0].Trigger != "scheduled" || store.audits[0].Status != SyncSucceeded {
+		t.Fatalf("scheduled audit was not recorded: %+v", store.audits)
+	}
+}
+
+func TestServiceRunDuePreservesLookupErrorCode(t *testing.T) {
+	connector := Connector{ID: "conn-1", Type: ConnectorOneAPI, Status: StatusActive}
+	store := &fakeBillingStore{
+		connector: connector,
+		due:       []Connector{connector},
+		getErr:    NewError(ErrorNotFound, "billing_connector_not_found", "Billing connector not found"),
+	}
+	service := NewService(store, nil)
+
+	runs := service.RunDue(context.Background(), time.Now().UTC())
+	if len(runs) != 1 || runs[0].ErrorCode != "billing_connector_not_found" || store.audits[0].ErrorCode != "billing_connector_not_found" {
+		t.Fatalf("lookup error code was not preserved: runs=%+v audits=%+v", runs, store.audits)
+	}
+}
+
+func TestServiceSchedulerCanRestartAfterShutdown(t *testing.T) {
+	service := NewService(&fakeBillingStore{}, nil)
+	service.StartScheduler(time.Hour)
+	if err := service.Shutdown(context.Background()); err != nil {
+		t.Fatalf("first shutdown: %v", err)
+	}
+	service.StartScheduler(time.Hour)
+	if err := service.Shutdown(context.Background()); err != nil {
+		t.Fatalf("second shutdown: %v", err)
+	}
+}
+
+func assertBillingError(t *testing.T, err error, wantKind ErrorKind, wantCode string) {
+	t.Helper()
+	kind, code, _, ok := ErrorInfo(err)
+	if !ok || kind != wantKind || code != wantCode {
+		t.Fatalf("error=%v kind=%q code=%q ok=%v, want kind=%q code=%q", err, kind, code, ok, wantKind, wantCode)
+	}
+}

--- a/backend/internal/billing/types.go
+++ b/backend/internal/billing/types.go
@@ -1,0 +1,214 @@
+// Package billing owns provider-neutral billing synchronization and pricing-source
+// contracts. Persistence and HTTP adapters implement the ports declared here.
+package billing
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+const (
+	ConnectorAliyun = "aliyun"
+	ConnectorNewAPI = "newapi"
+	ConnectorOneAPI = "oneapi"
+
+	SyncRunning   = "running"
+	SyncSucceeded = "succeeded"
+	SyncFailed    = "failed"
+
+	StatusActive = "active"
+)
+
+// Connector is the persisted configuration for one external billing source.
+// Credentials are accepted through Credentials and must never be serialized by
+// an adapter in a connector summary.
+type Connector struct {
+	ID                      string
+	Name                    string
+	Type                    string
+	BaseURL                 string
+	Status                  string
+	ScheduleIntervalMinutes int
+	Config                  map[string]string
+	CredentialCiphertext    string
+	Credentials             map[string]string
+	CredentialsConfigured   bool
+	CredentialFields        []string
+	Checkpoint              string
+	LastSyncedThrough       *time.Time
+	LastSyncStatus          string
+	LastSyncMessage         string
+	LastSyncAt              *time.Time
+	NextSyncAt              *time.Time
+	CreatedAt               time.Time
+	UpdatedAt               time.Time
+}
+
+// Record is the provider-neutral billing model consumed by reconciliation and
+// analytics. Monetary values remain canonical decimal strings.
+type Record struct {
+	ID                string
+	ConnectorID       string
+	ExternalID        string
+	SourceType        string
+	AccountID         string
+	Service           string
+	Product           string
+	Model             string
+	Currency          string
+	GrossAmount       string
+	DiscountAmount    string
+	TaxAmount         string
+	RefundAmount      string
+	NetAmount         string
+	UsageQuantity     int64
+	UsageUnit         string
+	UsageStartAt      time.Time
+	UsageEndAt        time.Time
+	SourceTimezone    string
+	BillingPeriod     string
+	ExternalRequestID string
+	RawSnapshotID     string
+	Metadata          map[string]string
+	RawPayload        string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+type RawSnapshot struct {
+	ID                string
+	ConnectorID       string
+	ExternalID        string
+	PayloadHash       string
+	PayloadCiphertext string
+	CapturedAt        time.Time
+}
+
+type SyncRun struct {
+	ID              string
+	ConnectorID     string
+	Trigger         string
+	Status          string
+	RangeStart      time.Time
+	RangeEnd        time.Time
+	CursorStart     string
+	CursorEnd       string
+	PagesFetched    int
+	Attempts        int
+	RecordsSeen     int
+	RecordsInserted int
+	RecordsUpdated  int
+	ErrorCode       string
+	ErrorMessage    string
+	StartedAt       time.Time
+	FinishedAt      *time.Time
+}
+
+type SyncRequest struct {
+	From time.Time
+	To   time.Time
+}
+
+type FetchRequest struct {
+	From     time.Time
+	To       time.Time
+	Cursor   string
+	PageSize int
+}
+
+type FetchPage struct {
+	Records    []Record
+	NextCursor string
+}
+
+// Adapter is the only capability the synchronizer needs from an upstream
+// billing source. Concrete HTTP adapters may live outside this package.
+type Adapter interface {
+	Fetch(context.Context, Connector, FetchRequest) (FetchPage, error)
+}
+
+// Store is the persistence port used by the synchronization service.
+type Store interface {
+	GetBillingConnector(string, bool) (Connector, error)
+	StartBillingSyncRun(SyncRun) (SyncRun, error)
+	SaveBillingPage(string, string, []Record) (inserted int, updated int, err error)
+	FinishBillingSyncRun(SyncRun) (SyncRun, error)
+	ListDueBillingConnectors(time.Time, int) []Connector
+	RecordScheduledBillingAudit(SyncRun)
+}
+
+type ErrorKind string
+
+const (
+	ErrorInvalidInput ErrorKind = "invalid_input"
+	ErrorConflict     ErrorKind = "conflict"
+	ErrorNotFound     ErrorKind = "not_found"
+	ErrorRateLimited  ErrorKind = "rate_limited"
+	ErrorUpstream     ErrorKind = "upstream"
+	ErrorTimeout      ErrorKind = "timeout"
+)
+
+// Error carries a domain failure without prescribing a transport status.
+type Error struct {
+	Kind    ErrorKind
+	Code    string
+	Message string
+	Cause   error
+}
+
+func (e *Error) Error() string { return e.Message }
+func (e *Error) Unwrap() error { return e.Cause }
+
+func NewError(kind ErrorKind, code, message string) *Error {
+	return &Error{Kind: kind, Code: code, Message: message}
+}
+
+// WrapError preserves an adapter or persistence cause while exposing its
+// domain classification to callers that cannot depend on the concrete error.
+func WrapError(cause error, kind ErrorKind, code, message string) error {
+	err := NewError(kind, code, message)
+	err.Cause = cause
+	return err
+}
+
+type errorInfo interface {
+	ErrorKind() ErrorKind
+	ErrorCode() string
+	ErrorMessage() string
+}
+
+func (e *Error) ErrorKind() ErrorKind { return e.Kind }
+func (e *Error) ErrorCode() string    { return e.Code }
+func (e *Error) ErrorMessage() string { return e.Message }
+
+func ErrorInfo(err error) (kind ErrorKind, code, message string, ok bool) {
+	var info errorInfo
+	if err == nil || !errors.As(err, &info) {
+		return "", "", "", false
+	}
+	return info.ErrorKind(), info.ErrorCode(), info.ErrorMessage(), true
+}
+
+// AdapterFailure lets an adapter preserve its original error while exposing
+// domain-level retry and diagnostic information to the synchronizer.
+type AdapterFailure struct {
+	Err                error
+	Kind               ErrorKind
+	Code               string
+	Message            string
+	Retry              bool
+	RetryAfterDuration time.Duration
+}
+
+func (e *AdapterFailure) Error() string             { return e.Message }
+func (e *AdapterFailure) Unwrap() error             { return e.Err }
+func (e *AdapterFailure) ErrorKind() ErrorKind      { return e.Kind }
+func (e *AdapterFailure) ErrorCode() string         { return e.Code }
+func (e *AdapterFailure) ErrorMessage() string      { return e.Message }
+func (e *AdapterFailure) Retryable() bool           { return e.Retry }
+func (e *AdapterFailure) RetryAfter() time.Duration { return e.RetryAfterDuration }
+
+func NewAdapterFailure(err error, kind ErrorKind, code, message string, retry bool, retryAfter time.Duration) *AdapterFailure {
+	return &AdapterFailure{Err: err, Kind: kind, Code: code, Message: message, Retry: retry, RetryAfterDuration: retryAfter}
+}

--- a/backend/internal/server/billing_bridge.go
+++ b/backend/internal/server/billing_bridge.go
@@ -1,0 +1,262 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"tokenhub/backend/internal/billing"
+)
+
+// billingStoreBridge is a temporary adapter between the W03 domain seam and
+// the server-owned persistence model. W04 will replace it with a persistence
+// package implementation and remove the server model entirely.
+type billingStoreBridge struct {
+	store BillingStore
+}
+
+var _ billing.Store = (*billingStoreBridge)(nil)
+
+func (b *billingStoreBridge) CreateBillingConnector(connector billing.Connector) (billing.Connector, error) {
+	result, err := b.store.CreateBillingConnector(serverBillingConnector(connector))
+	return domainBillingConnector(result), domainBillingStoreError(err)
+}
+
+func (b *billingStoreBridge) ListBillingConnectors() []billing.Connector {
+	return domainBillingConnectors(b.store.ListBillingConnectors())
+}
+
+func (b *billingStoreBridge) GetBillingConnector(id string, includeCredentials bool) (billing.Connector, error) {
+	result, err := b.store.GetBillingConnector(id, includeCredentials)
+	return domainBillingConnector(result), domainBillingStoreError(err)
+}
+
+func (b *billingStoreBridge) UpdateBillingConnector(id string, connector billing.Connector) (billing.Connector, error) {
+	result, err := b.store.UpdateBillingConnector(id, serverBillingConnector(connector))
+	return domainBillingConnector(result), domainBillingStoreError(err)
+}
+
+func (b *billingStoreBridge) DeleteBillingConnector(id string) error {
+	return domainBillingStoreError(b.store.DeleteBillingConnector(id))
+}
+
+func (b *billingStoreBridge) StartBillingSyncRun(run billing.SyncRun) (billing.SyncRun, error) {
+	result, err := b.store.StartBillingSyncRun(serverBillingSyncRun(run))
+	return domainBillingSyncRun(result), domainBillingStoreError(err)
+}
+
+func (b *billingStoreBridge) SaveBillingPage(connectorID, checkpoint string, records []billing.Record) (int, int, error) {
+	inserted, updated, err := b.store.SaveBillingPage(connectorID, checkpoint, serverBillingRecords(records))
+	return inserted, updated, domainBillingStoreError(err)
+}
+
+func (b *billingStoreBridge) FinishBillingSyncRun(run billing.SyncRun) (billing.SyncRun, error) {
+	result, err := b.store.FinishBillingSyncRun(serverBillingSyncRun(run))
+	return domainBillingSyncRun(result), domainBillingStoreError(err)
+}
+
+func (b *billingStoreBridge) ListBillingRecords(connectorID string, limit int) []billing.Record {
+	return domainBillingRecords(b.store.ListBillingRecords(connectorID, limit))
+}
+
+func (b *billingStoreBridge) ListBillingSyncRuns(connectorID string, limit int) []billing.SyncRun {
+	return domainBillingSyncRuns(b.store.ListBillingSyncRuns(connectorID, limit))
+}
+
+func (b *billingStoreBridge) ListDueBillingConnectors(now time.Time, limit int) []billing.Connector {
+	return domainBillingConnectors(b.store.ListDueBillingConnectors(now, limit))
+}
+
+func (b *billingStoreBridge) RecordScheduledBillingAudit(run billing.SyncRun) {
+	b.store.RecordScheduledBillingAudit(serverBillingSyncRun(run))
+}
+
+type billingAdapterBridge struct {
+	adapter BillingAdapter
+}
+
+var _ billing.Adapter = (*billingAdapterBridge)(nil)
+
+func (b *billingAdapterBridge) Fetch(ctx context.Context, connector billing.Connector, request billing.FetchRequest) (billing.FetchPage, error) {
+	page, err := b.adapter.Fetch(ctx, serverBillingConnector(connector), serverBillingFetchRequest(request))
+	if err != nil {
+		return billing.FetchPage{}, domainBillingAdapterError(err)
+	}
+	return billing.FetchPage{Records: domainBillingRecords(page.Records), NextCursor: page.NextCursor}, nil
+}
+
+func domainBillingAdapterError(err error) error {
+	var upstream *billingUpstreamError
+	if errors.As(err, &upstream) {
+		return billing.NewAdapterFailure(err, billing.ErrorUpstream,
+			defaultString(upstream.code, "billing_upstream_error"),
+			defaultString(upstream.message, "Billing source request failed"),
+			upstream.retryable, upstream.retryAfter)
+	}
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		kind := billing.ErrorInvalidInput
+		if httpErr.Status >= 500 {
+			kind = billing.ErrorUpstream
+		} else if httpErr.Status == 404 {
+			kind = billing.ErrorNotFound
+		} else if httpErr.Status == 409 {
+			kind = billing.ErrorConflict
+		} else if httpErr.Status == 429 {
+			kind = billing.ErrorRateLimited
+		}
+		return billing.NewAdapterFailure(err, kind, httpErr.Code, httpErr.Message, httpErr.Status >= 500, 0)
+	}
+	return err
+}
+
+func domainBillingStoreError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		return err
+	}
+	kind := billing.ErrorInvalidInput
+	switch {
+	case httpErr.Status >= 500:
+		kind = billing.ErrorUpstream
+	case httpErr.Status == 404:
+		kind = billing.ErrorNotFound
+	case httpErr.Status == 409:
+		kind = billing.ErrorConflict
+	case httpErr.Status == 429:
+		kind = billing.ErrorRateLimited
+	}
+	return billing.WrapError(err, kind, httpErr.Code, httpErr.Message)
+}
+
+func domainBillingConnector(connector BillingConnector) billing.Connector {
+	return billing.Connector{
+		ID: connector.ID, Name: connector.Name, Type: connector.Type, BaseURL: connector.BaseURL,
+		Status: connector.Status, ScheduleIntervalMinutes: connector.ScheduleIntervalMinutes,
+		Config: billingCloneStringMap(connector.Config), CredentialCiphertext: connector.CredentialCiphertext,
+		Credentials: billingCloneStringMap(connector.Credentials), CredentialsConfigured: connector.CredentialsConfigured,
+		CredentialFields: append([]string(nil), connector.CredentialFields...), Checkpoint: connector.Checkpoint,
+		LastSyncedThrough: cloneTimePointer(connector.LastSyncedThrough), LastSyncStatus: connector.LastSyncStatus,
+		LastSyncMessage: connector.LastSyncMessage, LastSyncAt: cloneTimePointer(connector.LastSyncAt),
+		NextSyncAt: cloneTimePointer(connector.NextSyncAt), CreatedAt: connector.CreatedAt, UpdatedAt: connector.UpdatedAt,
+	}
+}
+
+func serverBillingConnector(connector billing.Connector) BillingConnector {
+	return BillingConnector{
+		ID: connector.ID, Name: connector.Name, Type: connector.Type, BaseURL: connector.BaseURL,
+		Status: connector.Status, ScheduleIntervalMinutes: connector.ScheduleIntervalMinutes,
+		Config: billingCloneStringMap(connector.Config), CredentialCiphertext: connector.CredentialCiphertext,
+		Credentials: billingCloneStringMap(connector.Credentials), CredentialsConfigured: connector.CredentialsConfigured,
+		CredentialFields: append([]string(nil), connector.CredentialFields...), Checkpoint: connector.Checkpoint,
+		LastSyncedThrough: cloneTimePointer(connector.LastSyncedThrough), LastSyncStatus: connector.LastSyncStatus,
+		LastSyncMessage: connector.LastSyncMessage, LastSyncAt: cloneTimePointer(connector.LastSyncAt),
+		NextSyncAt: cloneTimePointer(connector.NextSyncAt), CreatedAt: connector.CreatedAt, UpdatedAt: connector.UpdatedAt,
+	}
+}
+
+func domainBillingConnectors(connectors []BillingConnector) []billing.Connector {
+	result := make([]billing.Connector, len(connectors))
+	for index, connector := range connectors {
+		result[index] = domainBillingConnector(connector)
+	}
+	return result
+}
+
+func domainBillingRecord(record BillingRecord) billing.Record {
+	return billing.Record{
+		ID: record.ID, ConnectorID: record.ConnectorID, ExternalID: record.ExternalID, SourceType: record.SourceType,
+		AccountID: record.AccountID, Service: record.Service, Product: record.Product, Model: record.Model,
+		Currency: record.Currency, GrossAmount: record.GrossAmount, DiscountAmount: record.DiscountAmount,
+		TaxAmount: record.TaxAmount, RefundAmount: record.RefundAmount, NetAmount: record.NetAmount,
+		UsageQuantity: record.UsageQuantity, UsageUnit: record.UsageUnit, UsageStartAt: record.UsageStartAt,
+		UsageEndAt: record.UsageEndAt, SourceTimezone: record.SourceTimezone, BillingPeriod: record.BillingPeriod,
+		ExternalRequestID: record.ExternalRequestID, RawSnapshotID: record.RawSnapshotID,
+		Metadata: billingCloneStringMap(record.Metadata), RawPayload: record.RawPayload,
+		CreatedAt: record.CreatedAt, UpdatedAt: record.UpdatedAt,
+	}
+}
+
+func serverBillingRecord(record billing.Record) BillingRecord {
+	return BillingRecord{
+		ID: record.ID, ConnectorID: record.ConnectorID, ExternalID: record.ExternalID, SourceType: record.SourceType,
+		AccountID: record.AccountID, Service: record.Service, Product: record.Product, Model: record.Model,
+		Currency: record.Currency, GrossAmount: record.GrossAmount, DiscountAmount: record.DiscountAmount,
+		TaxAmount: record.TaxAmount, RefundAmount: record.RefundAmount, NetAmount: record.NetAmount,
+		UsageQuantity: record.UsageQuantity, UsageUnit: record.UsageUnit, UsageStartAt: record.UsageStartAt,
+		UsageEndAt: record.UsageEndAt, SourceTimezone: record.SourceTimezone, BillingPeriod: record.BillingPeriod,
+		ExternalRequestID: record.ExternalRequestID, RawSnapshotID: record.RawSnapshotID,
+		Metadata: billingCloneStringMap(record.Metadata), RawPayload: record.RawPayload,
+		CreatedAt: record.CreatedAt, UpdatedAt: record.UpdatedAt,
+	}
+}
+
+func domainBillingRecords(records []BillingRecord) []billing.Record {
+	result := make([]billing.Record, len(records))
+	for index, record := range records {
+		result[index] = domainBillingRecord(record)
+	}
+	return result
+}
+
+func serverBillingRecords(records []billing.Record) []BillingRecord {
+	result := make([]BillingRecord, len(records))
+	for index, record := range records {
+		result[index] = serverBillingRecord(record)
+	}
+	return result
+}
+
+func domainBillingSyncRun(run BillingSyncRun) billing.SyncRun {
+	return billing.SyncRun{
+		ID: run.ID, ConnectorID: run.ConnectorID, Trigger: run.Trigger, Status: run.Status,
+		RangeStart: run.RangeStart, RangeEnd: run.RangeEnd, CursorStart: run.CursorStart, CursorEnd: run.CursorEnd,
+		PagesFetched: run.PagesFetched, Attempts: run.Attempts, RecordsSeen: run.RecordsSeen,
+		RecordsInserted: run.RecordsInserted, RecordsUpdated: run.RecordsUpdated, ErrorCode: run.ErrorCode,
+		ErrorMessage: run.ErrorMessage, StartedAt: run.StartedAt, FinishedAt: cloneTimePointer(run.FinishedAt),
+	}
+}
+
+func serverBillingSyncRun(run billing.SyncRun) BillingSyncRun {
+	return BillingSyncRun{
+		ID: run.ID, ConnectorID: run.ConnectorID, Trigger: run.Trigger, Status: run.Status,
+		RangeStart: run.RangeStart, RangeEnd: run.RangeEnd, CursorStart: run.CursorStart, CursorEnd: run.CursorEnd,
+		PagesFetched: run.PagesFetched, Attempts: run.Attempts, RecordsSeen: run.RecordsSeen,
+		RecordsInserted: run.RecordsInserted, RecordsUpdated: run.RecordsUpdated, ErrorCode: run.ErrorCode,
+		ErrorMessage: run.ErrorMessage, StartedAt: run.StartedAt, FinishedAt: cloneTimePointer(run.FinishedAt),
+	}
+}
+
+func domainBillingSyncRuns(runs []BillingSyncRun) []billing.SyncRun {
+	result := make([]billing.SyncRun, len(runs))
+	for index, run := range runs {
+		result[index] = domainBillingSyncRun(run)
+	}
+	return result
+}
+
+func serverBillingFetchRequest(request billing.FetchRequest) BillingFetchRequest {
+	return BillingFetchRequest{From: request.From, To: request.To, Cursor: request.Cursor, PageSize: request.PageSize}
+}
+
+func billingCloneStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	result := make(map[string]string, len(values))
+	for key, value := range values {
+		result[key] = value
+	}
+	return result
+}
+
+func cloneTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}

--- a/backend/internal/server/billing_bridge_test.go
+++ b/backend/internal/server/billing_bridge_test.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"tokenhub/backend/internal/billing"
+)
+
+func TestDomainBillingAdapterErrorRetriesHTTP5xx(t *testing.T) {
+	err := domainBillingAdapterError(NewHTTPError(http.StatusBadGateway, "billing_cursor_invalid", "cursor invalid"))
+	var failure *billing.AdapterFailure
+	if !errors.As(err, &failure) || !failure.Retryable() {
+		t.Fatalf("expected HTTP 5xx adapter failure to be retryable: %T %v", err, err)
+	}
+	if kind, code, message, ok := billing.ErrorInfo(err); !ok || kind != billing.ErrorUpstream || code != "billing_cursor_invalid" || message != "cursor invalid" {
+		t.Fatalf("unexpected adapter failure info: kind=%q code=%q message=%q ok=%v", kind, code, message, ok)
+	}
+}
+
+func TestDomainBillingStoreErrorPreservesHTTPCompatibility(t *testing.T) {
+	original := NewHTTPError(http.StatusNotFound, "billing_connector_not_found", "Billing connector not found")
+	err := domainBillingStoreError(original)
+	if kind, code, message, ok := billing.ErrorInfo(err); !ok || kind != billing.ErrorNotFound || code != original.Code || message != original.Message {
+		t.Fatalf("unexpected store error info: kind=%q code=%q message=%q ok=%v", kind, code, message, ok)
+	}
+	httpErr := billingHTTPError(err)
+	if httpErr.Status != original.Status || httpErr.Code != original.Code || httpErr.Message != original.Message {
+		t.Fatalf("HTTP compatibility changed: got=%+v want=%+v", httpErr, original)
+	}
+}
+
+func TestBillingHTTPErrorMapsDomainKinds(t *testing.T) {
+	tests := []struct {
+		kind   billing.ErrorKind
+		status int
+	}{
+		{kind: billing.ErrorInvalidInput, status: http.StatusBadRequest},
+		{kind: billing.ErrorConflict, status: http.StatusConflict},
+		{kind: billing.ErrorNotFound, status: http.StatusNotFound},
+		{kind: billing.ErrorRateLimited, status: http.StatusTooManyRequests},
+		{kind: billing.ErrorUpstream, status: http.StatusBadGateway},
+		{kind: billing.ErrorTimeout, status: http.StatusGatewayTimeout},
+	}
+	for _, test := range tests {
+		t.Run(string(test.kind), func(t *testing.T) {
+			err := billingHTTPError(billing.NewError(test.kind, "billing_test_error", "billing test error"))
+			if err.Status != test.status || err.Code != "billing_test_error" || err.Message != "billing test error" {
+				t.Fatalf("unexpected HTTP mapping: got=%+v want status=%d", err, test.status)
+			}
+		})
+	}
+}
+
+func TestBillingHTTPErrorPreservesRateLimitHeaders(t *testing.T) {
+	original := NewHTTPError(http.StatusTooManyRequests, "billing_rate_limited", "Billing source rate limited")
+	original.Headers = map[string]string{"retry-after": "7"}
+	err := billingHTTPError(billing.NewAdapterFailure(original, billing.ErrorRateLimited, original.Code, original.Message, false, 0))
+	if err.Status != original.Status || err.Code != original.Code || err.Headers["retry-after"] != "7" {
+		t.Fatalf("rate-limit compatibility changed: got=%+v want=%+v", err, original)
+	}
+}

--- a/backend/internal/server/billing_http.go
+++ b/backend/internal/server/billing_http.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"tokenhub/backend/internal/billing"
 )
 
 func (s *Server) StartBillingScheduler() {
@@ -140,9 +142,9 @@ func (s *Server) handleAdminBillingConnectorAction(w http.ResponseWriter, r *htt
 func (s *Server) serveAdminBillingConnectorTest(w http.ResponseWriter, r *http.Request, user AdminUser, connectorID string) {
 	result, err := s.billing.Test(r.Context(), connectorID)
 	if err != nil {
-		httpErr := AsHTTPError(err)
+		httpErr := billingHTTPError(err)
 		s.recordAdminAuditWithStatus(r, user, "test", "billing_connector", connectorID, BillingSyncFailed, httpErr.Code, nil, map[string]any{"error_code": httpErr.Code})
-		writeError(w, r, err)
+		writeError(w, r, httpErr)
 		return
 	}
 	s.recordAdminAudit(r, user, "test", "billing_connector", connectorID, nil, result)
@@ -159,15 +161,16 @@ func (s *Server) serveAdminBillingConnectorSync(w http.ResponseWriter, r *http.R
 		writeError(w, r, NewHTTPError(http.StatusBadRequest, "invalid_billing_sync", "Invalid billing sync payload"))
 		return
 	}
-	run, err := s.billing.Sync(r.Context(), connectorID, request, "manual")
+	run, err := s.billing.Sync(r.Context(), connectorID, billing.SyncRequest{From: request.From, To: request.To}, "manual")
 	if err != nil {
-		httpErr := AsHTTPError(err)
-		s.recordAdminAuditWithStatus(r, user, "sync", "billing_connector", connectorID, BillingSyncFailed, httpErr.Code, nil, run)
-		writeError(w, r, err)
+		httpErr := billingHTTPError(err)
+		s.recordAdminAuditWithStatus(r, user, "sync", "billing_connector", connectorID, BillingSyncFailed, httpErr.Code, nil, serverBillingSyncRun(run))
+		writeError(w, r, httpErr)
 		return
 	}
-	s.recordAdminAudit(r, user, "sync", "billing_connector", connectorID, nil, run)
-	writeJSON(w, http.StatusOK, run)
+	response := serverBillingSyncRun(run)
+	s.recordAdminAudit(r, user, "sync", "billing_connector", connectorID, nil, response)
+	writeJSON(w, http.StatusOK, response)
 }
 
 func (s *Server) serveAdminBillingRecordsGet(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/server/billing_service.go
+++ b/backend/internal/server/billing_service.go
@@ -2,94 +2,20 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
+
+	"tokenhub/backend/internal/billing"
 )
 
+// BillingService is a compatibility composition wrapper. Domain behavior and
+// scheduler lifecycle are implemented by billing.Service until the remaining
+// server adapters move in W04.
 type BillingService struct {
-	store         BillingStore
-	adapters      map[string]BillingAdapter
-	mu            sync.Mutex
-	active        map[string]bool
-	schedulerMu   sync.Mutex
-	schedulerStop context.CancelFunc
-	schedulerDone chan struct{}
-}
-
-type billingCheckpoint struct {
-	From   time.Time `json:"from"`
-	To     time.Time `json:"to"`
-	Cursor string    `json:"cursor"`
-}
-
-func (s *BillingService) RunDue(ctx context.Context, now time.Time) []BillingSyncRun {
-	connectors := s.store.ListDueBillingConnectors(now, 25)
-	runs := make([]BillingSyncRun, 0, len(connectors))
-	for _, connector := range connectors {
-		run, err := s.Sync(ctx, connector.ID, BillingSyncRequest{}, "scheduled")
-		if run.ID == "" && err != nil {
-			run = BillingSyncRun{ConnectorID: connector.ID, Trigger: "scheduled", Status: BillingSyncFailed, ErrorCode: AsHTTPError(err).Code, ErrorMessage: AsHTTPError(err).Message}
-		}
-		s.store.RecordScheduledBillingAudit(run)
-		runs = append(runs, run)
-		if ctx.Err() != nil {
-			break
-		}
-	}
-	return runs
-}
-
-func (s *BillingService) StartScheduler(interval time.Duration) {
-	if interval <= 0 {
-		interval = 30 * time.Second
-	}
-	s.schedulerMu.Lock()
-	defer s.schedulerMu.Unlock()
-	if s.schedulerStop != nil {
-		return
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	s.schedulerStop = cancel
-	s.schedulerDone = make(chan struct{})
-	go func() {
-		defer close(s.schedulerDone)
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case now := <-ticker.C:
-				s.RunDue(ctx, now.UTC())
-			}
-		}
-	}()
-}
-
-func (s *BillingService) Shutdown(ctx context.Context) error {
-	s.schedulerMu.Lock()
-	stop := s.schedulerStop
-	s.schedulerMu.Unlock()
-	if stop == nil {
-		return nil
-	}
-	stop()
-	select {
-	case <-s.schedulerDone:
-		s.schedulerMu.Lock()
-		s.schedulerStop = nil
-		s.schedulerDone = nil
-		s.schedulerMu.Unlock()
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	*billing.Service
 }
 
 type billingUpstreamError struct {
@@ -100,229 +26,32 @@ type billingUpstreamError struct {
 	retryAfter time.Duration
 }
 
-func (e *billingUpstreamError) Error() string { return e.message }
+func (e *billingUpstreamError) Error() string             { return e.message }
+func (e *billingUpstreamError) Retryable() bool           { return e.retryable }
+func (e *billingUpstreamError) RetryAfter() time.Duration { return e.retryAfter }
+func (e *billingUpstreamError) StatusCode() int           { return e.status }
+func (e *billingUpstreamError) ErrorCode() string         { return e.code }
+func (e *billingUpstreamError) ErrorMessage() string      { return e.message }
 
 func newBillingService(store BillingStore) *BillingService {
 	client := &http.Client{Timeout: 30 * time.Second}
-	return &BillingService{
-		store: store,
-		adapters: map[string]BillingAdapter{
-			BillingConnectorAliyun: AliyunBillingAdapter{Client: client},
-			BillingConnectorNewAPI: NewAPIBillingAdapter{Client: client},
-			BillingConnectorOneAPI: OneAPIBillingAdapter{Client: client},
-		},
-		active: map[string]bool{},
-	}
+	return &BillingService{Service: billing.NewService(&billingStoreBridge{store: store}, map[string]billing.Adapter{
+		BillingConnectorAliyun: &billingAdapterBridge{adapter: AliyunBillingAdapter{Client: client}},
+		BillingConnectorNewAPI: &billingAdapterBridge{adapter: NewAPIBillingAdapter{Client: client}},
+		BillingConnectorOneAPI: &billingAdapterBridge{adapter: OneAPIBillingAdapter{Client: client}},
+	})}
 }
 
-func (s *BillingService) Test(ctx context.Context, connectorID string) (map[string]any, error) {
-	connector, err := s.store.GetBillingConnector(connectorID, true)
-	if err != nil {
-		return nil, err
+func billingConfigInt(config map[string]string, key string, fallback, minimum, maximum int) int {
+	value, err := strconv.Atoi(strings.TrimSpace(config[key]))
+	if err != nil || value < minimum || value > maximum {
+		return fallback
 	}
-	adapter, ok := s.adapters[connector.Type]
-	if !ok {
-		return nil, NewHTTPError(http.StatusBadRequest, "billing_adapter_missing", "Billing connector adapter is not registered")
-	}
-	now := time.Now().UTC()
-	page, _, err := fetchBillingPageWithRetry(ctx, billingConfigInt(connector.Config, "max_retries", 3, 1, 8), time.Duration(billingConfigInt(connector.Config, "retry_base_ms", 250, 1, 5000))*time.Millisecond, func() (BillingFetchPage, error) {
-		return adapter.Fetch(ctx, connector, BillingFetchRequest{From: now.Add(-time.Hour), To: now, PageSize: 1})
-	})
-	if err != nil {
-		return nil, billingHTTPError(err)
-	}
-	return map[string]any{
-		"ok":             true,
-		"connector_id":   connector.ID,
-		"connector_type": connector.Type,
-		"sample_records": len(page.Records),
-	}, nil
+	return value
 }
 
-func (s *BillingService) Sync(ctx context.Context, connectorID string, requested BillingSyncRequest, trigger string) (BillingSyncRun, error) {
-	if !s.begin(connectorID) {
-		return BillingSyncRun{}, NewHTTPError(http.StatusConflict, "billing_sync_in_progress", "A billing sync is already running for this connector")
-	}
-	defer s.end(connectorID)
-
-	connector, err := s.store.GetBillingConnector(connectorID, true)
-	if err != nil {
-		return BillingSyncRun{}, err
-	}
-	if connector.Status != StatusActive {
-		return BillingSyncRun{}, NewHTTPError(http.StatusConflict, "billing_connector_disabled", "Disabled billing connectors cannot be synchronized")
-	}
-	adapter, ok := s.adapters[connector.Type]
-	if !ok {
-		return BillingSyncRun{}, NewHTTPError(http.StatusBadRequest, "billing_adapter_missing", "Billing connector adapter is not registered")
-	}
-
-	from, to, cursor, err := resolveBillingSyncRange(connector, requested, time.Now().UTC())
-	if err != nil {
-		return BillingSyncRun{}, err
-	}
-	run, err := s.store.StartBillingSyncRun(BillingSyncRun{
-		ConnectorID: connector.ID,
-		Trigger:     defaultString(trigger, "manual"),
-		Status:      BillingSyncRunning,
-		RangeStart:  from,
-		RangeEnd:    to,
-		CursorStart: cursor,
-	})
-	if err != nil {
-		return BillingSyncRun{}, err
-	}
-
-	pageSize := billingConfigInt(connector.Config, "page_size", 100, 1, 1000)
-	maxRetries := billingConfigInt(connector.Config, "max_retries", 3, 1, 8)
-	retryBase := time.Duration(billingConfigInt(connector.Config, "retry_base_ms", 250, 1, 5000)) * time.Millisecond
-	requestsPerSecond := billingConfigInt(connector.Config, "rate_limit_per_second", 0, 0, 1000)
-	var lastRequest time.Time
-
-	for pageIndex := 0; pageIndex < 10000; pageIndex++ {
-		page, attempts, fetchErr := fetchBillingPageWithRetry(ctx, maxRetries, retryBase, func() (BillingFetchPage, error) {
-			if requestsPerSecond > 0 && !lastRequest.IsZero() {
-				minimumGap := time.Second / time.Duration(requestsPerSecond)
-				if wait := minimumGap - time.Since(lastRequest); wait > 0 {
-					timer := time.NewTimer(wait)
-					defer timer.Stop()
-					select {
-					case <-ctx.Done():
-						return BillingFetchPage{}, ctx.Err()
-					case <-timer.C:
-					}
-				}
-			}
-			lastRequest = time.Now()
-			return adapter.Fetch(ctx, connector, BillingFetchRequest{From: from, To: to, Cursor: cursor, PageSize: pageSize})
-		})
-		run.Attempts += attempts
-		if fetchErr != nil {
-			return s.failRun(run, fetchErr)
-		}
-
-		checkpoint, marshalErr := json.Marshal(billingCheckpoint{From: from, To: to, Cursor: page.NextCursor})
-		if marshalErr != nil {
-			return s.failRun(run, marshalErr)
-		}
-		inserted, updated, persistErr := s.store.SaveBillingPage(connector.ID, string(checkpoint), page.Records)
-		if persistErr != nil {
-			return s.failRun(run, persistErr)
-		}
-		run.PagesFetched++
-		run.RecordsSeen += len(page.Records)
-		run.RecordsInserted += inserted
-		run.RecordsUpdated += updated
-		run.CursorEnd = page.NextCursor
-		if page.NextCursor == "" {
-			run.Status = BillingSyncSucceeded
-			run.ErrorCode = ""
-			run.ErrorMessage = ""
-			return s.store.FinishBillingSyncRun(run)
-		}
-		if page.NextCursor == cursor {
-			return s.failRun(run, NewHTTPError(http.StatusBadGateway, "billing_cursor_stalled", "Billing source returned a cursor that did not advance"))
-		}
-		cursor = page.NextCursor
-	}
-	return s.failRun(run, NewHTTPError(http.StatusBadGateway, "billing_page_limit_exceeded", "Billing sync exceeded the maximum page count"))
-}
-
-func (s *BillingService) failRun(run BillingSyncRun, err error) (BillingSyncRun, error) {
-	run.Status = BillingSyncFailed
-	httpErr := billingHTTPError(err)
-	run.ErrorCode = httpErr.Code
-	run.ErrorMessage = httpErr.Message
-	finished, finishErr := s.store.FinishBillingSyncRun(run)
-	if finishErr != nil {
-		return run, finishErr
-	}
-	return finished, httpErr
-}
-
-func (s *BillingService) begin(connectorID string) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.active[connectorID] {
-		return false
-	}
-	s.active[connectorID] = true
-	return true
-}
-
-func (s *BillingService) end(connectorID string) {
-	s.mu.Lock()
-	delete(s.active, connectorID)
-	s.mu.Unlock()
-}
-
-func resolveBillingSyncRange(connector BillingConnector, requested BillingSyncRequest, now time.Time) (time.Time, time.Time, string, error) {
-	if requested.From.IsZero() && requested.To.IsZero() && strings.TrimSpace(connector.Checkpoint) != "" {
-		var checkpoint billingCheckpoint
-		if err := json.Unmarshal([]byte(connector.Checkpoint), &checkpoint); err == nil && !checkpoint.From.IsZero() && !checkpoint.To.IsZero() {
-			return checkpoint.From.UTC(), checkpoint.To.UTC(), checkpoint.Cursor, nil
-		}
-	}
-	to := requested.To.UTC()
-	if requested.To.IsZero() {
-		to = now.UTC()
-	}
-	from := requested.From.UTC()
-	if requested.From.IsZero() {
-		if connector.LastSyncedThrough != nil {
-			from = connector.LastSyncedThrough.UTC()
-		} else {
-			from = to.Add(-24 * time.Hour)
-		}
-	}
-	if !from.Before(to) {
-		return time.Time{}, time.Time{}, "", NewHTTPError(http.StatusBadRequest, "invalid_billing_range", "from must be earlier than to")
-	}
-	if to.After(now.Add(5 * time.Minute)) {
-		return time.Time{}, time.Time{}, "", NewHTTPError(http.StatusBadRequest, "invalid_billing_range", "to cannot be in the future")
-	}
-	return from, to, "", nil
-}
-
-func fetchBillingPageWithRetry(ctx context.Context, maxAttempts int, baseDelay time.Duration, fetch func() (BillingFetchPage, error)) (BillingFetchPage, int, error) {
-	var lastErr error
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		page, err := fetch()
-		if err == nil {
-			return page, attempt, nil
-		}
-		lastErr = err
-		if attempt == maxAttempts || !isRetryableBillingError(err) {
-			return BillingFetchPage{}, attempt, err
-		}
-		delay := baseDelay * time.Duration(1<<(attempt-1))
-		var upstream *billingUpstreamError
-		if errors.As(err, &upstream) && upstream.retryAfter > delay {
-			delay = upstream.retryAfter
-		}
-		timer := time.NewTimer(delay)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return BillingFetchPage{}, attempt, ctx.Err()
-		case <-timer.C:
-		}
-	}
-	return BillingFetchPage{}, maxAttempts, lastErr
-}
-
-func isRetryableBillingError(err error) bool {
-	var upstream *billingUpstreamError
-	if errors.As(err, &upstream) {
-		return upstream.retryable
-	}
-	var httpErr *HTTPError
-	if errors.As(err, &httpErr) {
-		return httpErr.Status >= 500
-	}
-	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
-}
-
+// billingHTTPError remains available to existing adapter tests and maps
+// upstream errors into the server's response error type.
 func billingHTTPError(err error) *HTTPError {
 	var upstream *billingUpstreamError
 	if errors.As(err, &upstream) {
@@ -332,20 +61,34 @@ func billingHTTPError(err error) *HTTPError {
 		}
 		return NewHTTPError(status, defaultString(upstream.code, "billing_upstream_error"), defaultString(upstream.message, "Billing source request failed"))
 	}
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr
+	}
+	if kind, code, message, ok := billing.ErrorInfo(err); ok {
+		return NewHTTPError(billingErrorStatus(kind), code, message)
+	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return NewHTTPError(http.StatusGatewayTimeout, "billing_sync_timeout", "Billing sync timed out")
 	}
 	return AsHTTPError(err)
 }
 
-func billingConfigInt(config map[string]string, key string, fallback int, minimum int, maximum int) int {
-	value, err := strconv.Atoi(strings.TrimSpace(config[key]))
-	if err != nil || value < minimum || value > maximum {
-		return fallback
+func billingErrorStatus(kind billing.ErrorKind) int {
+	switch kind {
+	case billing.ErrorConflict:
+		return http.StatusConflict
+	case billing.ErrorNotFound:
+		return http.StatusNotFound
+	case billing.ErrorRateLimited:
+		return http.StatusTooManyRequests
+	case billing.ErrorUpstream:
+		return http.StatusBadGateway
+	case billing.ErrorTimeout:
+		return http.StatusGatewayTimeout
+	case billing.ErrorInvalidInput:
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
 	}
-	return value
-}
-
-func (run BillingSyncRun) String() string {
-	return fmt.Sprintf("%s:%s", run.ConnectorID, run.Status)
 }

--- a/backend/internal/server/billing_test.go
+++ b/backend/internal/server/billing_test.go
@@ -715,16 +715,10 @@ func TestOneAPIBillingRecordPreservesLargeIntegerFields(t *testing.T) {
 func TestBillingSchedulerRestartsAfterShutdown(t *testing.T) {
 	service := newBillingService(NewMemoryStore())
 	service.StartScheduler(time.Hour)
-	if service.schedulerStop == nil {
-		t.Fatal("expected scheduler started")
-	}
 	if err := service.Shutdown(context.Background()); err != nil {
 		t.Fatalf("first shutdown: %v", err)
 	}
 	service.StartScheduler(time.Hour)
-	if service.schedulerStop == nil {
-		t.Fatal("expected scheduler to restart after shutdown")
-	}
 	if err := service.Shutdown(context.Background()); err != nil {
 		t.Fatalf("second shutdown: %v", err)
 	}

--- a/backend/internal/server/billing_types.go
+++ b/backend/internal/server/billing_types.go
@@ -15,9 +15,8 @@ const (
 	BillingSyncFailed    = "failed"
 )
 
-// BillingConnector is the persisted configuration for one external billing
-// source. Credentials are accepted through Credentials, encrypted into
-// CredentialCiphertext by the store, and never serialized back to callers.
+// BillingConnector is the persistence and HTTP representation retained by the
+// server until the W04 persistence/admin adapter migration.
 type BillingConnector struct {
 	ID                      string            `json:"id" gorm:"primaryKey"`
 	Name                    string            `json:"name"`
@@ -59,9 +58,6 @@ type BillingConnectorPatchRequest struct {
 	Credentials             map[string]string `json:"credentials"`
 }
 
-// BillingRecord is the provider-neutral billing model consumed by later
-// reconciliation and analysis modules. Monetary values are canonical decimal
-// strings so source precision is not lost through floating-point conversion.
 type BillingRecord struct {
 	ID                string            `json:"id" gorm:"primaryKey"`
 	ConnectorID       string            `json:"connector_id" gorm:"uniqueIndex:idx_billing_record_source;index"`


### PR DESCRIPTION
## Summary

Billing synchronization, retry handling, checkpoint recovery, and scheduler lifecycle were implemented inside the `server` package, which left the billing domain without an enforceable boundary. This PR introduces a standalone billing domain package while preserving the existing server-facing API and persistence behavior through temporary compatibility adapters.

## Related Issue

Related to #169 

## Changes

- Added the `backend/internal/billing` domain package with billing types, synchronization orchestration, narrow persistence and upstream adapter ports, and domain error types.
- Moved retry, range resolution, checkpoint, concurrency, scheduled execution, and scheduler lifecycle behavior into `billing.Service`.
- Added server-to-domain bridges for existing GORM persistence, upstream billing adapters, HTTP error mapping, and response representations.
- Added domain and bridge regression tests for synchronization, retries, error classification, status mapping, rate-limit headers, and scheduler restart behavior.
- Kept the remaining server HTTP, persistence, and upstream adapter implementations as explicit inputs for a follow-up PR.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...` pass
- `go vet ./...` pass
- `go test -race ./internal/billing` pass
- `go test -race ./internal/server -run '^(TestBillingSchedulerRestartsAfterShutdown|TestBillingConnectorTestAndScheduledSync|TestDomainBilling)'` pass
- `node --test tools/*.test.mjs` pass
- `node tools/check-doc-translations.mjs` pass
- `node tools/check-ui-translations.mjs` pass
- `node tools/check-env-contract.mjs` pass
- `node tools/check-source-lines.mjs` pass
- `git diff --check` pass

## Compatibility, Security, and Operations

No public API, response format, authentication, authorization, routing, billing rule, database schema, migration result, environment variable, or deployment change is included.

The server compatibility bridge is intentionally temporary. A follow-up PR will move the remaining persistence, admin HTTP, and upstream adapter implementations, then remove the bridge and server billing wrapper. This PR can be rolled back by removing the new billing package and restoring the prior server billing implementation.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.