### PR TITLE
test(metrics): wait for observation after image job completion

### DIFF
--- a/backend/internal/server/metrics_test.go
+++ b/backend/internal/server/metrics_test.go
@@ -805,13 +805,17 @@ func TestMetricsImageJobAttributesAttempts(t *testing.T) {
 		t.Fatalf("missing image job id: %s", create.Body)
 	}
 	deadline := time.Now().Add(5 * time.Second)
+	// Completion commits before the gateway observation runs, so a completed
+	// status alone does not guarantee the counters are published yet. The
+	// overhead series is the last one ObserveGatewayCall writes; wait for it.
 	for {
 		job, ok := store.GetImageJob(jobID)
-		if ok && job.Status == imageJobStatusCompleted {
-			break
-		}
 		if ok && job.Status == imageJobStatusFailed {
 			t.Fatalf("image job failed: %+v", job)
+		}
+		if ok && job.Status == imageJobStatusCompleted &&
+			testutil.CollectAndCount(server.metrics.overhead) > 0 {
+			break
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("image job did not complete")


### PR DESCRIPTION
## Summary

Fixes an intermittent flake in `TestMetricsImageJobAttributesAttempts` observed in CI.

`CompleteImageJob` commits the `completed` status to the store before `observeGatewayCall` publishes the request counters. The test polled only the job status and asserted the metrics immediately, so under CI load it could observe `completed` while the counters were still zero and fail with `expected the image request to be counted once, got 0`. The wait loop now also waits for the `overhead` series, the last one `ObserveGatewayCall` writes, so the assertions run after publication.

## Related Issue

N/A (observed in CI on the implicit-TLS SMTP PR #271; split out to keep that PR scoped to notification channels)

## Changes

- `TestMetricsImageJobAttributesAttempts` now breaks the polling loop only when the job is `completed` **and** the `overhead` metrics series is published
- Failed jobs still fail fast

## Type of Change

- [ ] Bug fix
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./internal/server/ -run TestMetricsImageJobAttributesAttempts -count=10` — passes
- `go test ./internal/server/ -race -run TestMetricsImageJobAttributesAttempts -count=8` — passes
- `go vet ./internal/server/` — clean
- `git diff --check` — clean

## Compatibility, Security, and Operations

None.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.