### PR TITLE
docs(readme): emphasize enterprise token governance

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -19,18 +19,25 @@
   <a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | 日本語
 </p>
 
-## 対応 Provider
+## エンタープライズ Token ガバナンス
 
-> [!TIP]
-> **Codex サブスクリプションに対応：**OpenAI Codex のサブスクリプションアカウントを TokenHub に接続し、API Provider と同じ統合ゲートウェイでモデルを提供・管理できます。[Codex 接続ガイド →](docs/ja/codex-tokenhub-profile-quick-start.md)
+企業が AI モデルを導入するときの課題は、単に特定のモデル API を呼び出せるかどうかだけではありません。Provider の認証情報を露出せずに各チームへ Token を配布すること、上流障害や価格変動に応じて適切なモデルへルーティングすること、Provider の請求を社内のプロジェクト、チーム、コストセンターと照合することが難しくなります。
 
-TokenHub は、Codex サブスクリプション、OpenAI、Azure OpenAI、Anthropic、Gemini、DeepSeek、Qwen、ローカルモデル向けのネイティブアダプターに加え、150 以上の Provider テンプレートとカスタム OpenAI-Compatible 上流接続を備えています。主な接続先：
+TokenHub は、これらの制御をすべてのモデル呼び出しの手前に置きます。
 
-<p align="center">
-  <img src="docs/assets/provider-showcase.svg" alt="Codex サブスクリプション、OpenAI、Anthropic、Google Gemini、DeepSeek、Qwen、Llama、カスタム上流を含む TokenHub の主な Provider 接続先。" width="100%">
-</p>
+- プロジェクト単位の Key により、Provider のシークレットを渡さずにチームへ利用権限を付与できます。
+- ルーティングポリシーでモデルチャネルの優先度、重み、フェイルオーバー、ヘルス診断を一元管理できます。
+- 利用分析とリクエストログを、ユーザー、プロジェクト、チーム、モデル、コストセンターへ紐づけられます。
+- RBAC、OAuth/OIDC ID ソース、監査証跡、クォータ、並行数制限により、プライベート環境の AI アクセスを管理可能にします。
 
-Provider テンプレートは、利用可能な場合は対応するネイティブアダプターを使用し、それ以外は OpenAI-Compatible エンドポイントへ接続します。利用可能なモデルと機能は、上流サービスおよびアカウントによって異なります。
+## TokenHub が選ばれる理由
+
+多くのオープンソース AI ゲートウェイは Provider の集約に重点を置いています。つまり、1 つのエンドポイントから複数の上流を呼び出す仕組みです。これは開発者のモデル接続には役立ちますが、企業運用の課題をそれだけで解決できるわけではありません。TokenHub は、その不足しているガバナンス層を中心に設計されています。
+
+- Token 配布をプロジェクトとチームで管理し、生の Provider Key を各アプリケーションへ散在させません。
+- モデルアクセス、ルーティング、フェイルオーバーを管理者がポリシーとして変更でき、クライアントコードの変更を抑えられます。
+- 請求とリクエスト履歴を社内の所有関係へ紐づけ、財務、プラットフォーム、事業チームが AI コストを説明できます。
+- ユーザー、チームリーダー、管理者のワークスペースを分け、日常利用、承認、コスト配賦、プラットフォーム運用を責任ごとに整理します。
 
 ## スクリーンショット
 
@@ -50,19 +57,28 @@ TokenHub は、日常的なモデル利用、チームガバナンス、プラ�
 
 ## プラットフォーム機能
 
