### PR TITLE
fix(gateway): honor max_completion_tokens in adapters

### DIFF
--- a/backend/internal/server/api_key_rate_limit.go
+++ b/backend/internal/server/api_key_rate_limit.go
@@ -51,14 +51,7 @@ func estimateChatMessagesTokens(messages []ChatMessage) int64 {
 }
 
 func chatMaximumOutputTokens(request ChatCompletionRequest) int64 {
-	maximum := int64(request.MaxTokens)
-	if raw := request.raw["max_completion_tokens"]; len(raw) > 0 {
-		var compatibleMaximum int64
-		if json.Unmarshal(raw, &compatibleMaximum) == nil && compatibleMaximum > maximum {
-			maximum = compatibleMaximum
-		}
-	}
-	return maximum
+	return request.requestedMaxTokens()
 }
 
 func anthropicTokenReservation(request anthropicMessagesRequest) int64 {

--- a/backend/internal/server/api_key_rate_limit_test.go
+++ b/backend/internal/server/api_key_rate_limit_test.go
@@ -845,6 +845,13 @@ func TestTokenReservationUsesExplicitMaximumOrSafeDefault(t *testing.T) {
 	if got := requestTokenReservation(compatible); got != 23 {
 		t.Fatalf("compatible maximum reservation = %d, want 23", got)
 	}
+	var overlapping ChatCompletionRequest
+	if err := json.Unmarshal([]byte(`{"max_tokens":17,"max_completion_tokens":23}`), &overlapping); err != nil {
+		t.Fatal(err)
+	}
+	if got := chatMaximumOutputTokens(overlapping); got != 23 {
+		t.Fatalf("overlapping maximum = %d, want 23", got)
+	}
 }
 
 func TestMeteredTokensDoesNotDoubleCountUsageDetails(t *testing.T) {

--- a/backend/internal/server/openapi/gateway.openapi.yaml
+++ b/backend/internal/server/openapi/gateway.openapi.yaml
@@ -1351,6 +1351,8 @@ components:
           type: number
         max_tokens:
           type: integer
+        max_completion_tokens:
+          type: integer
         top_p:
           type: number
         presence_penalty:

--- a/backend/internal/server/provider_anthropic_convert.go
+++ b/backend/internal/server/provider_anthropic_convert.go
@@ -20,7 +20,7 @@ func buildAnthropicRequest(providerModel string, req ChatCompletionRequest, reas
 		return nil, err
 	}
 
-	maxTokens := req.MaxTokens
+	maxTokens := req.requestedMaxTokens()
 	if maxTokens <= 0 {
 		// Anthropic requires an explicit positive max_tokens; 0 carries special
 		// prompt-cache semantics and must not be used as a default.

--- a/backend/internal/server/provider_anthropic_convert_test.go
+++ b/backend/internal/server/provider_anthropic_convert_test.go
@@ -16,6 +16,21 @@ func mustBuildAnthropic(t *testing.T, req ChatCompletionRequest) map[string]any 
 	return payload
 }
 
+func TestAnthropicRequestUsesCompatibleMaxCompletionTokens(t *testing.T) {
+	var req ChatCompletionRequest
+	if err := json.Unmarshal([]byte(`{
+		"messages":[{"role":"user","content":"hi"}],
+		"max_completion_tokens":4096
+	}`), &req); err != nil {
+		t.Fatal(err)
+	}
+
+	payload := mustBuildAnthropic(t, req)
+	if payload["max_tokens"] != int64(4096) {
+		t.Fatalf("max_completion_tokens must map to Anthropic max_tokens, got %v", payload["max_tokens"])
+	}
+}
+
 func TestAnthropicRequestMapsToolDefinitions(t *testing.T) {
 	payload := mustBuildAnthropic(t, ChatCompletionRequest{
 		Messages: []ChatMessage{{Role: "user", Content: "weather?"}},

--- a/backend/internal/server/provider_gemini_convert.go
+++ b/backend/internal/server/provider_gemini_convert.go
@@ -32,8 +32,8 @@ func buildGeminiRequest(providerModel string, req ChatCompletionRequest) (map[st
 	}
 
 	generationConfig := map[string]any{}
-	if req.MaxTokens > 0 {
-		generationConfig["maxOutputTokens"] = req.MaxTokens
+	if maxTokens := req.requestedMaxTokens(); maxTokens > 0 {
+		generationConfig["maxOutputTokens"] = maxTokens
 	}
 	if req.Temperature != nil {
 		generationConfig["temperature"] = *req.Temperature

--- a/backend/internal/server/provider_gemini_convert_test.go
+++ b/backend/internal/server/provider_gemini_convert_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -12,6 +13,22 @@ func mustBuildGemini(t *testing.T, req ChatCompletionRequest) map[string]any {
 		t.Fatalf("buildGeminiRequest: %v", err)
 	}
 	return payload
+}
+
+func TestGeminiRequestUsesCompatibleMaxCompletionTokens(t *testing.T) {
+	var req ChatCompletionRequest
+	if err := json.Unmarshal([]byte(`{
+		"messages":[{"role":"user","content":"hi"}],
+		"max_completion_tokens":4096
+	}`), &req); err != nil {
+		t.Fatal(err)
+	}
+
+	payload := mustBuildGemini(t, req)
+	config, _ := payload["generationConfig"].(map[string]any)
+	if config["maxOutputTokens"] != int64(4096) {
+		t.Fatalf("max_completion_tokens must map to Gemini maxOutputTokens, got %v", config["maxOutputTokens"])
+	}
 }
 
 func TestGeminiRequestUsesSystemInstruction(t *testing.T) {

--- a/backend/internal/server/types.go
+++ b/backend/internal/server/types.go
@@ -1025,6 +1025,17 @@ func (r ChatCompletionRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(raw)
 }
 
+func (r ChatCompletionRequest) requestedMaxTokens() int64 {
+	maximum := int64(r.MaxTokens)
+	if raw := r.raw["max_completion_tokens"]; len(raw) > 0 {
+		var compatibleMaximum int64
+		if json.Unmarshal(raw, &compatibleMaximum) == nil && compatibleMaximum > maximum {
+			maximum = compatibleMaximum
+		}
+	}
+	return maximum
+}
+
 type PlaygroundChatResponse struct {
 	Response  any                      `json:"response"`
 	Route     PlaygroundRouteSummary   `json:"route"`

--- a/docs/ja/user-guide.md
+++ b/docs/ja/user-guide.md
@@ -101,6 +101,7 @@ curl --request POST \
 | `model` | はい | `GET /v1/models` の ID |
 | `messages` | はい | `system`、`user`、`assistant` のメッセージ配列 |
 | `max_tokens` | いいえ | 最大生成 tokens |
+| `max_completion_tokens` | いいえ | OpenAI 互換の最大生成 tokens。両方の出力トークン上限フィールドがある場合、TokenHub は大きい値を使用します |
 | `temperature` | いいえ | サンプリング温度 |
 | `reasoning_effort` | いいえ | 対応するモデルとルートで使用する推論強度 |
 | `stream` | いいえ | `true` の場合 SSE stream |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -101,6 +101,7 @@ Common request fields:
 | `model` | Yes | Must be available in `GET /v1/models` |
 | `messages` | Yes | `system`, `user`, and `assistant` message list |
 | `max_tokens` | No | Maximum generated tokens |
+| `max_completion_tokens` | No | OpenAI-compatible maximum generated tokens; when both token-limit fields are present, TokenHub uses the larger value |
 | `temperature` | No | Sampling temperature |
 | `reasoning_effort` | No | Reasoning effort for models and routes that support it |
 | `stream` | No | `true` returns Server-Sent Events |

--- a/docs/zh-CN/user-guide.md
+++ b/docs/zh-CN/user-guide.md
@@ -101,6 +101,7 @@ curl --request POST \
 | `model` | 是 | 必须来自 `GET /v1/models` |
 | `messages` | 是 | `system`、`user`、`assistant` 消息数组 |
 | `max_tokens` | 否 | 最大生成 tokens |
+| `max_completion_tokens` | 否 | OpenAI 兼容的最大生成 tokens；两个输出 Token 上限字段同时存在时，TokenHub 使用较大值 |
 | `temperature` | 否 | 采样温度 |
 | `reasoning_effort` | 否 | 支持该参数的模型和路由所使用的推理强度 |
 | `stream` | 否 | `true` 时返回 SSE 流 |

--- a/frontend/features/admin/views/gateway-llm-en.tsx
+++ b/frontend/features/admin/views/gateway-llm-en.tsx
@@ -302,6 +302,7 @@ export function gatewayEnglishLLMUsageDocs(stats: GatewayDocStats, role: AppRole
                 ["model", "string", "Yes", `A model ID from /v1/models, for example ${stats.sampleModel}.`],
                 ["messages", "array", "Yes", "Conversation messages with system, user, or assistant roles."],
                 ["max_tokens", "integer", "No", "Maximum generated tokens."],
+                ["max_completion_tokens", "integer", "No", "OpenAI-compatible maximum generated tokens; if both token-limit fields are present, TokenHub uses the larger value."],
                 ["temperature", "number", "No", "Sampling temperature."],
                 ["reasoning_effort", "string", "No", "Reasoning effort; omitted when the selected route cannot represent it."],
                 ["stream", "boolean", "No", "When true, returns Server-Sent Events ending with data: [DONE]."],

--- a/frontend/features/admin/views/gateway-llm-ja.tsx
+++ b/frontend/features/admin/views/gateway-llm-ja.tsx
@@ -175,6 +175,7 @@ export function gatewayJapaneseLLMUsageDocs(stats: GatewayDocStats, role: AppRol
                 ["model", "string", "はい", `/v1/models のモデル ID。例: ${stats.sampleModel}`],
                 ["messages", "array", "はい", "system、user、assistant のメッセージ配列。"],
                 ["max_tokens", "integer", "いいえ", "最大生成 tokens。"],
+                ["max_completion_tokens", "integer", "いいえ", "OpenAI 互換の最大生成 tokens。両方の出力トークン上限フィールドがある場合、TokenHub は大きい値を使用します。"],
                 ["temperature", "number", "いいえ", "サンプリング温度。"],
                 ["reasoning_effort", "string", "いいえ", "推論強度。選択されたルートが対応しない場合は省略します。"],
                 ["stream", "boolean", "いいえ", "true の場合は SSE で返し、data: [DONE] で終了します。"],

--- a/frontend/features/admin/views/gateway-llm-zh.tsx
+++ b/frontend/features/admin/views/gateway-llm-zh.tsx
@@ -175,6 +175,7 @@ export function gatewayChineseLLMUsageDocs(stats: GatewayDocStats, role: AppRole
                 ["model", "string", "是", `来自 /v1/models 的模型 ID，例如 ${stats.sampleModel}。`],
                 ["messages", "array", "是", "由 system、user、assistant 组成的消息数组。"],
                 ["max_tokens", "integer", "否", "最大生成 token 数。"],
+                ["max_completion_tokens", "integer", "否", "OpenAI 兼容的最大生成 token 数；两个输出 Token 上限字段同时存在时，TokenHub 使用较大值。"],
                 ["temperature", "number", "否", "采样温度。"],
                 ["reasoning_effort", "string", "否", "推理强度；当前路由不支持时省略。"],
                 ["stream", "boolean", "否", "true 时返回 SSE 流，结束标记为 data: [DONE]。"],


### PR DESCRIPTION
## Summary

Fixes the OpenAI-compatible `max_completion_tokens` field being ignored by protocol-converting chat adapters. Before this change, Anthropic requests fell back to 1024 output tokens and Gemini requests omitted `maxOutputTokens` when clients sent only `max_completion_tokens`.

## Related Issue

Closes #289

## Changes

- Add a shared `ChatCompletionRequest.requestedMaxTokens()` helper that takes the larger value from `max_tokens` and `max_completion_tokens`.
- Use the shared output-token ceiling in Anthropic and Gemini request conversion.
- Keep rate-limit token reservation on the same shared helper.
- Add regression coverage for Anthropic, Gemini, and overlapping token-limit fields.
- Document `max_completion_tokens` in the English, Simplified Chinese, and Japanese user guides.
- Add `max_completion_tokens` to the admin LLM API reference rows and OpenAPI Chat Completions schema.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [x] Documentation
- [ ] Deployment or configuration

## Verification

- [x] `go test ./internal/server -run 'Test(OpenAPI|AnthropicRequestUsesCompatibleMaxCompletionTokens|GeminiRequestUsesCompatibleMaxCompletionTokens|TokenReservationUsesExplicitMaximumOrSafeDefault)'`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `npm ci` (completed; npm reported existing audit vulnerabilities)
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run build`
- [x] `git diff --check`
- [x] `node --test tools/*.test.mjs`
- [x] `node tools/check-doc-translations.mjs`
- [x] `node tools/check-doc-translations.mjs --base origin/main --head HEAD`
- [x] `node tools/check-ui-translations.mjs`
- [x] `node tools/check-env-contract.mjs`
- [x] `node tools/check-source-lines.mjs`

## Compatibility, Security, and Operations

No security, data, environment, deployment, or operational changes. This preserves `max_tokens` compatibility while honoring the current OpenAI-compatible `max_completion_tokens` field for Anthropic and Gemini routes, and documents the supported compatibility contract.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
