### PR TITLE
fix(db): raise sqlite billing migration budget

### DIFF
--- a/backend/internal/dbschema/migrations_manifest.json
+++ b/backend/internal/dbschema/migrations_manifest.json
@@ -12,7 +12,7 @@
       "dialect": "sqlite",
       "checksum": "tokenhub-schema-granular-billing-sqlite-v1",
       "lock_timeout_seconds": 30,
-      "statement_budget": 50
+      "statement_budget": 60
     },
     {
       "version": 3,

--- a/backend/internal/server/store_schema_handle.go
+++ b/backend/internal/server/store_schema_handle.go
@@ -93,6 +93,10 @@ func SchemaMigrationRegistry() []dbschema.Migration {
 			Dialect:          dbschema.DialectSQLite,
 			Go:               addGranularBillingColumnsSQLite,
 			ChecksumOverride: "tokenhub-schema-granular-billing-sqlite-v1",
+			// Every missing column requires a PRAGMA probe and an ALTER TABLE.
+			// The full migration currently covers 26 columns (52 operations), so
+			// retain a small margin above that worst-case budget.
+			StatementBudget: 60,
 		},
 		{
 			Version: 3,

--- a/backend/internal/server/store_schema_ledger_test.go
+++ b/backend/internal/server/store_schema_ledger_test.go
@@ -45,3 +45,19 @@ func TestSchemaLedgerBaselineAdoptedAndVerified(t *testing.T) {
 		t.Fatalf("expected checksum_mismatch refusal, got %v", err)
 	}
 }
+
+func TestSQLiteGranularBillingMigrationBudgetCoversColumnProbes(t *testing.T) {
+	const granularBillingColumns = 26
+	const minimumOperations = granularBillingColumns * 2 // PRAGMA probe plus ALTER TABLE per column.
+
+	for _, migration := range SchemaMigrationRegistry() {
+		if migration.Name != "add-granular-billing-columns-sqlite" {
+			continue
+		}
+		if migration.StatementBudget < minimumOperations {
+			t.Fatalf("sqlite granular billing migration statement budget = %d, want at least %d", migration.StatementBudget, minimumOperations)
+		}
+		return
+	}
+	t.Fatal("sqlite granular billing migration was not registered")
+}


### PR DESCRIPTION
## Summary

Fixes SQLite upgrades that fail before applying the granular billing schema migration because the migration budget did not include its column probes.

## Related Issue

N/A

## Changes

- Set the SQLite granular billing migration budget to 60 operations.
- Regenerate the embedded migration manifest.
- Add a regression test that requires the migration budget to cover all probes and column additions.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Compatibility, Security, and Operations

Existing SQLite databases can now apply the version 2 granular billing expansion during startup. No API, configuration, security, or rollback contract changes are introduced.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