-- OpenAI-Compatible モデル API: `/v1/chat/completions`、`/v1/responses`、`/v1/embeddings`。Anthropic Messages API: `/v1/messages`、`/v1/messages/count_tokens`。
-- OpenAI-Compatible の画像生成および参照画像編集 API: `/v1/images/generations`、`/v1/images/edits`。非同期ジョブとサーバー側の画像保持に対応し、`codex-gpt-image-2` は Codex サブスクリプション枠、`gpt-image-2` は OpenAI API Provider を使用します。[画像生成ガイド](docs/ja/user-guide.md#codex-サブスクリプション画像生成)を参照してください。
-- Provider チャネル: OpenAI-Compatible、Azure OpenAI、Anthropic、Gemini、DeepSeek、Qwen、ローカル vLLM/Ollama、カスタム上流。
-- モデルカタログとルーティングポリシー: 優先度、重み、フェイルオーバー順序、ルートヘルス診断に対応。
 - プロジェクト単位の Key 管理: チーム所有、メンバー権限、クォータ、並行数制限に対応。
+- モデルカタログとルーティングポリシー: 優先度、重み、フェイルオーバー順序、ルートヘルス診断に対応。
 - ユーザー、プロジェクト、チーム、モデル、コストセンターに紐づく利用分析とリクエストログ。
 - OAuth/OIDC によるエンタープライズサインイン、RBAC、監査証跡に対応する ID ソース設定。
+- OpenAI-Compatible モデル API: `/v1/chat/completions`、`/v1/responses`、`/v1/embeddings`。Anthropic Messages API: `/v1/messages`、`/v1/messages/count_tokens`。
+- OpenAI-Compatible の画像生成および参照画像編集 API: `/v1/images/generations`、`/v1/images/edits`。非同期ジョブとサーバー側の画像保持に対応します。
 - クリーンなコンソール: ロール別ナビゲーション、グローバル検索、ライト/ダーク切り替え、左ナビ + 右詳細の API ドキュメント。
 - SQLite-first のプライベートデプロイ向けに、ネイティブ systemd と Docker Compose の両方をサポート。
 - PostgreSQL はマルチインスタンス構成に対応します。リモート PostgreSQL で状態を共有し、フロントエンドとバックエンドのレプリカを水平スケールできるほか、コネクションプールも設定できます。[デプロイガイド](docs/ja/deployment.md)を参照してください。
 - 管理コンソールは英語、中国語、日本語の切り替えに対応。
-- TokenHub は OpenAI Codex のサブスクリプションアカウントリソースにも接続できます。分離および復旧が可能な Codex Profile を使用し、指定したローカル Codex CLI またはデスクトップセッションを TokenHub 経由で実行できます。[Codex 接続ガイド](docs/ja/codex-tokenhub-profile-quick-start.md)を参照してください。
-- Gemini CLI は TokenHub の Gemini ネイティブ API に直接接続し、Codex サブスクリプションアカウントの GPT モデルを CCswitch なしで使用できます。[Gemini CLI 接続ガイド](docs/ja/gemini-cli-codex-subscription.md)を参照してください。
+
+## Provider エコシステム
+
+複数 Provider への対応は TokenHub の一機能であり、中心的な約束ではありません。エンタープライズ Token ガバナンス、ルーティング、利用主体の特定、監査制御を先に整えたうえで、TokenHub はその管理されたワークフローを OpenAI、Azure OpenAI、Anthropic、Gemini、DeepSeek、Qwen、Codex サブスクリプション、ローカルモデル、カスタム OpenAI-Compatible 上流へ接続します。
+
+TokenHub は、OpenAI、Azure OpenAI、Anthropic、Gemini、DeepSeek、Qwen、Codex サブスクリプション、ローカルモデル向けのネイティブアダプターに加え、150 以上の Provider テンプレートを備えています。主な接続先：
+
+<p align="center">
+  <img src="docs/assets/provider-showcase.svg" alt="商用モデル、サブスクリプションモデル、ローカルモデル、カスタム上流を含む TokenHub の主な Provider 接続先。" width="100%">
+</p>
+
+Provider テンプレートは、利用可能な場合は対応するネイティブアダプターを使用し、それ以外は OpenAI-Compatible エンドポイントへ接続します。利用可能なモデルと機能は、上流サービスおよびアカウントによって異なります。
 
 ## クイックスタート
 

--- a/README.md
+++ b/README.md
@@ -19,18 +19,25 @@
   English | <a href="README.zh-CN.md">简体中文</a> | <a href="README.ja.md">日本語</a>
 </p>
 
-## Supported Providers
+## Enterprise Token Governance
 
-> [!TIP]
-> **Codex subscription ready:** connect OpenAI Codex subscription accounts to TokenHub and serve their models through the same governed gateway as API-based providers. [Set up Codex access →](docs/codex-tokenhub-profile-quick-start.md)
+Enterprises rarely struggle only with calling a model API. They struggle with distributing access tokens without exposing provider credentials, routing requests to the right model when upstreams fail or prices change, and reconciling provider invoices with internal projects, teams, and cost centers.
 
-TokenHub includes native adapters for Codex subscriptions, OpenAI, Azure OpenAI, Anthropic, Gemini, DeepSeek, Qwen, and local models, plus a catalog of 150+ provider templates and custom OpenAI-compatible upstreams. Popular integrations include:
+TokenHub puts those controls in front of every model call:
 
-<p align="center">
-  <img src="docs/assets/provider-showcase.svg" alt="Popular TokenHub provider integrations, including Codex Subscription, OpenAI, Anthropic, Google Gemini, DeepSeek, Qwen, Llama, and custom upstreams." width="100%">
-</p>
+- Project-scoped keys give teams usable access without handing out provider secrets.
+- Routing policies select, prioritize, weight, and fail over model channels centrally.
+- Usage logs and analytics attribute requests to users, projects, teams, models, and cost centers.
+- RBAC, OAuth/OIDC identity sources, audit trails, quotas, and concurrency limits make AI access governable inside private deployments.
 
-Provider templates use the matching native adapter when available; otherwise they connect through an OpenAI-compatible endpoint. Models and capabilities vary by upstream service and account.
+## Why TokenHub
+
+Many open source AI gateways focus on provider fan-out: one endpoint that can call many upstreams. That helps developers connect models, but it does not solve the enterprise operating problem by itself. TokenHub is built around the missing governance layer:
+
+- Token distribution is managed by project and team instead of by copying raw provider keys into every application.
+- Model access, routing, and fallback are policy decisions that administrators can change without rewriting client code.
+- Bills and request history can be compared against internal ownership so finance, platform, and business teams can explain AI spend.
+- User, team leader, and administrator workspaces keep daily usage, approval, cost attribution, and platform operations separated by responsibility.
 
 ## Screenshots
 
@@ -50,19 +57,28 @@ TokenHub separates everyday model usage, team governance, and platform administr
 
 ## Platform Capabilities
 
-- OpenAI-compatible model APIs: `/v1/chat/completions`, `/v1/responses`, `/v1/embeddings`; Anthropic Messages APIs: `/v1/messages`, `/v1/messages/count_tokens`.
-- OpenAI-compatible image generation and reference-image editing through `/v1/images/generations` and `/v1/images/edits`, with asynchronous jobs and server-side image retention; `codex-gpt-image-2` uses Codex subscription capacity, while `gpt-image-2` uses OpenAI API providers. See the [image generation guide](docs/user-guide.md#codex-subscription-image-generation).
-- Provider channels for OpenAI-compatible, Azure OpenAI, Anthropic, Gemini, DeepSeek, Qwen, local vLLM/Ollama, and custom upstreams.
-- Model catalog and routing policies with priority, weight, failover order, and route health diagnostics.
 - Project-scoped key management with team ownership, member permissions, quotas, and concurrency controls.
+- Model catalog and routing policies with priority, weight, failover order, and route health diagnostics.
 - Usage analytics and request logs attributed to user, project, team, model, and cost center.
 - Identity source configuration for OAuth/OIDC enterprise sign-in, plus RBAC and audit trails.
+- OpenAI-compatible model APIs: `/v1/chat/completions`, `/v1/responses`, `/v1/embeddings`; Anthropic Messages APIs: `/v1/messages`, `/v1/messages/count_tokens`.
+- OpenAI-compatible image generation and reference-image editing through `/v1/images/generations` and `/v1/images/edits`, with asynchronous jobs and server-side image retention.
 - Clean console with compact role-aware navigation, global search, light/dark mode, and split-view API documentation.
 - SQLite-first private deployment with native systemd and Docker Compose options.
 - PostgreSQL supports multi-instance deployments: share state through remote PostgreSQL, scale frontend and backend replicas horizontally, and configure connection pools. See the [deployment guide](docs/deployment.md) and [PostgreSQL setup guide](docs/postgresql-setup.md).
 - Console language switching for English, Chinese, and Japanese.
-- TokenHub can also connect OpenAI Codex subscription resources and route selected local Codex CLI or desktop sessions through an isolated, recoverable Codex profile. See the [Codex integration guides](docs/codex-tokenhub-profile-quick-start.md).
-- Gemini CLI can connect directly to TokenHub's native Gemini API and use GPT models backed by Codex subscription accounts, without CCswitch. See the [Gemini CLI guide](docs/gemini-cli-codex-subscription.md).
+
+## Provider Ecosystem
+
+Multi-provider support is one layer of TokenHub, not the core promise. Once enterprise token governance, routing, attribution, and audit controls are in place, TokenHub can connect those governed workflows to OpenAI, Azure OpenAI, Anthropic, Gemini, DeepSeek, Qwen, Codex subscriptions, local models, and custom OpenAI-compatible upstreams.
+
+TokenHub includes native adapters for OpenAI, Azure OpenAI, Anthropic, Gemini, DeepSeek, Qwen, Codex subscriptions, and local models, plus a catalog of 150+ provider templates. Popular integrations include:
+
+<p align="center">
+  <img src="docs/assets/provider-showcase.svg" alt="Popular TokenHub provider integrations across commercial, subscription, local, and custom upstreams." width="100%">
+</p>
+
+Provider templates use the matching native adapter when available; otherwise they connect through an OpenAI-compatible endpoint. Models and capabilities vary by upstream service and account.
 
 ## Quick Start
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,18 +19,25 @@
   <a href="README.md">English</a> | 简体中文 | <a href="README.ja.md">日本語</a>
 </p>
 
-## 支持的 Provider
+## 企业级 Token 治理
 
-> [!TIP]
-> **支持接入 Codex 订阅：**可将 OpenAI Codex 订阅账号接入 TokenHub，与 API Provider 一样通过统一网关进行模型服务与治理。[查看 Codex 接入指南 →](docs/zh-CN/codex-tokenhub-profile-quick-start.md)
+企业接入 AI 模型时，难点通常不只是“能不能调通某个模型 API”。真正麻烦的是：如何把 Token 安全分发给不同团队而不泄露 Provider 密钥，如何在上游故障或价格变化时把请求路由到合适模型，如何把 Provider 账单和内部项目、团队、成本中心对齐。
 
-TokenHub 原生适配 Codex 订阅、OpenAI、Azure OpenAI、Anthropic、Gemini、DeepSeek、Qwen 和本地模型，并内置 150+ Provider 模板，也支持自定义 OpenAI-Compatible 上游。常用接入包括：
+TokenHub 将这些控制能力放到每一次模型调用之前：
 
-<p align="center">
-  <img src="docs/assets/provider-showcase.svg" alt="TokenHub 常用 Provider 接入，包括 Codex 订阅、OpenAI、Anthropic、Google Gemini、DeepSeek、Qwen、Llama 和自定义上游。" width="100%">
-</p>
+- 按项目发放 Key，让团队获得可用权限，而不是直接复制 Provider 密钥。
+- 通过统一策略管理模型渠道的优先级、权重、失败回退和健康诊断。
+- 用量统计和请求日志可归因到用户、项目、团队、模型和成本中心。
+- RBAC、OAuth/OIDC 身份源、审计追踪、额度和并发限制让私有化 AI 访问真正可治理。
 
-Provider 模板会优先使用对应的原生适配器，其余模板通过 OpenAI-Compatible 接口接入；实际可用模型和能力以对应上游服务及账号权限为准。
+## 为什么选择 TokenHub
+
+许多开源 AI 网关主要解决的是 Provider 聚合：用一个接口调用多个上游。这对开发者接入模型很有帮助，但单靠它并不能解决企业运营里的治理问题。TokenHub 关注的正是这层缺失的治理能力：
+
+- Token 分发按项目和团队管理，不需要把原始 Provider Key 散落到每个应用里。
+- 模型访问、路由和失败回退由管理员通过策略统一调整，不必改客户端代码。
+- 账单和请求记录可以回到内部归属关系中，帮助财务、平台和业务团队解释 AI 成本。
+- 普通用户、团队负责人和管理员拥有分离的工作台，让日常调用、审批、成本归因和平台运维各归其位。
 
 ## 产品截图
 
@@ -50,19 +57,28 @@ TokenHub 将日常模型使用、团队治理和平台运维拆成清晰的角�
 
 ## 平台能力
 
-- OpenAI-Compatible 模型 API：`/v1/chat/completions`、`/v1/responses`、`/v1/embeddings`；Anthropic Messages API：`/v1/messages`、`/v1/messages/count_tokens`。
-- OpenAI-Compatible 生图与参考图编辑 API：`/v1/images/generations`、`/v1/images/edits`，支持异步任务和服务端图片留存；`codex-gpt-image-2` 使用 Codex 订阅额度，`gpt-image-2` 使用 OpenAI API Provider。参见[生图 API 调用与测试指南](docs/zh-CN/codex-image-generation-api.md)。
-- Provider 渠道：OpenAI-Compatible、Azure OpenAI、Anthropic、Gemini、DeepSeek、Qwen、本地 vLLM/Ollama 和自定义上游。
-- 模型目录和路由策略：支持优先级、权重、失败回退顺序和路由健康诊断。
 - 按项目归属的 Key 管理：支持团队归属、成员权限、额度和并发限制。
+- 模型目录和路由策略：支持优先级、权重、失败回退顺序和路由健康诊断。
 - 用量统计和请求日志：可归因到用户、项目、团队、模型和成本中心。
 - 身份源配置：支持 OAuth/OIDC 企业登录，并配合 RBAC 和审计追踪。
+- OpenAI-Compatible 模型 API：`/v1/chat/completions`、`/v1/responses`、`/v1/embeddings`；Anthropic Messages API：`/v1/messages`、`/v1/messages/count_tokens`。
+- OpenAI-Compatible 生图与参考图编辑 API：`/v1/images/generations`、`/v1/images/edits`，支持异步任务和服务端图片留存。
 - 简洁控制台：分角色导航、全局搜索、黑白主题，以及左侧 API 导航 + 右侧详情的接口文档。
 - SQLite-first 私有化部署，提供原生 systemd 和 Docker Compose 两种方式。
 - PostgreSQL 支持多实例部署：通过远端 PostgreSQL 共享状态，实现前后端实例横向扩展，并提供连接池配置。参见[部署指南](docs/zh-CN/deployment.md)。
 - 管理后台支持英文、中文、日文切换。
-- TokenHub 还支持接入 OpenAI Codex 订阅账号资源，并通过可隔离、可恢复的 Codex Profile，让指定的本地 Codex CLI 或桌面端会话经过 TokenHub。参见 [Codex 接入指南](docs/zh-CN/codex-tokenhub-profile-quick-start.md)。
-- Gemini CLI 可以直接连接 TokenHub 的 Gemini 原生接口，并使用 Codex 订阅账号提供的 GPT 模型，不需要 CCswitch。参见 [Gemini CLI 接入指南](docs/zh-CN/gemini-cli-codex-subscription.md)。
+
+## Provider 生态
+
+多 Provider 支持只是 TokenHub 的其中一层能力，不是项目的核心卖点。当前面的企业级 Token 治理、路由、归因和审计机制就位之后，TokenHub 才把这些受控工作流连接到 OpenAI、Azure OpenAI、Anthropic、Gemini、DeepSeek、Qwen、Codex 订阅、本地模型和自定义 OpenAI-Compatible 上游。
+
+TokenHub 原生适配 OpenAI、Azure OpenAI、Anthropic、Gemini、DeepSeek、Qwen、Codex 订阅和本地模型，并内置 150+ Provider 模板。常用接入包括：
+
+<p align="center">
+  <img src="docs/assets/provider-showcase.svg" alt="TokenHub 常用 Provider 接入，覆盖商业模型、订阅模型、本地模型和自定义上游。" width="100%">
+</p>
+
+Provider 模板会优先使用对应的原生适配器，其余模板通过 OpenAI-Compatible 接口接入；实际可用模型和能力以对应上游服务及账号权限为准。
 
 ## 快速开始
 


### PR DESCRIPTION
## Summary

Rework the root README structure so TokenHub leads with enterprise token governance, model routing, and billing attribution pain points instead of provider support.

## Related Issue

N/A

## Changes

- Add an enterprise token governance introduction to the English, Simplified Chinese, and Japanese READMEs.
- Add a differentiated “Why TokenHub” section that explains the governance layer beyond provider fan-out.
- Move provider support into a later provider ecosystem section and frame it as one platform capability.
- Remove Codex subscription-specific callouts, guide links, and CLI explanations so it is presented only as one provider option.
- Reorder the platform capability bullets so governance, routing, attribution, and identity controls come first.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [x] Documentation
- [ ] Deployment or configuration

## Verification

- `node --test tools/*.test.mjs` passed.
- `node tools/check-doc-translations.mjs` passed in local existence mode.
- `node tools/check-doc-translations.mjs --base origin/main --head HEAD` passed.
- `node tools/check-ui-translations.mjs` passed.
- `node tools/check-env-contract.mjs` passed.
- `node tools/check-source-lines.mjs` passed.
- `git diff --check` passed.
- `git diff --check origin/main..HEAD` passed.

## Compatibility, Security, and Operations

None.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.