### PR TITLE
fix(api-keys): restrict assigned key mutations

### DIFF
--- a/backend/internal/server/admin_api_key_management_authorization_test.go
+++ b/backend/internal/server/admin_api_key_management_authorization_test.go
@@ -1,0 +1,280 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestAssignedAPIKeyOwnerCannotManageAdminIssuedKey(t *testing.T) {
+	store := NewMemoryStore()
+	if _, err := store.CreateAdminUser(AdminUser{
+		Username: "assigned-key-admin",
+		Name:     "Assigned Key Admin",
+		Email:    "assigned-key-admin@tokenhub.local",
+		Role:     "admin",
+		Status:   StatusActive,
+	}, "admin123456"); err != nil {
+		t.Fatal(err)
+	}
+	sessionToken := func(userID string) string {
+		t.Helper()
+		_, session, err := store.CreateAdminSession(userID, time.Hour)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return session.Token
+	}
+	viewer, err := store.CreateAdminUser(AdminUser{
+		Username: "assigned-key-viewer",
+		Name:     "Assigned Key Viewer",
+		Email:    "assigned-key-viewer@tokenhub.local",
+		Role:     "user",
+		Status:   StatusActive,
+	}, "viewer123456")
+	if err != nil {
+		t.Fatal(err)
+	}
+	creator, err := store.CreateAdminUser(AdminUser{
+		Username: "self-key-creator",
+		Name:     "Self Key Creator",
+		Email:    "self-key-creator@tokenhub.local",
+		Role:     "user",
+		Status:   StatusActive,
+	}, "creator123456")
+	if err != nil {
+		t.Fatal(err)
+	}
+	maintainer, err := store.CreateAdminUser(AdminUser{
+		Username: "key-maintainer",
+		Name:     "Key Maintainer",
+		Email:    "key-maintainer@tokenhub.local",
+		Role:     "user",
+		Status:   StatusActive,
+	}, "maintainer123456")
+	if err != nil {
+		t.Fatal(err)
+	}
+	project := store.CreateProject(Project{Name: "Assigned Key Project", Status: StatusActive})
+	store.CreateResource("project-members", AdminResource{
+		Name:   "Assigned Viewer Membership",
+		Status: StatusActive,
+		Fields: map[string]any{
+			"project_id": project.ID,
+			"user_id":    viewer.ID,
+			"role":       "viewer",
+		},
+	})
+	store.CreateResource("project-members", AdminResource{
+		Name:   "Creator Developer Membership",
+		Status: StatusActive,
+		Fields: map[string]any{
+			"project_id": project.ID,
+			"user_id":    creator.ID,
+			"role":       "developer",
+		},
+	})
+	store.CreateResource("project-members", AdminResource{
+		Name:   "Maintainer Membership",
+		Status: StatusActive,
+		Fields: map[string]any{
+			"project_id": project.ID,
+			"user_id":    maintainer.ID,
+			"role":       "maintainer",
+		},
+	})
+	viewerToken := sessionToken(viewer.ID)
+	creatorToken := sessionToken(creator.ID)
+	maintainerToken := sessionToken(maintainer.ID)
+	server := New(store)
+	app := server.Handler()
+
+	issued := doJSON(t, app, http.MethodPost, "/api/admin/projects/"+project.ID+"/keys", map[string]any{
+		"name":          "Admin Issued Viewer Key",
+		"owner_user_id": viewer.ID,
+		"limits": map[string]any{
+			"daily_requests": 100,
+		},
+	}, "")
+	if issued.Code != http.StatusCreated {
+		t.Fatalf("admin key create failed: %d %s", issued.Code, issued.Body)
+	}
+	var adminKey struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(issued.Body), &adminKey); err != nil {
+		t.Fatal(err)
+	}
+
+	listed := doJSON(t, app, http.MethodGet, "/api/admin/api-keys", nil, viewerToken)
+	if listed.Code != http.StatusOK {
+		t.Fatalf("viewer list keys failed: %d %s", listed.Code, listed.Body)
+	}
+	var listedPayload struct {
+		Data []APIKey `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(listed.Body), &listedPayload); err != nil {
+		t.Fatal(err)
+	}
+	if !apiKeyPayloadContainsID(listedPayload.Data, adminKey.ID) {
+		t.Fatalf("assigned viewer cannot see admin-issued key: %#v", listedPayload.Data)
+	}
+
+	usage := doJSON(t, app, http.MethodGet, "/api/admin/api-keys/"+adminKey.ID+"/usage", nil, viewerToken)
+	if usage.Code != http.StatusOK {
+		t.Fatalf("assigned viewer should read admin-issued key usage, got %d: %s", usage.Code, usage.Body)
+	}
+	logs := doJSON(t, app, http.MethodGet, "/api/admin/audit/requests?api_key_id="+adminKey.ID, nil, viewerToken)
+	if logs.Code != http.StatusOK {
+		t.Fatalf("assigned viewer should filter request logs for admin-issued key, got %d: %s", logs.Code, logs.Body)
+	}
+
+	for _, testCase := range []struct {
+		name    string
+		method  string
+		path    string
+		payload any
+	}{
+		{
+			name:   "limits patch",
+			method: http.MethodPatch,
+			path:   "/api/admin/api-keys/" + adminKey.ID,
+			payload: map[string]any{
+				"limits": map[string]any{"daily_requests": 10000},
+			},
+		},
+		{
+			name:   "security patch",
+			method: http.MethodPatch,
+			path:   "/api/admin/api-keys/" + adminKey.ID,
+			payload: map[string]any{
+				"model_access_mode": "restricted",
+				"allowed_models":    []string{"gpt-4.1"},
+				"ip_allowlist":      []string{"203.0.113.10/32"},
+			},
+		},
+		{
+			name:    "rotate",
+			method:  http.MethodPost,
+			path:    "/api/admin/api-keys/" + adminKey.ID + "/rotate",
+			payload: map[string]any{},
+		},
+		{
+			name:   "delete",
+			method: http.MethodDelete,
+			path:   "/api/admin/api-keys/" + adminKey.ID,
+		},
+	} {
+		resp := doJSON(t, app, testCase.method, testCase.path, testCase.payload, viewerToken)
+		if resp.Code != http.StatusForbidden {
+			t.Fatalf("assigned viewer %s: expected 403, got %d: %s", testCase.name, resp.Code, resp.Body)
+		}
+	}
+
+	adminPatch := doJSON(t, app, http.MethodPatch, "/api/admin/api-keys/"+adminKey.ID, map[string]any{
+		"name": "Admin Updated Viewer Key",
+	}, "")
+	if adminPatch.Code != http.StatusOK {
+		t.Fatalf("platform admin should manage admin-issued key, got %d: %s", adminPatch.Code, adminPatch.Body)
+	}
+
+	maintainerPatch := doJSON(t, app, http.MethodPatch, "/api/admin/api-keys/"+adminKey.ID, map[string]any{
+		"name": "Maintainer Updated Viewer Key",
+	}, maintainerToken)
+	if maintainerPatch.Code != http.StatusOK {
+		t.Fatalf("project maintainer should manage admin-issued key, got %d: %s", maintainerPatch.Code, maintainerPatch.Body)
+	}
+
+	selfIssued := doJSON(t, app, http.MethodPost, "/api/admin/projects/"+project.ID+"/keys", map[string]any{
+		"name": "Self Issued Key",
+	}, creatorToken)
+	if selfIssued.Code != http.StatusCreated {
+		t.Fatalf("creator key create failed: %d %s", selfIssued.Code, selfIssued.Body)
+	}
+	var selfKey struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(selfIssued.Body), &selfKey); err != nil {
+		t.Fatal(err)
+	}
+	selfPatch := doJSON(t, app, http.MethodPatch, "/api/admin/api-keys/"+selfKey.ID, map[string]any{
+		"name": "Creator Updated Own Key",
+	}, creatorToken)
+	if selfPatch.Code != http.StatusOK {
+		t.Fatalf("creator should patch own key, got %d: %s", selfPatch.Code, selfPatch.Body)
+	}
+	selfRotate := doJSON(t, app, http.MethodPost, "/api/admin/api-keys/"+selfKey.ID+"/rotate", map[string]any{}, creatorToken)
+	if selfRotate.Code != http.StatusCreated {
+		t.Fatalf("creator should rotate own key, got %d: %s", selfRotate.Code, selfRotate.Body)
+	}
+	selfDelete := doJSON(t, app, http.MethodDelete, "/api/admin/api-keys/"+selfKey.ID, nil, creatorToken)
+	if selfDelete.Code != http.StatusNoContent {
+		t.Fatalf("creator should delete own key, got %d: %s", selfDelete.Code, selfDelete.Body)
+	}
+
+	legacyKey, _, err := store.CreateAPIKey(project.ID, APIKey{Name: "Legacy Assigned Key", OwnerUserID: viewer.ID, Status: StatusActive}, "thk_legacy_assigned")
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyPatch := doJSON(t, app, http.MethodPatch, "/api/admin/api-keys/"+legacyKey.ID, map[string]any{
+		"name": "Viewer Updated Legacy Key",
+	}, viewerToken)
+	if legacyPatch.Code != http.StatusForbidden {
+		t.Fatalf("legacy assigned key should fail closed for viewer mutation, got %d: %s", legacyPatch.Code, legacyPatch.Body)
+	}
+}
+
+func apiKeyPayloadContainsID(keys []APIKey, id string) bool {
+	for _, key := range keys {
+		if key.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestOrdinaryUsersCanReadOnlyOwnActiveTeamsForAPIKeyConsoleAuthz(t *testing.T) {
+	store := NewMemoryStore()
+	store.CreateResource("teams", AdminResource{ID: "team_active_authz", Name: "Active Authz Team", Status: StatusActive})
+	store.CreateResource("teams", AdminResource{ID: "team_disabled_authz", Name: "Disabled Authz Team", Status: StatusActive})
+	store.CreateResource("teams", AdminResource{ID: "team_other_authz", Name: "Other Authz Team", Status: StatusActive})
+	user, err := store.CreateAdminUser(AdminUser{
+		Username: "team-authz-user",
+		Email:    "team-authz-user@tokenhub.local",
+		Role:     "user",
+		TeamID:   "team_active_authz",
+		TeamIDs:  []string{"team_disabled_authz"},
+		Status:   StatusActive,
+	}, "team123456")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UpdateResource("teams", "team_disabled_authz", AdminResource{Status: StatusDisabled}); err != nil {
+		t.Fatal(err)
+	}
+	_, session, err := store.CreateAdminSession(user.ID, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := New(store).Handler()
+
+	listed := doJSON(t, app, http.MethodGet, "/api/admin/resources/teams", nil, session.Token)
+	if listed.Code != http.StatusOK {
+		t.Fatalf("ordinary user should read own active teams, got %d: %s", listed.Code, listed.Body)
+	}
+	var payload struct {
+		Data []AdminResource `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(listed.Body), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Data) != 1 || payload.Data[0].ID != "team_active_authz" {
+		t.Fatalf("ordinary user team resource scope = %#v, want only active own team", payload.Data)
+	}
+
+	created := doJSON(t, app, http.MethodPost, "/api/admin/resources/teams", map[string]any{"name": "Forbidden Team"}, session.Token)
+	if created.Code != http.StatusForbidden {
+		t.Fatalf("ordinary user should not create teams, got %d: %s", created.Code, created.Body)
+	}
+}

