### PR TITLE
fix: refresh plugin architecture and restore backend CI

### DIFF
--- a/backend/cmd/marketplace-validate/main.go
+++ b/backend/cmd/marketplace-validate/main.go
@@ -34,7 +34,7 @@ func run(args []string, stdout io.Writer) error {
 		if err != nil {
 			return fmt.Errorf("%s: %w", path, err)
 		}
-		fmt.Fprintf(stdout, "%s: valid marketplace index (%d plugins)\n", path, len(index.Plugins))
+		_, _ = fmt.Fprintf(stdout, "%s: valid marketplace index (%d plugins)\n", path, len(index.Plugins))
 	}
 	return nil
 }
@@ -63,7 +63,7 @@ func runOffline(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(stdout, "%s: verified signed marketplace index (%d plugins, %d artifacts)\n", options.indexPath, result.Plugins, result.ArtifactsVerified)
+	_, _ = fmt.Fprintf(stdout, "%s: verified signed marketplace index (%d plugins, %d artifacts)\n", options.indexPath, result.Plugins, result.ArtifactsVerified)
 	return nil
 }
 

--- a/backend/internal/plugin/install.go
+++ b/backend/internal/plugin/install.go
@@ -53,7 +53,7 @@ func (r Runtime) InstallZipArchive(archive []byte, options InstallOptions) (Pack
 	if err != nil {
 		return Package{}, err
 	}
-	defer os.RemoveAll(staging)
+	defer func() { _ = os.RemoveAll(staging) }()
 	reader, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
 	if err != nil {
 		return Package{}, err

--- a/backend/internal/plugin/install_preview.go
+++ b/backend/internal/plugin/install_preview.go
@@ -18,7 +18,7 @@ func InspectInstallZipArchive(archive []byte) (Manifest, error) {
 	if err != nil {
 		return Manifest{}, err
 	}
-	defer os.RemoveAll(staging)
+	defer func() { _ = os.RemoveAll(staging) }()
 	reader, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
 	if err != nil {
 		return Manifest{}, err

--- a/backend/internal/plugin/stdio_command.go
+++ b/backend/internal/plugin/stdio_command.go
@@ -46,7 +46,7 @@ func runCommandJSON(ctx context.Context, options CommandSandboxOptions, input an
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() { _ = os.RemoveAll(tempDir) }()
 	options.TempDir = tempDir
 	policy, err := BuildCommandSandboxPolicy(options)
 	if err != nil {

--- a/backend/internal/server/admin_codex_image_capability.go
+++ b/backend/internal/server/admin_codex_image_capability.go
@@ -268,16 +268,8 @@ func (s *Server) codexImageResource(resourceID string, requireActive bool, profi
 	return resource, provider, nil
 }
 
-func (s *Server) updateCodexImageCapability(resourceID string, capability string) (ProviderResource, error) {
-	return s.updateProviderImageCapability(resourceID, capability, codexImageCapabilityRouteProfile())
-}
-
 func codexImageRouteMatches(route ModelRoute, providerID string) bool {
 	return providerImageCapabilityRouteMatches(route, providerID, codexImageCapabilityRouteProfile())
-}
-
-func codexImageRouteHasSupportedResource(route ModelRoute, resources []ProviderResource) bool {
-	return providerImageCapabilityRouteHasSupportedResource(route, resources, codexImageCapabilityRouteProfile())
 }
 
 func providerImageCapabilityRouteHasSupportedResource(route ModelRoute, resources []ProviderResource, profile providerImageCapabilityRouteProfile) bool {
@@ -314,18 +306,6 @@ func activeProviderImageCapabilityRoute(routes []ModelRoute, providerID string, 
 		}
 	}
 	return nil
-}
-
-func (s *Server) ensureCodexImageRoute(providerID string) (ModelRoute, error) {
-	return s.ensureProviderImageCapabilityRoute(providerID, codexImageCapabilityRouteProfile())
-}
-
-func (s *Server) setCodexImageRoutesStatus(providerID string, status string) error {
-	return s.setProviderImageCapabilityRoutesStatus(providerID, codexImageCapabilityRouteProfile(), status)
-}
-
-func defaultCodexImageRoute(providerID string) ModelRoute {
-	return defaultProviderImageCapabilityRoute(providerID, codexImageCapabilityRouteProfile())
 }
 
 func codexImageCapabilityRouteProfile() providerImageCapabilityRouteProfile {
@@ -429,10 +409,6 @@ func backfillProviderImageCapabilityRoutesForProfile(store Store, profile provid
 	}
 }
 
-func codexImageRouteBackfillDone(resources []ProviderResource, providerID string) bool {
-	return providerImageCapabilityRouteBackfillDone(resources, providerID, codexImageCapabilityRouteProfile())
-}
-
 func providerImageCapabilityRouteBackfillDone(resources []ProviderResource, providerID string, profile providerImageCapabilityRouteProfile) bool {
 	profile.withDefaults()
 	for _, resource := range resources {
@@ -441,10 +417,6 @@ func providerImageCapabilityRouteBackfillDone(resources []ProviderResource, prov
 		}
 	}
 	return false
-}
-
-func providerHasSupportedCodexImageResource(resources []ProviderResource, providerID string) bool {
-	return providerHasSupportedImageCapabilityResource(resources, providerID, codexImageCapabilityRouteProfile())
 }
 
 func providerHasSupportedImageCapabilityResource(resources []ProviderResource, providerID string, profile providerImageCapabilityRouteProfile) bool {

--- a/backend/internal/server/admin_plugin_actions_test.go
+++ b/backend/internal/server/admin_plugin_actions_test.go
@@ -1145,11 +1145,7 @@ func TestAdminPluginBackgroundJobRunExecutesThroughRunner(t *testing.T) {
 		t.Fatalf("register background job: %v", err)
 	}
 
-	reqBody, err := json.Marshal(map[string]any{"resource_id": "rsrc_1"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	reqBody, err = json.Marshal(map[string]any{
+	reqBody, err := json.Marshal(map[string]any{
 		"resource_id":   "rsrc_1",
 		"refresh_token": "request-refresh-secret",
 	})

--- a/backend/internal/server/admin_plugins_http.go
+++ b/backend/internal/server/admin_plugins_http.go
@@ -439,7 +439,7 @@ func (s *Server) readAdminPluginInstallRequest(w http.ResponseWriter, r *http.Re
 		return adminPluginInstallPayload{}, nil, NewHTTPError(http.StatusBadRequest, "invalid_plugin_upload", "Plugin package upload is invalid")
 	}
 	if r.MultipartForm != nil {
-		defer r.MultipartForm.RemoveAll()
+		defer func() { _ = r.MultipartForm.RemoveAll() }()
 	}
 	file, err := firstAdminPluginUploadFile(r, "package", "plugin_package", "file")
 	if err != nil {

--- a/backend/internal/server/admin_provider_plugin_actions.go
+++ b/backend/internal/server/admin_provider_plugin_actions.go
@@ -25,10 +25,6 @@ func (s *Server) executeProviderProbeAction(ctx context.Context, user AdminUser,
 	return result.Data, true, nil
 }
 
-func (s *Server) executeProviderResourceModelsAction(ctx context.Context, user AdminUser, resourceID string) (ProviderCatalogEntry, bool, error) {
-	return s.executeProviderResourceModelsActionForCatalog(ctx, user, "", resourceID)
-}
-
 func (s *Server) executeProviderResourceModelsActionForCatalog(ctx context.Context, user AdminUser, catalogProviderType string, resourceID string) (ProviderCatalogEntry, bool, error) {
 	resource, ok := s.providerResourceByID(resourceID)
 	if !ok {

--- a/backend/internal/server/claude_code_attribution.go
+++ b/backend/internal/server/claude_code_attribution.go
@@ -44,10 +44,6 @@ func anthropicRequestForRoute(req anthropicMessagesRequest, route RouteSelection
 	return req
 }
 
-func defaultClaudeCodeAttributionPolicyForDescriptor(descriptor AdapterDescriptor) string {
-	return defaultSystemPromptTransformPolicyForDescriptor(descriptor)
-}
-
 func defaultSystemPromptTransformPolicyForDescriptor(descriptor AdapterDescriptor) string {
 	if policy := normalizeSystemPromptTransformPolicyOrEmpty(descriptor.ProviderPolicy.SystemPromptTransformDefault); policy != "" {
 		return policy
@@ -68,10 +64,6 @@ func normalizeSystemPromptTransformPolicyOrEmpty(value string) string {
 		return policy
 	}
 	return ""
-}
-
-func applyClaudeCodeAttributionPolicy(options map[string]string, requested *string) (map[string]string, error) {
-	return applySystemPromptTransformPolicy(options, nil, requested)
 }
 
 func applySystemPromptTransformPolicy(options map[string]string, requested *string, legacyRequested *string) (map[string]string, error) {
@@ -95,10 +87,6 @@ func applySystemPromptTransformPolicy(options map[string]string, requested *stri
 	return next, nil
 }
 
-func validateClaudeCodeAttributionOptions(options map[string]string) error {
-	return validateSystemPromptTransformOptions(options)
-}
-
 func validateSystemPromptTransformOptions(options map[string]string) error {
 	if value, exists := options[systemPromptTransformPolicyOption]; exists {
 		policy, err := normalizeSystemPromptTransformPolicy(value)
@@ -118,10 +106,6 @@ func validateSystemPromptTransformOptions(options map[string]string) error {
 		delete(options, claudeCodeAttributionPolicyOption)
 	}
 	return nil
-}
-
-func normalizeClaudeCodeAttributionPolicy(value string) (string, error) {
-	return normalizeSystemPromptTransformPolicy(value)
 }
 
 func normalizeSystemPromptTransformPolicy(value string) (string, error) {

--- a/backend/internal/server/codex_compat_route.go
+++ b/backend/internal/server/codex_compat_route.go
@@ -172,10 +172,6 @@ func (s *Server) compatibleChatRoutes(routed RoutedCall, req ChatCompletionReque
 	return compatible, nil
 }
 
-func compatibleChatRoutes(routed RoutedCall, req ChatCompletionRequest) (RoutedCall, error) {
-	return (&Server{}).compatibleChatRoutes(routed, req)
-}
-
 func (s *Server) anthropicGatewayAffinity(
 	apiKeyID string,
 	model string,

--- a/backend/internal/server/gateway_http.go
+++ b/backend/internal/server/gateway_http.go
@@ -431,32 +431,6 @@ func (s *Server) handleResponses(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func (s *Server) startRoutedCall(w http.ResponseWriter, r *http.Request, project Project, key APIKey, model string, stream bool, requestPayload any) (RoutedCall, bool) {
-	return s.startRoutedCallWithAudit(w, r, project, key, model, stream, requestPayload, requestPayload)
-}
-
-func (s *Server) startRoutedCallWithAudit(w http.ResponseWriter, r *http.Request, project Project, key APIKey, model string, stream bool, requestPayload any, auditPayload any) (RoutedCall, bool) {
-	admittedAt := time.Now().UTC()
-	call, err := s.admitRoutedCall(w, r, project, key, model, stream, requestTokenReservation(requestPayload))
-	if err != nil {
-		requestID := s.finishRejectedCall(r, admittedAt, project, key, model, stream, err, auditPayload)
-		w.Header().Set("x-request-id", requestID)
-		writeError(w, r, err)
-		return RoutedCall{}, false
-	}
-	if err := s.runGatewayAuthContextHooks(r.Context(), &call, r.Header); err != nil {
-		s.finishFailedRoutedCall(r, RoutedCall{Call: call}, nil, Usage{}, err, auditPayload)
-		writeError(w, r, err)
-		return RoutedCall{}, false
-	}
-	if err := s.runGatewayAdmissionHooks(r.Context(), call, r.Header, requestPayload, requestTokenReservation(requestPayload)); err != nil {
-		s.finishFailedRoutedCall(r, RoutedCall{Call: call}, nil, Usage{}, err, auditPayload)
-		writeError(w, r, err)
-		return RoutedCall{}, false
-	}
-	return s.prepareAdmittedRoutedCallWithAudit(w, r, call, model, auditPayload)
-}
-
 func (s *Server) admitRoutedCall(w http.ResponseWriter, r *http.Request, project Project, key APIKey, model string, stream bool, tokenReservation int64) (CallContext, error) {
 	call, err := s.store.StartCall(r.Context(), project, key, model, tokenReservation)
 	call.Stream = stream
@@ -1104,15 +1078,6 @@ func cacheDomainScoreFromHash(raw uint64, weight int) float64 {
 		unit = 0.99999999999999988
 	}
 	return float64(weight) / -math.Log(unit)
-}
-
-func routesContainAdapterType(routes []RouteSelection, adapterType string) bool {
-	for _, route := range routes {
-		if route.Provider.Type == adapterType {
-			return true
-		}
-	}
-	return false
 }
 
 func sortRouteGroupByStrategy(strategy string, routes []RouteSelection) {

--- a/backend/internal/server/instance_heartbeat_test.go
+++ b/backend/internal/server/instance_heartbeat_test.go
@@ -52,7 +52,7 @@ func TestInstanceHeartbeatStopsWhenStoreCloses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer maintenanceStore.Close()
+	defer func() { _ = maintenanceStore.Close() }()
 	heartbeats, err := maintenanceStore.ListInstanceHeartbeats(context.Background())
 	if err != nil {
 		t.Fatalf("list heartbeats after store close: %v", err)

--- a/backend/internal/server/multi_instance_e2e_test.go
+++ b/backend/internal/server/multi_instance_e2e_test.go
@@ -372,6 +372,7 @@ func (a *multiInstanceBlockingResponseAdapter) Responses(ctx context.Context, pr
 
 func testSharedResponseJobExecution(t *testing.T, storeA *GormStore, storeB *GormStore, config Config) {
 	t.Helper()
+	config.ResponseWorkerStartupEnabled = true
 	config.ResponseWorkerConcurrency = 1
 	config.ResponsePollIntervalMillis = 20
 	config.ResponseJobTimeoutSeconds = 5
@@ -1154,7 +1155,9 @@ func testSharedOAuthAndRefresh(t *testing.T, storeA *GormStore, storeB *GormStor
 
 	tokenRequests.Store(0)
 	suffix := NewID("oauth")
-	provider := storeA.AddProvider(Provider{ID: "prv_" + suffix, Name: "OAuth Provider", Type: ProviderOpenAI, Status: StatusActive, Healthy: true})
+	provider := storeA.AddProvider(Provider{ID: "prv_" + suffix, Name: "OAuth Provider", Type: ProviderOpenAICodex, Status: StatusActive, Healthy: true,
+		Options: map[string]string{providerCredentialRefreshProfileOption: openAIAccountOAuthRefreshProfile},
+	})
 	resource, err := storeA.AddProviderResource(ProviderResource{
 		ID:           "rsrc_" + suffix,
 		ProviderID:   provider.ID,

--- a/backend/internal/server/provider_account_codex_models.go
+++ b/backend/internal/server/provider_account_codex_models.go
@@ -308,10 +308,6 @@ func (s *Server) queryOpenAICodexModels(ctx context.Context, resourceID string) 
 	return s.queryProviderResourceModels(ctx, resourceID)
 }
 
-func (s *Server) persistCodexResourceModels(resourceID string, models []ProviderCatalogModel, fetchedAt time.Time) error {
-	return s.persistProviderResourceModels(resourceID, models, fetchedAt)
-}
-
 func codexResourceCachedModels(resource *ProviderResource) ([]string, time.Time, bool) {
 	return providerResourceCachedModels(resource)
 }
@@ -337,33 +333,4 @@ func providerResourceModelOptionLegacyKeys(key string) []string {
 
 func (s *Server) filterCodexRoutesByModel(_ context.Context, modelName string, routes []RouteSelection) ([]RouteSelection, error) {
 	return s.filterProviderAccountRoutesByModel(modelName, routes)
-}
-
-func (s *Server) removeCodexResourceModel(resourceID string, modelName string) {
-	s.removeProviderResourceModel(resourceID, modelName)
-}
-
-func codexProviderCatalogFromModels(models []ProviderCatalogModel) ProviderCatalogEntry {
-	candidates := append([]ProviderCatalogModel(nil), models...)
-	for index := range candidates {
-		candidates[index].Category = "codex"
-	}
-	entry := customProviderCatalogFromModelsWithType(candidates, "codex", ProviderOpenAICodex)
-	entry.ID = codexProviderCatalogID
-	entry.Name = "OpenAI Codex"
-	entry.DisplayName = "OpenAI Codex"
-	entry.Type = ProviderOpenAICodex
-	entry.BaseURL = openAICodexBaseURL
-	entry.DocURL = "https://developers.openai.com/codex"
-	entry.Source = "openai-codex-live"
-	return entry
-}
-
-func (s *Server) codexProviderCatalogMetadata() ProviderCatalogEntry {
-	if s != nil {
-		if entry, ok := s.pluginProviderCatalogCapabilityEntryForType(ProviderOpenAICodex); ok {
-			return entry
-		}
-	}
-	return codexProviderCatalogFromModels(nil)
 }

--- a/backend/internal/server/provider_account_quota.go
+++ b/backend/internal/server/provider_account_quota.go
@@ -52,10 +52,6 @@ type OpenAIAccountQuota struct {
 	FetchedAt             int64                               `json:"fetched_at"`
 }
 
-func (s *Server) queryOpenAIAccountQuota(ctx context.Context, resourceID string) (OpenAIAccountQuota, error) {
-	return s.queryOpenAIAccountQuotaCached(ctx, resourceID, false)
-}
-
 func (s *Server) queryOpenAIAccountQuotaCached(ctx context.Context, resourceID string, force bool) (OpenAIAccountQuota, error) {
 	resource, ok := s.providerResourceByID(resourceID)
 	if !ok {

--- a/backend/internal/server/provider_catalog.go
+++ b/backend/internal/server/provider_catalog.go
@@ -218,10 +218,6 @@ func (s *providerCatalogService) reloadLocked(previous []ProviderCatalogEntry) (
 	return cloneCatalogEntries(entries, false), nil
 }
 
-func prepareProviderCatalogRefresh(entries []ProviderCatalogEntry, previous []ProviderCatalogEntry) ([]ProviderCatalogEntry, error) {
-	return prepareProviderCatalogRefreshWithDefault(entries, previous, defaultProviderCatalogProviderType())
-}
-
 func prepareProviderCatalogRefreshWithDefault(entries []ProviderCatalogEntry, previous []ProviderCatalogEntry, defaultType string) ([]ProviderCatalogEntry, error) {
 	if err := validateProviderCatalogRefresh(entries, previous); err != nil {
 		return nil, err
@@ -298,18 +294,6 @@ func loadLocalProviderCatalogWithPolicy(catalogFile string, catalogTypes map[str
 		return nil, fmt.Errorf("parse provider catalog %s: %w", catalogFile, err)
 	}
 	return entries, nil
-}
-
-func parseProviderCatalog(content []byte, source string) ([]ProviderCatalogEntry, error) {
-	return parseProviderCatalogWithTypes(content, source, nil)
-}
-
-func parseProviderCatalogWithTypes(content []byte, source string, catalogTypes map[string]string) ([]ProviderCatalogEntry, error) {
-	return parseProviderCatalogWithDefault(content, source, catalogTypes, defaultProviderCatalogProviderType())
-}
-
-func parseProviderCatalogWithDefault(content []byte, source string, catalogTypes map[string]string, defaultType string) ([]ProviderCatalogEntry, error) {
-	return parseProviderCatalogWithPolicy(content, source, catalogTypes, defaultType, nil)
 }
 
 func parseProviderCatalogWithPolicy(content []byte, source string, catalogTypes map[string]string, defaultType string, modelCategories []providerModelCategoryDefinition) ([]ProviderCatalogEntry, error) {
@@ -453,10 +437,6 @@ func normalizeProviderCatalogModelWithCategories(raw map[string]any, modelCatego
 	model.Capabilities = catalogModelCapabilities(raw, model)
 	model.SupportedParameters = catalogModelParameters(raw, model)
 	return model
-}
-
-func catalogModelCategory(raw map[string]any, id string, displayName string) string {
-	return catalogModelCategoryWithDefinitions(raw, id, displayName, nil)
 }
 
 func catalogModelCategoryWithDefinitions(raw map[string]any, id string, displayName string, modelCategories []providerModelCategoryDefinition) string {
@@ -757,10 +737,6 @@ func providerModelsUpstreamError(status int) *HTTPError {
 	default:
 		return NewHTTPError(statusForProvider(status), "provider_models_upstream_error", "Upstream model catalog request failed")
 	}
-}
-
-func customProviderModelsFromPayload(payload map[string]any) []ProviderCatalogModel {
-	return customProviderModelsFromPayloadWithDefinitions(payload, nil)
 }
 
 func customProviderModelsFromPayloadWithDefinitions(payload map[string]any, modelCategories []providerModelCategoryDefinition) []ProviderCatalogModel {

--- a/backend/internal/server/provider_credential_refresh_service_test.go
+++ b/backend/internal/server/provider_credential_refresh_service_test.go
@@ -215,7 +215,7 @@ func TestProviderQuotaRefreshBackgroundJobPersistsExternalPluginSnapshots(t *tes
 	providerType := "quota_background_plugin"
 	resourceType := "quota_background_account"
 	pluginID := "tokenhub.provider.quota-background"
-	store.ConfigureProviderResourceTypePolicy(map[string][]string{providerType: []string{resourceType}})
+	store.ConfigureProviderResourceTypePolicy(map[string][]string{providerType: {resourceType}})
 	provider := store.AddProvider(Provider{
 		Name:    "Quota Background Plugin",
 		Type:    providerType,
@@ -316,7 +316,7 @@ func TestProviderCredentialRefreshServiceUsesNativeRefreshProfilePolicy(t *testi
 	providerType := "profile_oauth_subscription"
 	resourceType := "profile_oauth_account"
 	refreshProfile := "profile_oauth"
-	store.ConfigureProviderResourceTypePolicy(map[string][]string{providerType: []string{resourceType}})
+	store.ConfigureProviderResourceTypePolicy(map[string][]string{providerType: {resourceType}})
 	store.ConfigureProviderCredentialRefreshHandlers([]providerResourceCredentialRefreshRegistration{{
 		ProviderType:        providerType,
 		Profile:             refreshProfile,
@@ -380,7 +380,7 @@ func TestProviderCredentialRefreshUsesRegisteredNativeHandler(t *testing.T) {
 	providerType := "native_handler_subscription"
 	resourceType := "native_handler_account"
 	refreshProfile := "native_handler_oauth"
-	store.ConfigureProviderResourceTypePolicy(map[string][]string{providerType: []string{resourceType}})
+	store.ConfigureProviderResourceTypePolicy(map[string][]string{providerType: {resourceType}})
 	store.ConfigureProviderCredentialRefreshHandlers([]providerResourceCredentialRefreshRegistration{{
 		ProviderType: "native_handler_subscription",
 		Profile:      refreshProfile,

--- a/backend/internal/server/provider_model_categories.go
+++ b/backend/internal/server/provider_model_categories.go
@@ -49,32 +49,6 @@ func providerModelCategoryDefinitionsFromPlugin(plugin pluginmeta.Descriptor) []
 	return definitions
 }
 
-func providerModelCategoryDefinitionsForKeys(keys []string) []providerModelCategoryDefinition {
-	definitionsByKey := map[string]providerModelCategoryDefinition{}
-	for _, definition := range fallbackProviderModelCategoryDefinitions() {
-		definition = normalizeProviderModelCategoryDefinition(definition)
-		definitionsByKey[definition.Key] = definition
-	}
-	result := make([]providerModelCategoryDefinition, 0, len(keys))
-	seen := map[string]struct{}{}
-	for _, key := range keys {
-		key = strings.ToLower(strings.TrimSpace(key))
-		if key == "" {
-			continue
-		}
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		if definition, ok := definitionsByKey[key]; ok {
-			result = append(result, definition)
-			continue
-		}
-		result = append(result, providerModelCategoryDefinition{Key: key, Label: key, Aliases: []string{key}})
-	}
-	return normalizeProviderModelCategoryDefinitions(result)
-}
-
 func standardModelCategorySet() map[string]bool {
 	categories := map[string]bool{}
 	for _, definition := range defaultProviderModelCategoryDefinitions() {
@@ -138,22 +112,6 @@ func lowerUniqueStrings(values []string) []string {
 		}
 	}
 	return catalogUniqueStrings(normalized)
-}
-
-func adapterModelCategoriesFromDefinitions(definitions []providerModelCategoryDefinition) []AdapterModelCategory {
-	definitions = normalizeProviderModelCategoryDefinitions(definitions)
-	categories := make([]AdapterModelCategory, 0, len(definitions))
-	for _, definition := range definitions {
-		categories = append(categories, AdapterModelCategory{
-			Key:               definition.Key,
-			Label:             definition.Label,
-			Order:             definition.Order,
-			Aliases:           append([]string(nil), definition.Aliases...),
-			FamilyPrefixes:    append([]string(nil), definition.FamilyPrefixes...),
-			CanonicalPrefixes: append([]string(nil), definition.CanonicalPrefixes...),
-		})
-	}
-	return categories
 }
 
 func providerModelCategoryDefinitionsFromAdapter(categories []AdapterModelCategory) []providerModelCategoryDefinition {

--- a/backend/internal/server/provider_plugin_catalog.go
+++ b/backend/internal/server/provider_plugin_catalog.go
@@ -331,12 +331,9 @@ func providerCatalogEntryFromPluginCapability(plugin pluginmeta.Descriptor, adap
 		if capability.Subject != "" && capability.Subject != adapter.Type {
 			continue
 		}
-		entry, ok := providerCatalogEntryFromPluginCatalogCapability(plugin, capability, adapter)
+		entry, _ := providerCatalogEntryFromPluginCatalogCapability(plugin, capability, adapter)
 		if entry.ID != "" && entry.Type != "" {
 			return entry, true
-		}
-		if !ok {
-			continue
 		}
 	}
 	return ProviderCatalogEntry{}, false
@@ -452,10 +449,6 @@ func (entry pluginProviderCatalogEntry) providerCatalogEntry(plugin pluginmeta.D
 		ETag:           strings.TrimSpace(entry.ETag),
 		Models:         models,
 	}
-}
-
-func (model pluginProviderCatalogModel) providerCatalogModel() (ProviderCatalogModel, bool) {
-	return model.providerCatalogModelWithCategories(nil)
 }
 
 func (model pluginProviderCatalogModel) providerCatalogModelWithCategories(modelCategories []providerModelCategoryDefinition) (ProviderCatalogModel, bool) {

--- a/backend/internal/server/provider_resource_credentials.go
+++ b/backend/internal/server/provider_resource_credentials.go
@@ -375,22 +375,6 @@ func openAIAccountAuthenticationPatch(creds *ProviderResourceCredentials) bool {
 		strings.TrimSpace(creds.ClientID) != ""
 }
 
-func openAIAccountImageBindingChanged(
-	before ProviderResource,
-	beforeCredentials ProviderResourceCredentials,
-	after ProviderResource,
-	afterCredentials ProviderResourceCredentials,
-) bool {
-	if before.ProviderID != after.ProviderID ||
-		before.ResourceType != after.ResourceType ||
-		strings.TrimSpace(before.BaseURL) != strings.TrimSpace(after.BaseURL) ||
-		strings.TrimSpace(before.Options["allowed_codex_hosts"]) != strings.TrimSpace(after.Options["allowed_codex_hosts"]) {
-		return true
-	}
-	return !openAIAccountAuthenticationEqual(beforeCredentials, afterCredentials) ||
-		strings.TrimSpace(beforeCredentials.AccountID) != strings.TrimSpace(afterCredentials.AccountID)
-}
-
 func openAIAccountAuthenticationEqual(left ProviderResourceCredentials, right ProviderResourceCredentials) bool {
 	return providerResourceAuthenticationEqual(left, right)
 }

--- a/backend/internal/server/provider_route_bridge.go
+++ b/backend/internal/server/provider_route_bridge.go
@@ -106,10 +106,6 @@ func (s *Server) anthropicRouteBridge(route RouteSelection) (providerRouteBridge
 	return providerRouteBridgeForRoute(s.adapterRegistry, route, anthropicRouteBridgeSupported)
 }
 
-func (s *Server) streamAnthropicRouteBridge(route RouteSelection) (providerRouteBridge, bool) {
-	return providerRouteBridgeForRoute(s.adapterRegistry, route, streamAnthropicRouteBridgeSupported)
-}
-
 func (s *Server) geminiRouteBridge(route RouteSelection) (providerRouteBridge, bool) {
 	return providerRouteBridgeForRoute(s.adapterRegistry, route, geminiRouteBridgeSupported)
 }

--- a/backend/internal/server/provider_session_affinity.go
+++ b/backend/internal/server/provider_session_affinity.go
@@ -145,10 +145,6 @@ func codexSessionIdentifier(headers http.Header, request ResponsesRequest) (stri
 	return compatibilitySessionIdentifier(headers, request)
 }
 
-func codexClientMetadataSessionID(request ResponsesRequest) string {
-	return compatibilityClientMetadataSessionID(request)
-}
-
 func compatibilityClientMetadataSessionID(request ResponsesRequest) string {
 	if request.raw == nil {
 		return ""

--- a/backend/internal/server/seed_postgres_integration_test.go
+++ b/backend/internal/server/seed_postgres_integration_test.go
@@ -72,7 +72,18 @@ func testPostgresV040BootstrapUpgrade(t *testing.T, adminStore *GormStore, confi
 	parsedURL.RawQuery = query.Encode()
 	config.DatabaseURL = parsedURL.String()
 	config.ModelCatalogFile = filepath.Join(t.TempDir(), "model-catalog.yaml")
-	if err := os.WriteFile(config.ModelCatalogFile, []byte("version: 1\nmodels:\n  - name: postgres-upgrade-test-model\n"), 0o600); err != nil {
+	if err := os.WriteFile(config.ModelCatalogFile, []byte(`version: 1
+models:
+  - name: postgres-upgrade-test-model
+    category: custom
+    modality: chat
+    family: test
+    context_window: 4096
+    capabilities: [chat]
+    supported_parameters: []
+    input_modalities: [text]
+    output_modalities: [text]
+`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/internal/server/session_affinity_key.go
+++ b/backend/internal/server/session_affinity_key.go
@@ -179,10 +179,6 @@ func providerResponsesSessionIdentifier(headers http.Header, request ResponsesRe
 	return "", sessionScopeNone
 }
 
-func codexRawStringField(request ResponsesRequest, key string) string {
-	return responsesRawStringField(request, key)
-}
-
 func responsesRawStringField(request ResponsesRequest, key string) string {
 	if request.raw == nil {
 		return ""

--- a/backend/internal/server/store_image_capability_models.go
+++ b/backend/internal/server/store_image_capability_models.go
@@ -5,10 +5,6 @@ import (
 	"time"
 )
 
-func (s *GormStore) codexImageAllowedByPolicyLocked(project Project, key APIKey, policy *ScopedRoutingPolicy) bool {
-	return s.providerImageCapabilityAllowedByPolicyLocked(project, key, policy, codexImageCapabilityRouteProfile())
-}
-
 func (s *GormStore) providerImageCapabilityAllowedByPolicyLocked(project Project, key APIKey, policy *ScopedRoutingPolicy, profile providerImageCapabilityRouteProfile) bool {
 	profile.withDefaults()
 	var routes []ModelRoute
@@ -55,10 +51,6 @@ func (s *GormStore) providerImageCapabilityAllowedByPolicyLocked(project Project
 		}
 	}
 	return false
-}
-
-func (s *GormStore) codexImageResourceAvailable(resource ProviderResource) bool {
-	return s.providerImageCapabilityResourceAvailable(resource, codexImageCapabilityRouteProfile())
 }
 
 func (s *GormStore) providerImageCapabilityResourceAvailable(resource ProviderResource, profile providerImageCapabilityRouteProfile) bool {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,8 @@ This document describes the architecture implemented in this repository for deve
 
 The Go backend hosts the Admin API, OpenAI-compatible model API, routing, provider adapters, audit, and persistence in one process. The Next.js application is the admin console. Control plane and data plane are logical boundaries: they share one backend and database by default, while multi-instance deployments share state through PostgreSQL.
 
+The backend is organized as Core plus built-in and external plugins. Core retains public API compatibility, authentication, authorization, routing admission, persistence, metering, and audit. Plugins contribute declared provider capabilities, gateway hooks, background jobs, and presentation metadata; the backend invokes external executable plugins as child processes.
+
 ```mermaid
 flowchart TB
     admin["Administrators and team leaders"]
@@ -21,7 +23,10 @@ flowchart TB
         modelApi["Model API\n/v1/*"]
         governance["Access and governance\nKeys, RBAC, quotas, concurrency, IP allowlists"]
         routing["Routing\ncandidates, strategy, weight, failover, affinity"]
-        adapters["Adapter registry\ngeneral providers and OpenAI Codex"]
+        adapters["Adapter registry"]
+        builtin["Built-in provider plugins"]
+        plugins["Plugin registry and runtime"]
+        hooks["Gateway hooks and brokers"]
         operations["Operations and observability\nusage, audit, alerts, health"]
         store["GORM Store"]
 
@@ -31,7 +36,19 @@ flowchart TB
         modelApi --> operations --> store
         adminApi --> operations
         routing --> store
+        adminApi --> plugins
+        plugins --> adapters
+        adapters --> builtin
+        plugins --> hooks
+        routing <--> hooks
     end
+
+    external["External plugin processes\nstdio-json-v1"]
+    packages["Plugin packages and lifecycle state"]
+    packages --> plugins
+    plugins --> external
+    hooks --> external
+    adapters --> external
 
     subgraph persistence["Persistence and configuration"]
         sqlite[("SQLite\ndefault single instance")]
@@ -50,11 +67,14 @@ flowchart TB
     admin --> ingress --> frontend
     frontend -->|"TOKENHUB_API_BASE_URL"| backend
     app --> ingress -->|"/v1/*"| backend
-    adapters --> compatible
-    adapters --> azure
-    adapters --> anthropic
-    adapters --> gemini
-    adapters --> codex
+    external --> upstream
+    backend --> adminApi
+    backend --> modelApi
+    builtin --> compatible
+    builtin --> azure
+    builtin --> anthropic
+    builtin --> gemini
+    builtin --> codex
     store --> sqlite
     store --> postgres
     catalog --> store
@@ -91,6 +111,24 @@ The default Compose file has no reverse proxy and exposes frontend and backend p
 
 The default image uses the model catalog bundled at build time so the executable and catalog share a version. A custom catalog is an explicit override through `./deploy/install.sh --model-catalog /absolute/path/to/model-catalog.yaml`; it is not a default Compose mount.
 
+## Plugin Runtime and Boundaries
+
+`backend/internal/server/plugin_bootstrap.go` assembles the plugin registry, gateway chain and runner, admin UI registry, action broker, background-job broker/runner, and adapter registry. It registers built-in contributions, loads packages from `TOKENHUB_PLUGIN_DIR`, and attaches enabled external Provider adapters. Built-in and external plugins share metadata and capability contracts, but built-ins execute inside the Go process and external commands execute through `stdio-json-v1`.
+
+| Surface | Implementation entry points | Responsibility and boundary |
+| --- | --- | --- |
+| Package contract and loading | `backend/internal/plugin/manifest.go`, `runtime.go`, `registry.go` | Validate manifest schema, Plugin API compatibility, permissions, and package state before registration |
+| Provider | `backend/internal/server/provider_plugin_adapter.go`, `adapter_registry.go` | Invoke declared operations using provider/resource/credential projections; Core retains routing and accounting |
+| Gateway chain | `backend/internal/plugin/gateway_chain.go`, `gateway_runner.go`; `backend/internal/server/gateway_plugin_hooks.go` | Run stage-specific hooks with permitted data, validate structured results, and enforce stage mutation rules |
+| Background jobs and actions | `backend/internal/plugin/background_scheduler.go`, `background_job.go`, `action_broker.go` | Schedule declared jobs and broker operator actions; these are separate from durable background Responses jobs |
+| Presentation | `backend/internal/plugin/admin_ui.go`, `sim.go` | Declarative panels, settings, themes, and layouts rendered by the console; no arbitrary plugin React or JavaScript execution |
+
+Packages declare `plugin.yaml` with manifest schema `1` and Plugin API `v1`. Permissions constrain which Core data is projected into an invocation and which structured changes Core accepts. This is not an operating-system sandbox: the command policy currently reports network and resource enforcement as `unsupported`. External commands use a restricted environment, package-relative executable paths, bounded input/output, and timeouts. The generic command defaults are 30 seconds, 4 MiB input, and 1 MiB output; individual runtime surfaces can apply their own timeout, including a 5-second default gateway-hook timeout. Streaming support must be checked per adapter; the external Provider bridge currently decodes an event array from a command result rather than forwarding a live child-process stream.
+
+All three Compose variants mount `tokenhub-plugins` at `/app/plugins` and expose `TOKENHUB_PLUGIN_DIR` and `TOKENHUB_PLUGIN_MARKETPLACE_URL`. Package files and lifecycle state live on the filesystem, while registries and runners are process-local. PostgreSQL does not distribute plugin binaries or refresh every replica's registry. `plugin_runtime_reload.go` serializes a reload through a cluster operation but rebuilds only the current server's runtime; deployments must coordinate package versions and reload/restart each replica. The package-update handler currently replaces package files without calling that reload path, so an update response alone does not establish that the new runtime is active.
+
+Installation and marketplace code provide checksum verification, signed-marketplace trust checks, permission review, failed-package quarantine, and rollback paths. These controls do not establish atomic fleet-wide activation or isolation from host resources. See the [Plugin Development Guide](plugin-development.md) for the detailed contract and lifecycle procedures.
+
 ## Components and Providers
 
 | Component | Location | Responsibility |
@@ -99,20 +137,25 @@ The default image uses the model catalog bundled at build time so the executable
 | HTTP server | `backend/internal/server/http.go` | APIs, authentication, routed calls, responses, and health endpoints |
 | Routing | `backend/internal/server/http.go` | Candidate ordering by priority, resource priority, strategy, weight, and affinity |
 | Adapter registry and integration service | `adapter_registry.go`, `integration_service.go` | Declares provider capabilities and runs provider/resource probes |
-| Provider adapters | `providers.go`, `provider_account_codex.go` | Protocol translation; Codex subscription OAuth, refresh, and session affinity |
+| Provider adapters | `builtin_provider_plugins.go`, `provider_plugin_adapter.go`, `provider_account_codex.go` | Protocol translation; Codex subscription OAuth, refresh, and session affinity |
 | Store | `store.go` | GORM access, quotas, credential encryption, SQLite backups, PostgreSQL leases, and cluster locks |
+
+The following are representative built-in registrations, not a closed list of supported providers. Effective capabilities come from the enabled plugin and adapter descriptors, provider policy, and model/resource support. External plugins may add provider types.
 
 | Provider type | Adapter and capabilities |
 | --- | --- |
-| `openai`, `openai_compatible`, `qwen`, `local` | OpenAI compatible: Chat, streaming Chat, Responses, Embeddings, and probes |
-| `deepseek` | OpenAI compatible; Chat, streaming Chat, Embeddings, and probes. Responses and streaming Responses are model-scoped and enabled for `deepseek-v4-flash` and `deepseek-v4-pro` |
+| `openai` | Chat, streaming Chat, Responses, streaming Responses, Embeddings, probes, and image generation |
+| `openai_compatible`, `deepseek`, `qwen`, `local` | OpenAI-compatible operations; model and provider policy can narrow Responses support |
+| `kronk` | Chat, streaming Chat, Responses, streaming Responses, Embeddings, model discovery, and probes |
 | `azure_openai` | Chat, streaming Chat, Embeddings, and probes |
 | `anthropic` | Chat, streaming Chat, and probes |
 | `gemini` | Chat, streaming Chat, Embeddings, and probes |
-| `openai_codex` | OpenAI Codex Subscription: Responses, streaming Responses, models, quota, OAuth, session affinity, and Compact |
-| `mock` | Built-in adapter for local verification and tests |
+| `openai_codex` | Responses, streaming Responses, models, probes, quota, OAuth, session affinity, Compact, and image generation |
+| `mock` | Local verification and tests |
 
 ## Model Request Flow
+
+This sequence summarizes the Core request flow. At the applicable stages, the gateway runner projects permitted data to registered hooks and validates their results before Core continues. Hook stages cover privacy/guardrail processing, context and cache operations, candidate selection/ranking, request/response transforms, usage, settlement, and trace export. A declared stage does not mean every endpoint or installed plugin implements that capability; endpoint support and stage rules still apply.
 
 `Model` is the external API contract, `ProviderModel` is a persisted upstream inventory item for one Provider, and `ModelRoute` maps between them. External models carry an explicit persisted directory role, so removing their last route leaves them as drafts instead of turning them back into candidate templates. Route creation and editing require the selected `ProviderModel` to exist in inventory. The narrow exception is the subscription-backed virtual model `codex-gpt-image-2`: its route must target an OpenAI Codex Provider and the fixed upstream model `gpt-image-2`, which is an execution capability rather than a chat-model inventory item. This allows a same-name 1:1 mapping or a custom alias without exposing provider-specific model names to callers. `POST /v1/chat/completions`, `POST /v1/responses`, `POST /v1/responses/compact`, and `POST /v1/embeddings` share the same authentication, quota, and routing entry point.
 
@@ -121,6 +164,7 @@ sequenceDiagram
     participant C as Application
     participant G as TokenHub /v1
     participant S as Store and database
+    participant H as Gateway hooks
     participant A as Provider adapter
     participant U as Upstream model service
 
@@ -133,6 +177,11 @@ sequenceDiagram
     G->>S: Query active and healthy Provider / Resource / Route
     G->>G: Resolve API Key, Project, or Global policy; filter candidates
     G->>G: Plan attempts from strategy, weights, and session affinity
+    opt At applicable request stages: permitted data projection
+        G->>H: At applicable request stages: permitted data projection
+        H-->>G: Validated structured result
+    end
+    Note over G,A: Invoke enabled built-in adapter or external Provider bridge
     loop Failover-capable candidate routes
         G->>A: Normalized request and route selection
         A->>U: Provider protocol request
@@ -143,7 +192,7 @@ sequenceDiagram
     G-->>C: Compatible response and x-request-id
 ```
 
-Inactive or unhealthy providers, resources, and routes are skipped, with one exception: a resource whose cooldown has lapsed is readmitted as a half-open candidate. The first request that reaches it claims the trial by pushing its cooldown deadline forward, so concurrent requests are still rejected and a failed trial has already armed the next, longer window. Only that trial's own success closes the breaker and restores the resource without admin action — a request that was already in flight when the breaker tripped cannot resurrect it. Repeated failures widen the window exponentially up to `TOKENHUB_RESOURCE_COOLDOWN_MAX_SECONDS`. A resource an administrator disabled is never readmitted. Non-streaming calls try candidates in order. A stream cannot safely switch upstream after output has started; streaming Responses require an adapter with the `response_stream` capability. `openai_codex` routes can derive a session affinity key from the request and API key, then persist a resource binding for continuity.
+Inactive or unhealthy providers, resources, and routes are skipped, with one exception: a resource whose cooldown has lapsed is readmitted as a half-open candidate. The first request that reaches it claims the trial by pushing its cooldown deadline forward, so concurrent requests are still rejected and a failed trial has already armed the next, longer window. Only that trial's own success closes the breaker and restores the resource without admin action — a request that was already in flight when the breaker tripped cannot resurrect it. Repeated failures widen the window exponentially up to `TOKENHUB_RESOURCE_COOLDOWN_MAX_SECONDS`. A resource an administrator disabled is never readmitted. Non-streaming calls try candidates in order. A stream cannot safely switch upstream after output has started; streaming Responses require an adapter with the `responses_stream` capability. `openai_codex` routes can derive a session affinity key from the request and API key, then persist a resource binding for continuity.
 
 For `POST /v1/responses` with `background: true`, the synchronous request flow stops after authentication and durable submission. Every replica polls the durable queue even when it was empty at startup. A worker claims the job, revalidates its original authorization, and commits the admitted phase, request ID, quota counters, token reservation, and concurrency lease in one database transaction before entering the same guardrail, routing, provider, metering, audit, and tracing flow. A lease epoch fences stale workers. PostgreSQL uses row locks with `SKIP LOCKED` across replicas; SQLite uses an atomic claim in the supported single-backend deployment. Pre-admission lease loss is replayable, while post-admission lease loss is terminal rather than risking a duplicate provider request; an undispatched token reservation is refunded during recovery.
 

--- a/docs/ja/architecture.md
+++ b/docs/ja/architecture.md
@@ -8,6 +8,8 @@ Language: [English](../architecture.md) | [简体中文](../zh-CN/architecture.m
 
 Go バックエンドの 1 プロセスで管理 API、OpenAI 互換モデル API、ルーティング、Provider アダプター、監査、永続化を提供します。Next.js は管理コンソールです。コントロールプレーンとデータプレーンは論理的な境界であり、既定構成では 1 つのバックエンドとデータベースを共有します。マルチインスタンス構成では PostgreSQL を介して状態を共有します。
 
+バックエンドは Core、内蔵プラグイン、外部プラグインで構成されます。Core は公開 API の互換性、認証・認可、ルーティングの准入制御、永続化、計量、監査を担当します。プラグインは宣言された Provider 能力、ゲートウェイフック、バックグラウンドジョブ、画面メタデータを提供し、外部実行プラグインはバックエンドから子プロセスとして呼び出されます。
+
 ```mermaid
 flowchart TB
     admin["管理者 / チームリーダー"]
@@ -21,7 +23,10 @@ flowchart TB
         modelApi["モデル API\n/v1/*"]
         governance["認証とガバナンス\nKey、RBAC、クォータ、並行数、IP 許可リスト"]
         routing["ルーティング\n候補、戦略、重み、フェイルオーバー、アフィニティ"]
-        adapters["アダプターレジストリ\n汎用 Provider / OpenAI Codex"]
+        adapters["アダプターレジストリ"]
+        builtin["内蔵 Provider プラグイン"]
+        plugins["プラグインレジストリとランタイム"]
+        hooks["ゲートウェイフックと Broker"]
         operations["運用と可観測性\n利用量、監査、アラート、ヘルスチェック"]
         store["GORM Store"]
 
@@ -31,7 +36,19 @@ flowchart TB
         modelApi --> operations --> store
         adminApi --> operations
         routing --> store
+        adminApi --> plugins
+        plugins --> adapters
+        adapters --> builtin
+        plugins --> hooks
+        routing <--> hooks
     end
+
+    external["外部プラグインプロセス\nstdio-json-v1"]
+    packages["プラグインパッケージとライフサイクル状態"]
+    packages --> plugins
+    plugins --> external
+    hooks --> external
+    adapters --> external
 
     subgraph persistence["永続化と設定"]
         sqlite[("SQLite\n既定の単一インスタンス")]
@@ -50,11 +67,14 @@ flowchart TB
     admin --> ingress --> frontend
     frontend -->|"TOKENHUB_API_BASE_URL"| backend
     app --> ingress -->|"/v1/*"| backend
-    adapters --> compatible
-    adapters --> azure
-    adapters --> anthropic
-    adapters --> gemini
-    adapters --> codex
+    external --> upstream
+    backend --> adminApi
+    backend --> modelApi
+    builtin --> compatible
+    builtin --> azure
+    builtin --> anthropic
+    builtin --> gemini
+    builtin --> codex
     store --> sqlite
     store --> postgres
     catalog --> store
@@ -91,6 +111,24 @@ flowchart LR
 
 既定イメージはビルド時に内蔵したモデルカタログを使用し、実行ファイルとカタログのバージョンを一致させます。カスタムカタログは `./deploy/install.sh --model-catalog /absolute/path/to/model-catalog.yaml` による明示的な上書きであり、既定の Compose マウントではありません。
 
+## プラグインランタイムと境界
+
+`backend/internal/server/plugin_bootstrap.go` は、プラグインレジストリ、ゲートウェイチェーンと実行器、管理 UI レジストリ、Action Broker、バックグラウンドジョブの Broker/Runner、アダプターレジストリを組み立てます。内蔵機能を登録し、`TOKENHUB_PLUGIN_DIR` からパッケージを読み込み、有効な外部 Provider アダプターを接続します。内蔵と外部のプラグインはメタデータと能力の契約を共有しますが、内蔵実装は Go プロセス内で、外部コマンドは `stdio-json-v1` 経由で実行されます。
+
+| 能力面 | 実装入口 | 責務と境界 |
+| --- | --- | --- |
+| パッケージ契約と読み込み | `backend/internal/plugin/manifest.go`、`runtime.go`、`registry.go` | 登録前に manifest schema、Plugin API 互換性、権限、パッケージ状態を検証 |
+| Provider | `backend/internal/server/provider_plugin_adapter.go`、`adapter_registry.go` | Provider・リソース・認証情報の投影を使って宣言された操作を呼び出す。ルーティングと計量は Core が担当 |
+| ゲートウェイチェーン | `backend/internal/plugin/gateway_chain.go`、`gateway_runner.go`、`backend/internal/server/gateway_plugin_hooks.go` | 各段階のフックに許可されたデータを渡し、構造化結果と変更範囲を検証 |
+| バックグラウンドジョブと管理操作 | `backend/internal/plugin/background_scheduler.go`、`background_job.go`、`action_broker.go` | 宣言されたジョブの実行と管理操作を仲介。永続化されたバックグラウンド Responses ジョブとは別の仕組み |
+| 画面 | `backend/internal/plugin/admin_ui.go`、`sim.go` | 宣言的なパネル、設定、テーマ、レイアウトをコンソールが描画。任意のプラグイン React や JavaScript は実行しない |
+
+パッケージは `plugin.yaml` で manifest schema `1` と Plugin API `v1` を宣言します。権限は呼び出しに投影できる Core データと、Core が受け入れる構造化変更を制限します。これは OS サンドボックスではありません。コマンドポリシーではネットワークとリソースの強制隔離は現在 `unsupported` です。外部コマンドには制限された環境変数、パッケージ相対の実行パス、入出力上限、タイムアウトを適用します。汎用コマンドの既定値は 30 秒、入力 4 MiB、出力 1 MiB で、各能力面には独自のタイムアウトがあります。例えばゲートウェイフックの既定値は 5 秒です。ストリーミング対応はアダプターごとに確認が必要です。現在の外部 Provider ブリッジはコマンド結果のイベント配列を解析し、子プロセスの出力をリアルタイムに中継するものではありません。
+
+3 種類の Compose はいずれも `tokenhub-plugins` を `/app/plugins` にマウントし、`TOKENHUB_PLUGIN_DIR` と `TOKENHUB_PLUGIN_MARKETPLACE_URL` を提供します。ファイルとライフサイクル状態はファイルシステムに保存され、レジストリと実行器はプロセスごとに保持されます。PostgreSQL はプラグインバイナリの配布や全レプリカのレジストリ更新を行いません。`plugin_runtime_reload.go` はクラスタ操作でリロードを直列化しますが、再構築するのは現在のサーバープロセスだけです。デプロイではパッケージのバージョンを揃え、各レプリカをリロードまたは再起動する必要があります。現在のパッケージ更新ハンドラーはファイルを置換した後にこのリロード経路を呼ばないため、更新レスポンスだけでは新しいランタイムの有効化を確認できません。
+
+インストールとマーケットプレイスのコードには、チェックサム検証、署名付きマーケットプレイスの信頼検証、権限レビュー、失敗したパッケージの隔離、ロールバック経路があります。これらは全レプリカの原子的な有効化やホストリソースの隔離を保証しません。詳細な契約とライフサイクル操作は[プラグイン開発ガイド](plugin-development.md)を参照してください。
+
 ## コンポーネントと Provider
 
 | コンポーネント | 場所 | 責務 |
@@ -99,20 +137,25 @@ flowchart LR
 | HTTP サーバー | `backend/internal/server/http.go` | API、認証、ルーティング呼び出し、レスポンス、ヘルスエンドポイント |
 | ルーティング | `backend/internal/server/http.go` | 優先度、リソース優先度、戦略、重み、アフィニティによる候補の順序付け |
 | アダプターレジストリと統合サービス | `adapter_registry.go`、`integration_service.go` | Provider 能力の宣言と Provider/リソースのプローブ |
-| Provider アダプター | `providers.go`、`provider_account_codex.go` | プロトコル変換、Codex Subscription の OAuth、更新、セッションアフィニティ |
+| Provider アダプター | `builtin_provider_plugins.go`、`provider_plugin_adapter.go`、`provider_account_codex.go` | プロトコル変換、Codex Subscription の OAuth、更新、セッションアフィニティ |
 | Store | `store.go` | GORM、クォータ、認証情報暗号化、SQLite バックアップ、PostgreSQL リース、クラスタロック |
+
+以下は代表的な内蔵登録であり、固定された全 Provider 一覧ではありません。実際の能力は有効なプラグインとアダプターの記述、Provider ポリシー、モデルとリソースの対応状況で決まります。外部プラグインは Provider 型を追加できます。
 
 | Provider 型 | アダプターと能力 |
 | --- | --- |
-| `openai`、`openai_compatible`、`qwen`、`local` | OpenAI 互換：Chat、ストリーミング Chat、Responses、Embeddings、プローブ |
-| `deepseek` | OpenAI 互換：Chat、ストリーミング Chat、Embeddings、プローブ。Responses とストリーミング Responses はモデル単位で宣言し、`deepseek-v4-flash` と `deepseek-v4-pro` で有効 |
+| `openai` | Chat、ストリーミング Chat、Responses、ストリーミング Responses、Embeddings、プローブ、画像生成 |
+| `openai_compatible`、`deepseek`、`qwen`、`local` | OpenAI 互換操作。モデルと Provider ポリシーによって Responses 対応を制限可能 |
+| `kronk` | Chat、ストリーミング Chat、Responses、ストリーミング Responses、Embeddings、モデル検出、プローブ |
 | `azure_openai` | Chat、ストリーミング Chat、Embeddings、プローブ |
 | `anthropic` | Chat、ストリーミング Chat、プローブ |
 | `gemini` | Chat、ストリーミング Chat、Embeddings、プローブ |
-| `openai_codex` | OpenAI Codex Subscription：Responses、ストリーミング Responses、モデル、クォータ、OAuth、セッションアフィニティ、Compact |
-| `mock` | ローカル検証とテスト用の内蔵アダプター |
+| `openai_codex` | Responses、ストリーミング Responses、モデル、プローブ、クォータ、OAuth、セッションアフィニティ、Compact、画像生成 |
+| `mock` | ローカル検証とテスト |
 
 ## モデルリクエスト経路
+
+以下は Core のリクエストフローの概要です。該当する段階で実行器が登録済みフックに許可されたデータを投影し、Core が処理を続ける前に結果を検証します。フック段階はプライバシーとガードレール、コンテキストとキャッシュ、候補選択と順位付け、リクエスト・レスポンス変換、利用量、精算、トレース出力を含みます。段階の宣言は全エンドポイントやインストール済みプラグインの実装を意味せず、各エンドポイントの対応状況と段階の規則が適用されます。
 
 `Model` は外部 API 契約、`ProviderModel` は 1 つの Provider に対する永続化された上流モデルインベントリ、`ModelRoute` はその間のマッピングです。外部モデルには明示的で永続化されたディレクトリロールが付くため、最後のルートを削除しても候補テンプレートへ戻らず、下書きとして残ります。ルートの作成または編集では、選択した `ProviderModel` がインベントリに存在する必要があります。限定的な例外は、サブスクリプション型仮想モデル `codex-gpt-image-2` です。このルートは OpenAI Codex Provider を対象とし、上流モデルを `gpt-image-2` に固定する必要があります。これはチャットモデルのインベントリ項目ではなく、実行能力です。これにより、同名 1:1 マッピングとカスタムエイリアスの両方を支持し、呼び出し側は Provider 固有のモデル名を意識しません。`POST /v1/chat/completions`、`POST /v1/responses`、`POST /v1/responses/compact`、`POST /v1/embeddings` は同じ認証、クォータ、ルーティング入口を共有します。
 
@@ -121,6 +164,7 @@ sequenceDiagram
     participant C as 業務アプリケーション
     participant G as TokenHub /v1
     participant S as Store とデータベース
+    participant H as ゲートウェイフック
     participant A as Provider Adapter
     participant U as 上流モデルサービス
 
@@ -133,6 +177,11 @@ sequenceDiagram
     G->>S: 有効かつ健全な Provider / Resource / Route を取得
     G->>G: API Key、Project、Global ポリシーを解決し候補を絞り込む
     G->>G: 戦略、重み、セッションアフィニティで試行順序を計画
+    opt 該当するリクエスト段階で許可データを投影
+        G->>H: 該当するリクエスト段階で許可データを投影
+        H-->>G: 検証済みの構造化結果
+    end
+    Note over G,A: 有効な内蔵アダプターまたは外部 Provider ブリッジを呼び出す
     loop フェイルオーバー可能な候補ルート
         G->>A: 正規化済みリクエストとルート選択
         A->>U: Provider プロトコルリクエスト
@@ -143,7 +192,7 @@ sequenceDiagram
     G-->>C: 互換レスポンスと x-request-id
 ```
 
-非アクティブまたは不健全な Provider、Resource、Route は除外されます。ただし例外として、クールダウンが満了した Resource はハーフオープン候補として再び候補に加わります。最初に到達したリクエストがクールダウン期限を前方へ進めることで試行権を取得するため、同時実行のリクエストは引き続き拒否され、試行が失敗した場合は次のより長いウィンドウがすでに設定されています。その試行自身が成功した場合にのみブレーカーが閉じ、管理者の操作なしに Resource が復旧します。ブレーカー作動時にすでに実行中だったリクエストが Resource を復活させることはありません。失敗が繰り返される場合は `TOKENHUB_RESOURCE_COOLDOWN_MAX_SECONDS` を上限として指数的にウィンドウが延長されます。管理者が無効化した Resource が再び組み入れられることはありません。非ストリーミング呼び出しは候補を順番に試行します。出力開始後のストリームは安全に上流を切り替えられません。ストリーミング Responses には `response_stream` 能力を持つアダプターが必要です。`openai_codex` のルートでは、リクエストと API Key からセッションアフィニティキーを導出し、継続性のために Resource バインドを永続化できます。
+非アクティブまたは不健全な Provider、Resource、Route は除外されます。ただし例外として、クールダウンが満了した Resource はハーフオープン候補として再び候補に加わります。最初に到達したリクエストがクールダウン期限を前方へ進めることで試行権を取得するため、同時実行のリクエストは引き続き拒否され、試行が失敗した場合は次のより長いウィンドウがすでに設定されています。その試行自身が成功した場合にのみブレーカーが閉じ、管理者の操作なしに Resource が復旧します。ブレーカー作動時にすでに実行中だったリクエストが Resource を復活させることはありません。失敗が繰り返される場合は `TOKENHUB_RESOURCE_COOLDOWN_MAX_SECONDS` を上限として指数的にウィンドウが延長されます。管理者が無効化した Resource が再び組み入れられることはありません。非ストリーミング呼び出しは候補を順番に試行します。出力開始後のストリームは安全に上流を切り替えられません。ストリーミング Responses には `responses_stream` 能力を持つアダプターが必要です。`openai_codex` のルートでは、リクエストと API Key からセッションアフィニティキーを導出し、継続性のために Resource バインドを永続化できます。
 
 `background: true` を設定した `POST /v1/responses` では、同期リクエストフローは認証と永続化された投入の後で終了します。各レプリカは起動時にキューが空でも永続キューを継続して poll します。Worker はジョブを取得して元の認可を再検証し、admitted phase、request ID、quota counter、token reservation、concurrency lease を同じデータベース transaction で commit してから、同じ guardrail、routing、Provider、metering、audit、trace のフローへ入ります。lease epoch が古い Worker を fence します。PostgreSQL の複数レプリカは row lock と `SKIP LOCKED` で取得し、SQLite は対応対象の単一バックエンド構成で原子的に取得します。Admission 前の lease 喪失は安全に再実行できます。Admission 後の lease 喪失は Provider への重複リクエストを避けるため明示的な終端状態となり、未 dispatch の token reservation は復旧時に返却されます。
 

--- a/docs/zh-CN/architecture.md
+++ b/docs/zh-CN/architecture.md
@@ -8,6 +8,8 @@ Language: [English](../architecture.md) | 简体中文 | [日本語](../ja/archi
 
 后端是一个 Go 进程，承载管理 API、OpenAI 兼容模型 API、路由编排、Provider 适配、审计和持久化逻辑。前端是 Next.js 管理后台。控制面与数据面是逻辑边界；默认部署中它们共享一个后端实例和数据库，多实例模式则通过 PostgreSQL 共享状态。
 
+后端由 Core、内置插件和外部插件组成。Core 保留公共 API 兼容、认证授权、路由准入、持久化、计量和审计职责。插件通过声明提供 Provider 能力、请求链 Hook、后台任务和界面元数据；外部可执行插件由后端以子进程调用。
+
 ```mermaid
 flowchart TB
     admin["平台管理员 / 团队负责人"]
@@ -21,7 +23,10 @@ flowchart TB
         modelApi["模型 API\n/v1/*"]
         governance["鉴权与治理\nKey、RBAC、配额、并发、IP 白名单"]
         routing["路由编排\n候选路由、策略、权重、回退、会话亲和"]
-        adapters["适配器注册表\n通用 Provider / OpenAI Codex"]
+        adapters["适配器注册表"]
+        builtin["内置 Provider 插件"]
+        plugins["插件注册表与运行时"]
+        hooks["请求链 Hook 与 Broker"]
         operations["运维与可观测性\n用量、审计、告警、健康检查"]
         store["GORM Store"]
 
@@ -31,7 +36,19 @@ flowchart TB
         modelApi --> operations --> store
         adminApi --> operations
         routing --> store
+        adminApi --> plugins
+        plugins --> adapters
+        adapters --> builtin
+        plugins --> hooks
+        routing <--> hooks
     end
+
+    external["外部插件进程\nstdio-json-v1"]
+    packages["插件包与生命周期状态"]
+    packages --> plugins
+    plugins --> external
+    hooks --> external
+    adapters --> external
 
     subgraph persistence["持久化与配置"]
         sqlite[("SQLite\n默认单实例")]
@@ -50,11 +67,14 @@ flowchart TB
     admin --> ingress --> frontend
     frontend -->|"TOKENHUB_API_BASE_URL"| backend
     app --> ingress -->|"/v1/*"| backend
-    adapters --> compatible
-    adapters --> azure
-    adapters --> anthropic
-    adapters --> gemini
-    adapters --> codex
+    external --> upstream
+    backend --> adminApi
+    backend --> modelApi
+    builtin --> compatible
+    builtin --> azure
+    builtin --> anthropic
+    builtin --> gemini
+    builtin --> codex
     store --> sqlite
     store --> postgres
     catalog --> store
@@ -91,6 +111,24 @@ flowchart LR
 
 默认镜像直接使用构建时内置的 `model-catalog.yaml`，以保证后端程序和模型目录版本一致。需要自定义目录时，通过 `./deploy/install.sh --model-catalog /absolute/path/to/model-catalog.yaml` 显式覆盖；该文件不是默认 Compose 挂载项。
 
+## 插件运行时与边界
+
+`backend/internal/server/plugin_bootstrap.go` 统一装配插件注册表、请求链及执行器、管理 UI 注册表、Action Broker、后台任务 Broker/Runner 和适配器注册表。启动时注册内置能力，从 `TOKENHUB_PLUGIN_DIR` 加载插件包，再接入启用的外部 Provider 适配器。内置与外部插件共享元数据和能力契约，但内置实现运行于 Go 进程内，外部命令通过 `stdio-json-v1` 执行。
+
+| 能力面 | 实现入口 | 职责与边界 |
+| --- | --- | --- |
+| 插件包契约与加载 | `backend/internal/plugin/manifest.go`、`runtime.go`、`registry.go` | 注册前校验 manifest schema、Plugin API 兼容性、权限和包状态 |
+| Provider | `backend/internal/server/provider_plugin_adapter.go`、`adapter_registry.go` | 使用 Provider、资源和凭证的数据投影调用声明的操作；路由与计量仍由 Core 负责 |
+| 请求链 | `backend/internal/plugin/gateway_chain.go`、`gateway_runner.go`；`backend/internal/server/gateway_plugin_hooks.go` | 向各阶段 Hook 提供获准数据，校验结构化结果并限制可修改内容 |
+| 后台任务与管理动作 | `backend/internal/plugin/background_scheduler.go`、`background_job.go`、`action_broker.go` | 调度声明的任务并代理管理员操作；与持久化后台 Responses 任务分开 |
+| 界面 | `backend/internal/plugin/admin_ui.go`、`sim.go` | 由控制台渲染声明式面板、设置、主题和布局；不执行任意插件 React 或 JavaScript |
+
+插件包通过 `plugin.yaml` 声明 manifest schema `1` 和 Plugin API `v1`。权限决定调用时可投影哪些 Core 数据，以及 Core 接受哪些结构化修改。这不等同于操作系统沙箱：命令策略当前将网络和资源强制隔离标记为 `unsupported`。外部命令使用受限环境变量、包内相对可执行路径、输入输出大小限制和超时。通用命令默认超时为 30 秒，输入上限 4 MiB、输出上限 1 MiB；各能力面可设置自己的超时，例如请求链 Hook 默认 5 秒。流式支持须按适配器核对；当前外部 Provider 桥接从命令结果中解析事件数组，并非实时转发子进程输出流。
+
+三种 Compose 编排均将 `tokenhub-plugins` 挂载到 `/app/plugins`，并提供 `TOKENHUB_PLUGIN_DIR` 和 `TOKENHUB_PLUGIN_MARKETPLACE_URL`。插件文件与生命周期状态保存在文件系统，注册表和执行器则属于各进程。PostgreSQL 不负责分发插件二进制，也不会刷新所有副本的注册表。`plugin_runtime_reload.go` 通过集群操作串行执行重载，但只重建当前服务进程的运行时；部署时仍需协调插件版本，并逐副本重载或重启。当前包更新处理器替换文件后没有调用该重载路径，因此仅凭更新响应不能确认新运行时已经生效。
+
+安装与市场代码提供校验和验证、签名市场信任校验、权限审查、失败插件隔离和回滚路径。这些机制不代表已实现跨副本原子激活，也不提供宿主资源隔离。详细契约和生命周期操作见[插件开发指南](plugin-development.md)。
+
 ## 关键组件
 
 | 组件 | 位置 | 责任 |
@@ -99,23 +137,28 @@ flowchart LR
 | HTTP 服务 | `backend/internal/server/http.go` | 注册 API、执行鉴权、路由调用、写入响应和健康检查 |
 | 路由编排 | `backend/internal/server/http.go` | 为统一模型名选择候选路由，按优先级、资源优先级、策略、权重和亲和性确定尝试顺序 |
 | 适配器注册与探测 | `adapter_registry.go`、`integration_service.go` | 声明各 Provider 的能力，执行 Provider 与资源探测 |
-| Provider 适配层 | `providers.go`、`provider_account_codex.go` | 将统一请求转换为上游协议；管理 Codex 订阅资源的 OAuth、刷新与会话亲和 |
+| Provider 适配层 | `builtin_provider_plugins.go`、`provider_plugin_adapter.go`、`provider_account_codex.go` | 将统一请求转换为上游协议；管理 Codex 订阅资源的 OAuth、刷新与会话亲和 |
 | 持久化层 | `store.go` | GORM 数据访问、配额计数、凭证加密、SQLite 备份、PostgreSQL 租约和集群锁 |
 | 模型目录 | `data/model-catalog.yaml` | 为镜像构建提供标准模型元数据，启动时同步到数据库 |
 
 Provider 类型与主要能力如下：
 
+下表列出代表性的内置注册项，并非完整且固定的 Provider 清单。实际能力由启用的插件与适配器描述、Provider 策略以及模型和资源支持共同决定；外部插件可以增加 Provider 类型。
+
 | Provider 类型 | 适配器与能力 |
 | --- | --- |
-| `openai`、`openai_compatible`、`qwen`、`local` | OpenAI 兼容；Chat、流式 Chat、Responses、Embeddings、探测 |
-| `deepseek` | OpenAI 兼容；Chat、流式 Chat、Embeddings、探测。Responses 与流式 Responses 按模型声明，对 `deepseek-v4-flash` 和 `deepseek-v4-pro` 开放 |
+| `openai` | Chat、流式 Chat、Responses、流式 Responses、Embeddings、探测和图像生成 |
+| `openai_compatible`、`deepseek`、`qwen`、`local` | OpenAI 兼容操作；模型与 Provider 策略可进一步限制 Responses 支持 |
+| `kronk` | Chat、流式 Chat、Responses、流式 Responses、Embeddings、模型发现和探测 |
 | `azure_openai` | Chat、流式 Chat、Embeddings、探测 |
 | `anthropic` | Chat、流式 Chat、探测 |
 | `gemini` | Chat、流式 Chat、Embeddings、探测 |
-| `openai_codex` | OpenAI Codex Subscription；Responses、Responses 流式、模型发现、额度、OAuth、会话亲和和 Compact |
-| `mock` | 内置 Mock，供本地验证与测试 |
+| `openai_codex` | Responses、流式 Responses、模型发现、探测、额度、OAuth、会话亲和、Compact 和图像生成 |
+| `mock` | 本地验证与测试 |
 
 ## 模型请求链路
+
+下图概括 Core 请求流程。在适用的阶段，请求链执行器向已注册 Hook 投影获准数据，并在 Core 继续执行前校验结果。Hook 阶段覆盖隐私与内容安全、上下文与缓存、候选选择与排序、请求响应转换、用量、结算和追踪导出。声明了阶段不代表每个端点或已安装插件都实现了相应能力；仍以端点支持和阶段规则为准。
 
 `Model` 是对外 API 契约，`ProviderModel` 是某个 Provider 下持久化的上游模型库存，`ModelRoute` 在两者之间建立映射。对外模型带有明确且持久化的目录角色，因此删除最后一条路由后会保留为草稿，而不会重新变成候选模板；创建或编辑路由时，所选 `ProviderModel` 必须已经存在于库存中。唯一的窄例外是订阅制虚拟模型 `codex-gpt-image-2`：它的路由必须指向 OpenAI Codex Provider，并固定使用上游模型 `gpt-image-2`；这是执行能力，不属于聊天模型库存。这既支持同名 1:1 映射，也支持自定义别名，调用方无需感知具体 Provider 模型名。`POST /v1/chat/completions`、`POST /v1/responses`、`POST /v1/responses/compact` 和 `POST /v1/embeddings` 都遵循相同的鉴权、配额与路由起点。
 
@@ -124,6 +167,7 @@ sequenceDiagram
     participant C as 业务应用
     participant G as TokenHub /v1
     participant S as Store + 数据库
+    participant H as 请求链 Hook
     participant A as Provider Adapter
     participant U as 上游模型服务
 
@@ -136,6 +180,11 @@ sequenceDiagram
     G->>S: 查询活跃且健康的 Provider / Resource / Route
     G->>G: 解析 API Key、项目或全局策略，筛选候选路由
     G->>G: 按策略、权重与会话亲和生成尝试顺序
+    opt 在适用的请求阶段投影获准数据
+        G->>H: 在适用的请求阶段投影获准数据
+        H-->>G: 校验后的结构化结果
+    end
+    Note over G,A: 调用已启用的内置适配器或外部 Provider 桥接
     loop 可回退的候选路由
         G->>A: 统一请求 + 路由选择
         A->>U: Provider 协议请求
@@ -146,7 +195,7 @@ sequenceDiagram
     G-->>C: OpenAI 兼容响应 + x-request-id
 ```
 
-路由筛选会跳过非活跃或不健康的 Provider、Provider Resource 和 Route，但有一个例外：冷却期已过的资源会作为半开候选重新进入候选池。第一个选中它的请求通过把冷却截止时间向后推进来占用这次试探，因此并发请求仍会被拒绝，而试探失败时下一个（更长的）冷却窗口已经就位。只有该次试探自身成功才会关闭熔断器并自动恢复资源，无需管理员介入——熔断触发时已经在途的请求无法把资源救活；反复失败则按指数退避加长窗口，上限为 `TOKENHUB_RESOURCE_COOLDOWN_MAX_SECONDS`。被管理员禁用的资源永远不会被重新纳入。非流式调用依次尝试候选路由。已开始输出的流无法安全切换到另一条上游路由；Responses 流式仅选择声明 `response_stream` 能力的适配器。对于 `openai_codex` 路由，系统可根据请求与 Key 派生会话亲和键，并持久化资源绑定以保持会话连续性。
+路由筛选会跳过非活跃或不健康的 Provider、Provider Resource 和 Route，但有一个例外：冷却期已过的资源会作为半开候选重新进入候选池。第一个选中它的请求通过把冷却截止时间向后推进来占用这次试探，因此并发请求仍会被拒绝，而试探失败时下一个（更长的）冷却窗口已经就位。只有该次试探自身成功才会关闭熔断器并自动恢复资源，无需管理员介入——熔断触发时已经在途的请求无法把资源救活；反复失败则按指数退避加长窗口，上限为 `TOKENHUB_RESOURCE_COOLDOWN_MAX_SECONDS`。被管理员禁用的资源永远不会被重新纳入。非流式调用依次尝试候选路由。已开始输出的流无法安全切换到另一条上游路由；Responses 流式仅选择声明 `responses_stream` 能力的适配器。对于 `openai_codex` 路由，系统可根据请求与 Key 派生会话亲和键，并持久化资源绑定以保持会话连续性。
 
 对于设置 `background: true` 的 `POST /v1/responses`，同步请求链路会在认证和持久化提交后结束。每个副本即使在启动时队列为空，也会持续轮询持久化队列。Worker 领取任务并重新验证原始授权后，会在同一个数据库事务中提交 admitted 阶段、请求 ID、配额计数、Token 预留与并发租约，再进入相同的 Guardrail、路由、Provider、计量、审计和链路追踪流程。租约代次用于隔离过期 Worker。PostgreSQL 多实例通过行锁和 `SKIP LOCKED` 领取任务；SQLite 在受支持的单后端部署中通过原子操作领取。准入前的租约丢失可安全重放；准入后的租约丢失会进入明确终态，避免重复请求 Provider，尚未分发的 Token 预留会在恢复时退还。
 


### PR DESCRIPTION
## Summary

Update the English, Simplified Chinese, and Japanese architecture overview for the implemented plugin runtime, and repair backend CI failures inherited from the plugin migration. PostgreSQL fixtures now enable startup workers, supply the required model metadata, and select the Codex credential-refresh policy; their original cross-replica assertions remain intact.

## Related Issue

N/A

## Changes

- Update the architecture diagram and request sequence to include plugin registration, built-in providers, external processes, and gateway hooks.
- Document Provider, gateway, background-job, action, and declarative UI surfaces, with implementation entry points.
- Explain permission projection, command limits, streaming behavior, package persistence, process-local reloads, and multi-replica coordination requirements.
- Refresh representative provider capabilities and correct the `responses_stream` capability identifier.
- Remove 36 unused internal compatibility functions and resolve error-result, redundant-assignment, and formatting lint findings.
- Align PostgreSQL integration fixtures with current worker startup, model catalog, and credential-refresh contracts.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [x] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...`, `go vet ./...`, and `golangci-lint run ./...` (v2.12.2) passed.
- Reproduced all three PostgreSQL failures locally before fixing their fixtures. The full server integration selection used by CI and `go test -tags=integration ./internal/dbschema -run '^TestPostgres' -count=1 -v` passed against an isolated PostgreSQL 16 instance.
- All 168 tracked repository tool tests passed. Documentation translation, UI translation, environment contract, source-line, and whitespace checks passed; the source-line gate reports an existing opportunity to tighten a baseline.
- Frontend/application browser tests and Compose rendering were not rerun locally because this update changes no frontend or deployment files; the preceding CI run passed those jobs. The updated commit is also validated by the PR workflow.

## Compatibility, Security, and Operations

No public API, database schema, environment, or deployment changes. Internal cleanup removes unreachable compatibility helpers; test-fixture changes preserve the existing behavioral assertions. The documentation explicitly records that external commands do not enforce network/resource isolation, runtime reload is process-local, and package replacement alone does not establish activation across replicas.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