--- a/backend/internal/server/admin_api_key_usage.go
+++ b/backend/internal/server/admin_api_key_usage.go
@@ -25,13 +25,13 @@ func (s *Server) handleAdminAPIKeyUsageGet(w http.ResponseWriter, r *http.Reques
 		writeError(w, r, NewHTTPError(http.StatusNotFound, "not_found", "Not found"))
 		return
 	}
-	if !s.canManageAPIKey(user, keyID) {
-		writeError(w, r, NewHTTPError(http.StatusForbidden, "api_key_forbidden", "API key is not available for this user"))
-		return
-	}
 	key, err := s.findAPIKey(keyID)
 	if err != nil {
 		writeError(w, r, err)
+		return
+	}
+	if !s.canAccessAPIKey(user, key) {
+		writeError(w, r, NewHTTPError(http.StatusForbidden, "api_key_forbidden", "API key is not available for this user"))
 		return
 	}
 	project, ok := s.store.GetProject(key.ProjectID)

--- a/backend/internal/server/admin_authorization.go
+++ b/backend/internal/server/admin_authorization.go
@@ -654,12 +654,16 @@ func (s *Server) canManageAPIKey(user AdminUser, keyID string) bool {
 	if isPlatformAdminRole(role) {
 		return true
 	}
-	for _, key := range s.store.ListAPIKeys() {
-		if key.ID == keyID {
-			return s.canAccessAPIKey(user, key)
-		}
+	key, ok := s.store.GetAPIKey(keyID)
+	if !ok {
+		return false
 	}
-	return false
+	project, ok := s.store.GetProject(key.ProjectID)
+	projects := map[string]Project{}
+	if ok {
+		projects[project.ID] = project
+	}
+	return canManageAPIKeyWithProjects(user, key, projects, s.store.ListResources("project-members"), s.activeTeamIDSet())
 }
 
 func (s *Server) findAPIKey(keyID string) (APIKey, error) {
@@ -731,6 +735,17 @@ func canAccessAPIKeyWithProjects(user AdminUser, key APIKey, projects map[string
 		return true
 	}
 	if strings.TrimSpace(key.OwnerUserID) == "" && key.Metadata != nil && key.Metadata["created_by"] == user.ID {
+		return true
+	}
+	project, ok := projects[key.ProjectID]
+	if !ok {
+		return false
+	}
+	return projectAccessRoleRank(projectAccessRole(user, project, memberships, activeTeams)) >= projectAccessRoleRank("maintainer")
+}
+
+func canManageAPIKeyWithProjects(user AdminUser, key APIKey, projects map[string]Project, memberships []AdminResource, activeTeams map[string]bool) bool {
+	if key.Metadata != nil && strings.TrimSpace(key.Metadata["created_by"]) == user.ID {
 		return true
 	}
 	project, ok := projects[key.ProjectID]
@@ -871,6 +886,15 @@ func (s *Server) filterResourcesForUser(user AdminUser, kind string, resources [
 		out := make([]AdminResource, 0, len(resources))
 		for _, item := range resources {
 			if item.Status == StatusActive && strings.TrimSpace(stringField(item.Fields, "user_id")) == user.ID {
+				out = append(out, item)
+			}
+		}
+		return out
+	}
+	if role == "user" && kind == "teams" {
+		out := make([]AdminResource, 0, len(resources))
+		for _, item := range resources {
+			if item.Status == StatusActive && userHasTeam(user, item.ID) {
 				out = append(out, item)
 			}
 		}
@@ -1315,7 +1339,10 @@ func adminResourcePermission(path string) string {
 		strings.Contains(path, "/approval-flows") || strings.Contains(path, "/reports") {
 		return "usage"
 	}
-	if strings.Contains(path, "/teams") || strings.Contains(path, "/role-configs") {
+	if strings.Contains(path, "/teams") {
+		return "project"
+	}
+	if strings.Contains(path, "/role-configs") {
 		return "identity"
 	}
 	if strings.Contains(path, "/monitors") || strings.Contains(path, "/proxies") || strings.Contains(path, "/settings") {

--- a/backend/internal/server/admin_identity_api_key_method_routing_contract_test.go
+++ b/backend/internal/server/admin_identity_api_key_method_routing_contract_test.go
@@ -560,7 +560,12 @@ func newAdminIdentityAPIKeyMethodRoutingServer(t *testing.T) (*GormStore, *Serve
 	ordinary, ordinaryToken := createAdminIdentityAPIKeyMethodSession(t, store, AdminUser{Username: "ordinary-method-user", Email: "ordinary-method-user@tokenhub.local", Role: "user", Status: StatusActive})
 	_, teamLeaderToken := createAdminIdentityAPIKeyMethodSession(t, store, AdminUser{Username: "leader-method-user", Email: "leader-method-user@tokenhub.local", Role: "team_leader", TeamID: "team_platform", Status: StatusActive})
 	_, securityToken := createAdminIdentityAPIKeyMethodSession(t, store, AdminUser{Username: "security-method-user", Email: "security-method-user@tokenhub.local", Role: "security_admin", Status: StatusActive})
-	key, _, err := store.CreateAPIKey(defaultProjectID, APIKey{Name: "Owned Method Routing Key", OwnerUserID: ordinary.ID, Status: StatusActive}, "thk_owned_method_routing")
+	key, _, err := store.CreateAPIKey(defaultProjectID, APIKey{
+		Name:        "Owned Method Routing Key",
+		OwnerUserID: ordinary.ID,
+		Status:      StatusActive,
+		Metadata:    map[string]string{"created_by": ordinary.ID},
+	}, "thk_owned_method_routing")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/server/admin_request_logs.go
+++ b/backend/internal/server/admin_request_logs.go
@@ -79,11 +79,12 @@ func (s *Server) requestLogQueryForUser(user AdminUser, r *http.Request) (Reques
 	}
 	apiKeyID := strings.TrimSpace(r.URL.Query().Get("api_key_id"))
 	if apiKeyID != "" {
-		if !s.canManageAPIKey(user, apiKeyID) {
-			return RequestLogQuery{}, NewHTTPError(http.StatusForbidden, "api_key_forbidden", "API key is not available for this user")
-		}
-		if _, err := s.findAPIKey(apiKeyID); err != nil {
+		key, err := s.findAPIKey(apiKeyID)
+		if err != nil {
 			return RequestLogQuery{}, err
+		}
+		if !s.canAccessAPIKey(user, key) {
+			return RequestLogQuery{}, NewHTTPError(http.StatusForbidden, "api_key_forbidden", "API key is not available for this user")
 		}
 		query.Global = false
 		query.ProjectIDs = nil

--- a/backend/internal/server/admin_resources_method_routing_contract_test.go
+++ b/backend/internal/server/admin_resources_method_routing_contract_test.go
@@ -44,6 +44,11 @@ func TestAdminResourceMethodRoutesPreserveAuthorizationOrder(t *testing.T) {
 		})
 		t.Run(route.name+"/ordinary_user", func(t *testing.T) {
 			response := methodRoutingRequest(app, route.wrongMethod, route.path, userSession.Token)
+			if route.name == "item" {
+				assertJSONError(t, response, http.StatusMethodNotAllowed, "method_not_allowed")
+				assertAllowHeader(t, response, route.allow)
+				return
+			}
 			assertJSONError(t, response, http.StatusForbidden, "admin_forbidden")
 			assertAllowHeader(t, response, "")
 		})

--- a/frontend/features/admin/core/data-loading.tsx
+++ b/frontend/features/admin/core/data-loading.tsx
@@ -174,9 +174,7 @@ export function loadPlanForView(user: AdminUser, view: ViewKey): LoadPlan {
       plan.overview = true;
       plan.keys = true;
       plan.users = can("users") || appRole(user.role) === "team_leader";
-      if (appRole(user.role) !== "user") {
-        addResourceDependency(plan, "teams");
-      }
+      addResourceDependency(plan, "teams");
       addResourceDependency(plan, "project-members");
       break;
     case "teams":

--- a/frontend/features/admin/core/types.tsx
+++ b/frontend/features/admin/core/types.tsx
@@ -1055,7 +1055,8 @@ export type ResourceConfig<T> = {
   create?: (ctx: ApiContext, values: Record<string, string>, data?: AppData) => Promise<void>;
   update?: (ctx: ApiContext, item: T, values: Record<string, string>) => Promise<void>;
   remove?: (ctx: ApiContext, item: T) => Promise<void>;
-  canRemove?: (item: T, currentUser: AdminUser | null) => boolean;
+  canUpdate?: (item: T, currentUser: AdminUser | null, data: AppData) => boolean;
+  canRemove?: (item: T, currentUser: AdminUser | null, data: AppData) => boolean;
   actions?: ResourceAction<T>[];
   toolbarActions?: ToolbarAction[];
   toForm?: (item: T) => Record<string, string>;
@@ -1064,7 +1065,7 @@ export type ResourceConfig<T> = {
 export type ResourceAction<T> = {
   label: string;
   title?: string;
-  visible?: (item: T) => boolean;
+  visible?: (item: T, currentUser: AdminUser | null, data: AppData) => boolean;
   href?: (item: T) => string;
   navigate?: (item: T) => ViewKey;
   run?: (ctx: ApiContext, item: T) => Promise<void>;

--- a/frontend/features/admin/domain/api-key-management-authz.test.mjs
+++ b/frontend/features/admin/domain/api-key-management-authz.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { importTypeScript } from "./typescript-test-loader.mjs";
+
+const { apiKeyCanManage } = await importTypeScript(new URL("./api-key-management-authz.ts", import.meta.url));
+
+const baseData = {
+  projects: [{ id: "prj_authz", name: "Authz Project", status: "active" }],
+  resources: {
+    "project-members": [
+      {
+        id: "member_viewer",
+        status: "active",
+        fields: { project_id: "prj_authz", user_id: "usr_viewer", role: "viewer" },
+      },
+      {
+        id: "member_maintainer",
+        status: "active",
+        fields: { project_id: "prj_authz", user_id: "usr_maintainer", role: "maintainer" },
+      },
+    ],
+  },
+};
+
+const adminIssuedKey = {
+  id: "key_admin_issued",
+  project_id: "prj_authz",
+  owner_user_id: "usr_viewer",
+  metadata: { created_by: "usr_admin" },
+};
+
+test("API key management actions stay hidden from assigned non-creators", () => {
+  assert.equal(apiKeyCanManage(baseData, adminIssuedKey, { id: "usr_viewer", role: "user" }), false);
+});
+
+test("API key management actions remain visible to creators and privileged project users", () => {
+  assert.equal(apiKeyCanManage(baseData, { ...adminIssuedKey, metadata: { created_by: "usr_creator" } }, { id: "usr_creator", role: "user" }), true);
+  assert.equal(apiKeyCanManage(baseData, adminIssuedKey, { id: "usr_maintainer", role: "user" }), true);
+  assert.equal(apiKeyCanManage(baseData, adminIssuedKey, { id: "usr_admin", role: "admin" }), true);
+});
+
+test("legacy assigned API keys fail closed for ordinary users", () => {
+  assert.equal(apiKeyCanManage(baseData, { ...adminIssuedKey, metadata: undefined }, { id: "usr_viewer", role: "user" }), false);
+});
+
+test("team-based API key management ignores disabled teams", () => {
+  const teamKey = { ...adminIssuedKey, project_id: "prj_team" };
+  const teamData = {
+    projects: [{
+      id: "prj_team",
+      name: "Team Project",
+      status: "active",
+      teams: [
+        { project_id: "prj_team", team_id: "team_active", role: "maintainer" },
+        { project_id: "prj_team", team_id: "team_disabled", role: "maintainer" },
+      ],
+    }],
+    resources: {
+      teams: [
+        { id: "team_active", status: "active" },
+        { id: "team_disabled", status: "disabled" },
+      ],
+    },
+  };
+  assert.equal(apiKeyCanManage(teamData, teamKey, { id: "usr_active_team", role: "user", team_ids: ["team_active"] }), true);
+  assert.equal(apiKeyCanManage(teamData, teamKey, { id: "usr_disabled_team", role: "user", team_ids: ["team_disabled"] }), false);
+  assert.equal(apiKeyCanManage({ ...teamData, resources: {} }, teamKey, { id: "usr_unloaded_team", role: "user", team_ids: ["team_active"] }), false);
+});

--- a/frontend/features/admin/domain/api-key-management-authz.ts
+++ b/frontend/features/admin/domain/api-key-management-authz.ts
@@ -1,0 +1,72 @@
+import { type AdminUser, type APIKey, type AppData, type Project } from "../core/types";
+
+export function apiKeyCanManage(data: AppData, key: APIKey, currentUser?: AdminUser | null) {
+  if (!currentUser) return false;
+  const role = adminAppRole(currentUser.role);
+  if (role === "admin") return true;
+  if (key.metadata?.created_by?.trim() === currentUser.id) return true;
+  const project = data.projects.find((item) => item.id === key.project_id);
+  if (!project) return false;
+  if (project.owner_user_id && project.owner_user_id === currentUser.id) return true;
+  if (projectRoleRank(projectTeamRoleForUser(project, currentUser, activeTeamIDs(data))) >= projectRoleRank("maintainer")) return true;
+  return projectManageMembership(data, project.id, currentUser.id);
+}
+
+function adminAppRole(role: string) {
+  const normalized = String(role || "").trim().toLowerCase();
+  if (normalized === "admin" || normalized === "system_admin") return "admin";
+  if (normalized === "team_leader" || normalized === "teamlead" || normalized === "project_admin") return "team_leader";
+  return "user";
+}
+
+function userTeamIDs(user: AdminUser) {
+  return Array.from(new Set([user.team_id, ...(user.team_ids ?? [])].filter((teamID): teamID is string => Boolean(teamID))));
+}
+
+function projectTeamRoleForUser(project: Project, user: AdminUser, activeTeams: Set<string>) {
+  const memberships = new Set(userTeamIDs(user));
+  let result = "";
+  for (const link of project.teams ?? []) {
+    if (!activeTeams.has(link.team_id)) continue;
+    if (!memberships.has(link.team_id)) continue;
+    let role = link.role;
+    if (role === "team_leader") {
+      if (adminAppRole(user.role) !== "team_leader") continue;
+      role = "maintainer";
+    }
+    if (projectRoleRank(role) > projectRoleRank(result)) result = role;
+  }
+  return result;
+}
+
+function projectRoleRank(role: string) {
+  if (role === "owner") return 4;
+  if (role === "maintainer") return 3;
+  if (role === "developer") return 2;
+  if (role === "viewer") return 1;
+  return 0;
+}
+
+function projectManageMembership(data: AppData, projectID: string, userID: string) {
+  return (data.resources["project-members"] ?? []).some((member) => {
+    if (member.status !== "active") return false;
+    if (stringifyValue(member.fields?.project_id) !== projectID || stringifyValue(member.fields?.user_id) !== userID) return false;
+    const role = stringifyValue(member.fields?.role).trim().toLowerCase();
+    return role === "owner" || role === "maintainer";
+  });
+}
+
+function activeTeamIDs(data: AppData) {
+  return new Set(
+    (data.resources.teams ?? [])
+      .filter((team) => team.status === "" || team.status === "active")
+      .map((team) => team.id),
+  );
+}
+
+function stringifyValue(value: unknown) {
+  if (value == null) return "";
+  if (Array.isArray(value)) return value.join(", ");
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}

--- a/frontend/features/admin/resources/project-key-config.tsx
+++ b/frontend/features/admin/resources/project-key-config.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, Download } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { type AdminResource, type APIKey, type AppData, type FieldConfig, type Project, type ResourceAction, type ResourceConfig } from "../core/types";
+import { apiKeyCanManage } from "../domain/api-key-management-authz";
 import { apiKeyOwnerSelectOptions, apiKeyOwnerUserID, costCenterLabel, costCenterSelectOptions, ownerUserLabel, projectMemberCanIssueLabel, projectMemberProjectSelectOptions, projectMemberRoleLabel, projectMemberRoleOptions, projectName, projectOwnerLabel, projectSelectOptions, projectTeamLabel, stringifyForm, stringifyValue, teamLabel, teamSelectOptions, truthyValue, userSelectOptions } from "../domain/entities";
 import { apiGatewayBaseURL } from "../domain/formatting";
 import { tx } from "../i18n/runtime";
@@ -212,6 +213,8 @@ export function apiKeyConfig(): ResourceConfig<APIKey> {
     create: async () => undefined,
     update: (ctx, item, values) => adminMutate(ctx, `/api/admin/api-keys/${item.id}`, "PATCH", keyPatchPayload(values)),
     remove: (ctx, item) => adminDelete(ctx, `/api/admin/api-keys/${item.id}`),
+    canUpdate: (item, currentUser, data) => apiKeyCanManage(data, item, currentUser),
+    canRemove: (item, currentUser, data) => apiKeyCanManage(data, item, currentUser),
     actions: [
       {
         label: "用量",
@@ -221,6 +224,7 @@ export function apiKeyConfig(): ResourceConfig<APIKey> {
       {
         label: "轮换",
         title: "生成新 Key，并立即吊销旧 Key",
+        visible: (item, currentUser, data) => apiKeyCanManage(data, item, currentUser),
         run: async (ctx, item) => {
           const resp = await adminFetch(ctx, `/api/admin/api-keys/${item.id}/rotate`, {
             method: "POST",

--- a/frontend/features/admin/views/crud-projects.tsx
+++ b/frontend/features/admin/views/crud-projects.tsx
@@ -418,7 +418,7 @@ export function ProviderChannelTable({
                 <td>
                   <div className="row-actions provider-channel-actions">
                     {(config.actions ?? [])
-                      .filter((action) => action.visible?.(row.provider) ?? true)
+                      .filter((action) => action.visible?.(row.provider, currentUser, data) ?? true)
                       .map((action) => (
                         <button
                           className="text-button"
@@ -430,12 +430,12 @@ export function ProviderChannelTable({
                           {tx(action.label)}
                         </button>
                       ))}
-                    {config.update ? (
+                    {config.update && (config.canUpdate?.(row.provider, currentUser, data) ?? true) ? (
                       <button className="text-button" onClick={() => onEdit(row.provider)} type="button">
                         {tx("编辑")}
                       </button>
                     ) : null}
-                    {config.remove && (config.canRemove?.(row.provider, currentUser) ?? true) ? (
+                    {config.remove && (config.canRemove?.(row.provider, currentUser, data) ?? true) ? (
                       <button className="danger-button" onClick={() => onDelete(row.provider)} title={tx("删除")} type="button">
                         <Trash2 size={15} />
                       </button>

--- a/frontend/features/admin/views/settings-table.tsx
+++ b/frontend/features/admin/views/settings-table.tsx
@@ -298,59 +298,66 @@ export function EntityTable<T>({
           </tr>
         </thead>
         <tbody>
-          {items.map((item) => (
-            <tr
-              className={`${onRowClick ? "clickable-row" : ""} ${selectedRowID === rowID(item) ? "selected-row" : ""}`}
-              key={rowID(item)}
-              onClick={onRowClick ? () => onRowClick(item) : undefined}
-            >
-              {config.columns.map((column) => (
-                <td key={column.key}>
-                  {config.view === "api-keys" && column.key === "status" ? (
-                    <APIKeyStatusSwitch
-                      item={item as APIKey}
-                      onToggle={(nextStatus) => onAction(apiKeyStatusAction(nextStatus) as unknown as ResourceAction<T>, item)}
-                    />
-                  ) : column.render ? (
-                    translatedCell(column.render(item, data))
-                  ) : (
-                    displayCellValue(readPath(item, column.key))
-                  )}
-                </td>
-              ))}
-              <td>
-                <div className="row-actions" onClick={(event) => event.stopPropagation()}>
-                  {config.view === "api-keys" && apiBaseURL ? <APIKeyDownloadMenu baseURL={apiBaseURL} data={data} item={item as APIKey} /> : null}
-                  {onRowClick && rowOpenLabel ? (
-                    <button className="text-button" onClick={() => onRowClick(item)} type="button">
-                      {tx(rowOpenLabel)}
-                    </button>
-                  ) : null}
-                  {(config.actions ?? [])
-                    .filter((action) => action.visible?.(item) ?? true)
-                    .map((action) => action.href ? (
-                      <Link className="text-button row-action-link" href={action.href(item)} key={action.label} title={tx(action.title ?? action.label)}>
-                        {tx(action.label)}
-                      </Link>
+          {items.map((item) => {
+            const canUpdate = config.canUpdate?.(item, currentUser, data) ?? true;
+            return (
+              <tr
+                className={`${onRowClick ? "clickable-row" : ""} ${selectedRowID === rowID(item) ? "selected-row" : ""}`}
+                key={rowID(item)}
+                onClick={onRowClick ? () => onRowClick(item) : undefined}
+              >
+                {config.columns.map((column) => (
+                  <td key={column.key}>
+                    {config.view === "api-keys" && column.key === "status" ? (
+                      canUpdate ? (
+                        <APIKeyStatusSwitch
+                          item={item as APIKey}
+                          onToggle={(nextStatus) => onAction(apiKeyStatusAction(nextStatus) as unknown as ResourceAction<T>, item)}
+                        />
+                      ) : (
+                        <StatusPill status={(item as APIKey).status} />
+                      )
+                    ) : column.render ? (
+                      translatedCell(column.render(item, data))
                     ) : (
-                      <button className="text-button" key={action.label} onClick={() => onAction(action, item)} title={tx(action.title ?? action.label)} type="button">
-                        {tx(action.label)}
+                      displayCellValue(readPath(item, column.key))
+                    )}
+                  </td>
+                ))}
+                <td>
+                  <div className="row-actions" onClick={(event) => event.stopPropagation()}>
+                    {config.view === "api-keys" && apiBaseURL ? <APIKeyDownloadMenu baseURL={apiBaseURL} data={data} item={item as APIKey} /> : null}
+                    {onRowClick && rowOpenLabel ? (
+                      <button className="text-button" onClick={() => onRowClick(item)} type="button">
+                        {tx(rowOpenLabel)}
                       </button>
-                    ))}
-                  {config.update ? (
-                    <button className="text-button" onClick={() => onEdit(item)} type="button">
-                      {tx("编辑")}
-                    </button>
-                  ) : null}
-                  {config.remove && (config.canRemove?.(item, currentUser) ?? true) ? (
-                    <button className="danger-button" onClick={() => onDelete(item)} type="button" title={tx("删除")}>
-                      <Trash2 size={15} />
-                    </button>
-                  ) : null}
-                </div>
-              </td>
-            </tr>
-          ))}
+                    ) : null}
+                    {(config.actions ?? [])
+                      .filter((action) => action.visible?.(item, currentUser, data) ?? true)
+                      .map((action) => action.href ? (
+                        <Link className="text-button row-action-link" href={action.href(item)} key={action.label} title={tx(action.title ?? action.label)}>
+                          {tx(action.label)}
+                        </Link>
+                      ) : (
+                        <button className="text-button" key={action.label} onClick={() => onAction(action, item)} title={tx(action.title ?? action.label)} type="button">
+                          {tx(action.label)}
+                        </button>
+                      ))}
+                    {config.update && canUpdate ? (
+                      <button className="text-button" onClick={() => onEdit(item)} type="button">
+                        {tx("编辑")}
+                      </button>
+                    ) : null}
+                    {config.remove && (config.canRemove?.(item, currentUser, data) ?? true) ? (
+                      <button className="danger-button" onClick={() => onDelete(item)} type="button" title={tx("删除")}>
+                        <Trash2 size={15} />
+                      </button>
+                    ) : null}
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary

Prevent non-privileged users from editing, rotating, or deleting API keys that were assigned to them but created by someone else. This separates API key visibility from management authorization so assigned users can still view their keys, inspect usage, and filter request logs, while backend mutation endpoints remain authoritative.

## Related Issue

Closes #275

## Changes

- Split API key management authorization from API key visibility in the backend.
- Preserve assigned-key read access for key listing, usage detail, and request-log filtering.
- Allow management only for platform administrators, authorized project maintainers, and the original key creator recorded in `metadata.created_by`.
- Fail closed for legacy assigned keys without reliable creator metadata when a non-privileged user attempts mutation.
- Let ordinary users read only their own active team resources so the admin console can evaluate project-team management rights without exposing unrelated teams.
- Hide edit, delete, rotate, and writable status controls in the admin console when the current user lacks management rights.
- Add backend and frontend regression coverage for assigned viewers, creators, maintainers, legacy keys, and disabled-team authorization.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- [x] `go test ./...` from `backend/`
- [x] `go vet ./...` from `backend/`
- [x] `npm run lint` from `frontend/`
- [x] `npm test` from `frontend/`
- [x] `npm run typecheck` from `frontend/`
- [x] `npm run test:domain` from `frontend/`
- [x] `go test ./internal/server -run 'TestAssignedAPIKeyOwnerCannotManageAdminIssuedKey|TestOrdinaryUsersCanReadOnlyOwnActiveTeamsForAPIKeyConsoleAuthz|TestAdminResourceMethodRoutes'` from `backend/`
- [x] `node --test tools/*.test.mjs`
- [x] `node tools/check-doc-translations.mjs` (local run reported no diff endpoints available, so co-change comparison was skipped)
- [x] `node tools/check-ui-translations.mjs`
- [x] `node tools/check-env-contract.mjs`
- [x] `node tools/check-source-lines.mjs`
- [x] `git diff --check`
- [x] `git diff --cached --check`

## Compatibility, Security, and Operations

Security fix. No API schema, environment variable, deployment, or model catalog changes are included. Assigned API keys remain visible and usable by their assigned users, but non-privileged mutations now require reliable creator attribution; legacy assigned keys without `metadata.created_by` fail closed for non-privileged mutations. Rollback restores the previous looser authorization behavior.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
