### PR TITLE
fix(admin): resolve plugin management findings from live testing

### DIFF
--- a/backend/internal/server/provider_error_classification.go
+++ b/backend/internal/server/provider_error_classification.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"sort"
@@ -117,14 +118,22 @@ func newProviderPolicyRefusal(message string) error {
 // provider account, and the bodies quote it: OpenAI echoes a masked API key,
 // Azure names the subscription key. Those go no further than the attempt log,
 // where the recorded upstream status already says what happened.
-func providerErrorMessage(class providerErrorClass, data []byte) string {
+func providerErrorMessage(class providerErrorClass, upstreamStatus int, data []byte) string {
 	switch class.code {
 	case "provider_auth_error":
 		return "The gateway's credential for this provider was rejected"
 	case "provider_payment_required":
 		return "The gateway's account with this provider cannot be billed"
 	}
-	return strings.TrimSpace(string(data))
+	message := strings.TrimSpace(string(data))
+	if message == "" {
+		// Some providers answer a failure with an empty body, and an empty
+		// message tells the caller nothing about what went wrong. The upstream
+		// status is reported rather than class.status, which is what the gateway
+		// decided to return and hides the status the provider actually sent.
+		return fmt.Sprintf("Upstream provider returned HTTP %d", upstreamStatus)
+	}
+	return message
 }
 
 // newProviderMisconfigured reports a provider that cannot be called at all. That
@@ -188,7 +197,7 @@ func newProfiledProviderHTTPError(profile providerErrorProfileDescriptor, upstre
 	if override, ok := profile.CodeClassOverrides[profileCode]; ok {
 		class = override
 	}
-	httpErr := NewHTTPError(class.status, class.code, providerErrorMessage(class, normalized))
+	httpErr := NewHTTPError(class.status, class.code, providerErrorMessage(class, upstreamStatus, normalized))
 	httpErr.UpstreamStatus = upstreamStatus
 	return &ProviderInvocationError{
 		Err:         httpErr,
@@ -381,7 +390,7 @@ func providerSecretRepresentations(value string) []string {
 // replaced by a fail-closed mask because its string boundaries are ambiguous.
 func newProviderHTTPError(upstreamStatus int, headers http.Header, data []byte) error {
 	class := classifyProviderStatus(upstreamStatus)
-	httpErr := NewHTTPError(class.status, class.code, providerErrorMessage(class, data))
+	httpErr := NewHTTPError(class.status, class.code, providerErrorMessage(class, upstreamStatus, data))
 	httpErr.UpstreamStatus = upstreamStatus
 	return &ProviderInvocationError{
 		Err:         httpErr,

--- a/backend/internal/server/provider_error_classification_test.go
+++ b/backend/internal/server/provider_error_classification_test.go
@@ -442,3 +442,79 @@ func TestAuthErrorDoesNotForwardTheUpstreamBody(t *testing.T) {
 		t.Fatalf("the upstream credential fragment reached the caller: %s", body)
 	}
 }
+
+// Providers do not always explain a failure: DeepSeek answers a chat model sent
+// to /embeddings with a bare 404 and no body. Passing that body straight through
+// left the caller an empty message, so the upstream status is reported instead.
+func TestEmptyUpstreamBodyFallsBackToTheUpstreamStatus(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		body string
+	}{
+		{name: "empty body", body: ""},
+		{name: "whitespace-only body", body: " \n\t "},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: http.StatusNotFound,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader(testCase.body)),
+			}
+			err := checkProviderResponse(resp)
+			httpErr := AsHTTPError(err)
+			if httpErr == nil {
+				t.Fatalf("upstream 404 did not produce an HTTP error: %#v", err)
+			}
+			if httpErr.Code != "provider_model_not_found" {
+				t.Fatalf("code = %q, want %q", httpErr.Code, "provider_model_not_found")
+			}
+			if httpErr.Status != http.StatusBadGateway {
+				t.Fatalf("caller status = %d, want 502", httpErr.Status)
+			}
+			// The upstream status, not the 502 the gateway decided to return.
+			if want := "Upstream provider returned HTTP 404"; httpErr.Message != want {
+				t.Fatalf("message = %q, want %q", httpErr.Message, want)
+			}
+			if got := providerErrorDisposition(err); got != ProviderErrorModelUnsupported {
+				t.Fatalf("disposition = %q, want %q", got, ProviderErrorModelUnsupported)
+			}
+		})
+	}
+}
+
+func TestEmptyUpstreamBodyFallsBackForProfiledProviders(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+	err := checkProviderResponseForProviderPolicy(resp, Provider{}, AdapterProviderPolicy{
+		ErrorProfile: providerErrorProfileKronk,
+	})
+	httpErr := AsHTTPError(err)
+	if httpErr == nil {
+		t.Fatalf("upstream 404 did not produce an HTTP error: %#v", err)
+	}
+	if want := "Upstream provider returned HTTP 404"; httpErr.Message != want {
+		t.Fatalf("message = %q, want %q", httpErr.Message, want)
+	}
+	if httpErr.Code != "provider_model_not_found" || httpErr.Status != http.StatusBadGateway {
+		t.Fatalf("profiled empty body changed the classification: %#v", httpErr)
+	}
+}
+
+func TestNonEmptyUpstreamBodyIsStillForwarded(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"model not found"}}`)),
+	}
+	err := checkProviderResponse(resp)
+	httpErr := AsHTTPError(err)
+	if httpErr == nil {
+		t.Fatalf("upstream 404 did not produce an HTTP error: %#v", err)
+	}
+	if want := `{"error":{"message":"model not found"}}`; httpErr.Message != want {
+		t.Fatalf("message = %q, want the upstream body %q", httpErr.Message, want)
+	}
+}

--- a/frontend/app/styles/redesign/plugin-template-settings.css
+++ b/frontend/app/styles/redesign/plugin-template-settings.css
@@ -281,6 +281,15 @@
   cursor: pointer;
 }
 
+.plugin-theme-token-hint {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 8px 0 0;
+  gap: 4px;
+  color: var(--ink-3, var(--muted));
+  font-size: 11px;
+}
+
 .plugin-theme-token-notice {
   margin: 9px 0 0;
   color: var(--pos);

--- a/frontend/e2e/start-stack.mjs
+++ b/frontend/e2e/start-stack.mjs
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { cp, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -93,6 +93,16 @@ process.on("SIGINT", () => void shutdown(0));
 process.on("SIGTERM", () => void shutdown(0));
 
 try {
+  // The smoke suite loads one plugin fixture. It is copied out of the tracked
+  // Go testdata tree first, because the backend writes plugin.state.json next to
+  // a plugin package and that would dirty the checkout the suite runs from.
+  const pluginDirectory = path.join(temporaryDirectory, "plugins");
+  await cp(
+    path.join(backendDirectory, "internal/plugin/testdata/external-trace-hook"),
+    path.join(pluginDirectory, "external-trace-hook"),
+    { recursive: true },
+  );
+
   const sharedEnvironment = {
     ...process.env,
     TOKENHUB_E2E_UPSTREAM_PORT: String(upstreamPort),
@@ -121,7 +131,7 @@ try {
       TOKENHUB_IMAGE_STORAGE_DIR: path.join(temporaryDirectory, "images"),
       TOKENHUB_MODEL_CATALOG_FILE: path.join(repositoryDirectory, "data/model-catalog.yaml"),
       TOKENHUB_PROVIDER_CATALOG_FILE: path.join(repositoryDirectory, "data/provider-catalog.json"),
-      TOKENHUB_PLUGIN_DIR: path.join(backendDirectory, "internal/plugin/testdata"),
+      TOKENHUB_PLUGIN_DIR: pluginDirectory,
       TOKENHUB_PROVIDER_UPSTREAM_ALLOW_LOOPBACK: "true",
       TOKENHUB_PROVIDER_UPSTREAM_ALLOWED_CIDRS: "127.0.0.1/32",
       TOKENHUB_GRACEFUL_SHUTDOWN_SECONDS: "1",

--- a/frontend/features/admin/domain/plugin-theme.test.tsx
+++ b/frontend/features/admin/domain/plugin-theme.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { pluginLayoutDensity, pluginShellPresentation, pluginThemeStyle } from "./plugin-theme";
+import { pluginLayoutDensity, pluginShellPresentation, pluginThemeStyle, pluginThemeTokenEntries } from "./plugin-theme";
 
 describe("plugin shell presentation", () => {
   it("applies safe default theme tokens for the active mode", () => {
@@ -294,5 +294,52 @@ describe("plugin shell presentation", () => {
     expect(presentation.layoutContribution?.id).toBe("legacy-layout");
     expect(presentation.style).toEqual({ "--accent": "#f97316" });
     expect(presentation.density).toBe("spacious");
+  });
+});
+
+describe("pluginThemeTokenEntries", () => {
+  it("keeps the position of the first declaration and the value of the last", () => {
+    expect(pluginThemeTokenEntries({ accent: "#2563eb", surface: "#ffffff", "--accent": "#16a34a" })).toEqual([
+      { name: "accent", defaultValue: "#16a34a" },
+      { name: "surface", defaultValue: "#ffffff" },
+    ]);
+  });
+
+  it("keeps an earlier renderable value over a later one the shell would reject", () => {
+    expect(pluginThemeTokenEntries({ accent: "#2563eb", "--accent": "url(https://example.test/a.css)" })).toEqual([
+      { name: "accent", defaultValue: "#2563eb" },
+    ]);
+    expect(pluginThemeStyle({
+      plugin_id: "tokenhub.sim",
+      id: "unsafe-duplicate-theme",
+      slot: "theme.tokens",
+      schema: { mode: "light", default: true, tokens: { accent: "#2563eb", "--accent": "url(https://example.test/a.css)" } },
+    })).toEqual({ "--accent": "#2563eb" });
+  });
+
+  it("keeps the last declaration when the shell would reject every one of them", () => {
+    expect(pluginThemeTokenEntries({ accent: "url(https://example.test/a.css)", "--accent": "url(https://example.test/b.css)" })).toEqual([
+      { name: "accent", defaultValue: "url(https://example.test/b.css)" },
+    ]);
+  });
+
+  it("drops names outside the allowlist and values that are not strings", () => {
+    expect(pluginThemeTokenEntries({ "--accent": "#2563eb", "not-a-real-token": "#000000", surface: 12 })).toEqual([
+      { name: "accent", defaultValue: "#2563eb" },
+    ]);
+  });
+
+  it("returns nothing for a payload that is not a token object", () => {
+    expect(pluginThemeTokenEntries(undefined)).toEqual([]);
+    expect(pluginThemeTokenEntries(["accent"])).toEqual([]);
+  });
+
+  it("gives the shell the same duplicate default the editor shows", () => {
+    expect(pluginThemeStyle({
+      plugin_id: "tokenhub.sim",
+      id: "duplicate-theme",
+      slot: "theme.tokens",
+      schema: { mode: "light", default: true, tokens: { accent: "#2563eb", "--accent": "#16a34a" } },
+    })).toEqual({ "--accent": "#16a34a" });
   });
 });

--- a/frontend/features/admin/domain/plugin-theme.ts
+++ b/frontend/features/admin/domain/plugin-theme.ts
@@ -88,19 +88,43 @@ export function pluginThemeStyle(
   contribution: AdminUIContribution | SIMThemeTokens,
   overrides: Record<string, string> = {},
 ): CSSProperties | undefined {
-  const tokens = themeTokenPayload(contribution);
-  if (!tokens || typeof tokens !== "object" || Array.isArray(tokens)) return undefined;
   const style: Record<string, string> = {};
-  for (const [rawName, rawValue] of Object.entries(tokens)) {
-    const name = rawName.trim().replace(/^--/, "");
-    if (!isPluginThemeTokenName(name) || typeof rawValue !== "string") continue;
+  for (const { name, defaultValue } of pluginThemeTokenEntries(themeTokenPayload(contribution))) {
     const override = overrides[name] ?? overrides[`--${name}`];
     const normalizedOverride = typeof override === "string" ? override.trim() : "";
-    const value = normalizedOverride && isSafePluginCSSValue(normalizedOverride) ? normalizedOverride : rawValue.trim();
+    const value = normalizedOverride && isSafePluginCSSValue(normalizedOverride) ? normalizedOverride : defaultValue.trim();
     if (!isSafePluginCSSValue(value)) continue;
     style[`--${name}`] = value;
   }
   return Object.keys(style).length > 0 ? style as CSSProperties : undefined;
+}
+
+/**
+ * Canonical, allowlisted theme tokens declared by a template, in declaration order.
+ *
+ * A template may declare the same token twice, once bare and once `--`-prefixed. The
+ * rendered shell applies declarations in order, so the later value is the one that takes
+ * effect; the entry keeps the position of the first occurrence and the value of the last
+ * so the editor offers exactly what the shell will use. A later declaration the shell
+ * would refuse to render never displaces an earlier one it would accept.
+ */
+export function pluginThemeTokenEntries(tokens: unknown): Array<{ name: string; defaultValue: string }> {
+  if (!tokens || typeof tokens !== "object" || Array.isArray(tokens)) return [];
+  const entries: Array<{ name: string; defaultValue: string }> = [];
+  const positions = new Map<string, number>();
+  for (const [rawName, rawValue] of Object.entries(tokens)) {
+    const name = rawName.trim().replace(/^--/, "");
+    if (!isPluginThemeTokenName(name) || typeof rawValue !== "string") continue;
+    const position = positions.get(name);
+    if (position === undefined) {
+      positions.set(name, entries.length);
+      entries.push({ name, defaultValue: rawValue });
+      continue;
+    }
+    if (!isSafePluginCSSValue(rawValue.trim()) && isSafePluginCSSValue(entries[position].defaultValue.trim())) continue;
+    entries[position] = { name, defaultValue: rawValue };
+  }
+  return entries;
 }
 
 export function pluginLayoutDensity(contribution?: AdminUIContribution | SIMShellLayout): PluginLayoutDensity {

--- a/frontend/features/admin/shell/admin-console.tsx
+++ b/frontend/features/admin/shell/admin-console.tsx
@@ -995,6 +995,7 @@ export function AdminConsole({ defaultBaseURL }: { defaultBaseURL: string }) {
             pluginDetailRoute ? (
               <PluginDetailView
                 api={api}
+                key={pluginDetailRoute.pluginID}
                 activeThemeKey={shellState.simSelection.theme.capability?.key}
                 data={data}
                 pluginID={pluginDetailRoute.pluginID}
@@ -1008,6 +1009,7 @@ export function AdminConsole({ defaultBaseURL }: { defaultBaseURL: string }) {
               <PluginsView
                 api={api}
                 data={data}
+                onReload={() => load("plugins")}
                 onSelectPlugin={selectPluginDetail}
                 onSIMSelectionPreferenceChange={setSIMSelectionPreference}
                 simSelectionPreference={simSelectionPreference}

--- a/frontend/features/admin/shell/navigation-ui.test.tsx
+++ b/frontend/features/admin/shell/navigation-ui.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { emptyData } from "../domain/catalog";
 import { adminConsoleSIMSelectionPreference, adminConsoleShellState, adminConsoleSIMSelectionStorageKey, readAdminConsoleSIMSelectionPreference, saveAdminConsoleSIMSelectionPreference } from "./admin-console";
-import { Sidebar } from "./navigation-ui";
+import { pageRecordCount, Sidebar } from "./navigation-ui";
 
 describe("Sidebar", () => {
   it("keeps plugin nav section contributions out of the sidebar", () => {
@@ -237,6 +237,23 @@ describe("Sidebar", () => {
     expect(templateStyles()).toContain('.app-shell[data-sim-plugin-id="tokenhub.sim.knowledge-sidebar"] .nav-title');
     expect(templateStyles()).toContain('.app-shell[data-sim-plugin-id="tokenhub.sim.knowledge-sidebar"] .nav-item.active');
     expect(responsiveStyles()).toContain('.app-shell[data-sim-plugin-id="tokenhub.sim.knowledge-sidebar"].sidebar-collapsed');
+  });
+});
+
+describe("pageRecordCount", () => {
+  it("counts installed plugins for the plugin management page", () => {
+    const data = emptyData();
+    data.plugins = [
+      { id: "example.first", name: "First", version: "1.0.0", source: "local_file", kinds: ["extension"], placements: ["gateway_chain"], capabilities: [] },
+      { id: "example.second", name: "Second", version: "1.0.0", source: "built_in", kinds: ["provider"], placements: ["gateway_chain"], capabilities: [] },
+    ];
+
+    expect(pageRecordCount("plugins", data)).toBe(2);
+  });
+
+  it("reports no records for a page without a countable list", () => {
+    expect(pageRecordCount("plugins", emptyData())).toBe(0);
+    expect(pageRecordCount("overview", emptyData())).toBe(0);
   });
 });
 

--- a/frontend/features/admin/shell/navigation-ui.tsx
+++ b/frontend/features/admin/shell/navigation-ui.tsx
@@ -323,6 +323,7 @@ export function pageHeaderChips(view: ViewKey, data: AppData, user: AdminUser) {
 export function pageRecordCount(view: ViewKey, data: AppData) {
   const config = resourceConfigFor(view);
   if (config) return config.list(data).length;
+  if (view === "plugins") return data.plugins.length;
   if (view === "alert-events") return data.alerts.length;
   if (view === "alert-deliveries") return data.alertDeliveries.length;
   if (view === "approvals") return data.approvals.length;

--- a/frontend/features/admin/views/plugin-detail.test.tsx
+++ b/frontend/features/admin/views/plugin-detail.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { emptyData } from "../domain/catalog";
 import { PluginDetailView } from "./plugin-detail";
@@ -111,9 +111,8 @@ describe("PluginDetailView", () => {
     expect(await screen.findByText("package main")).toBeInTheDocument();
     const blocked = screen.getByRole("button", { name: /credentials.json/ });
     expect(blocked).toBeDisabled();
-    const previewRequests = fetchMock.mock.calls.filter(([input]) => String(input).includes("/file?")).length;
-    fireEvent.click(blocked);
-    await waitFor(() => expect(fetchMock.mock.calls.filter(([input]) => String(input).includes("/file?")).length).toBe(previewRequests));
+    const previewed = fetchMock.mock.calls.map(([input]) => String(input)).filter((url) => url.includes("/file?"));
+    expect(previewed.some((url) => url.includes(`path=${encodeURIComponent("credentials.json")}`))).toBe(false);
   });
 
   it("shows declared permissions and UI configuration schemas", async () => {
@@ -133,5 +132,80 @@ describe("PluginDetailView", () => {
     renderDetail("files");
 
     expect(await screen.findByText("该内置插件没有独立安装包。")).toBeInTheDocument();
+  });
+});
+
+describe("PluginDetailView file preview isolation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  function packageWithFiles(files: Array<{ path: string; size: number; kind: string; viewable: boolean }>) {
+    return { file_count: files.length, total_size: files.reduce((total, file) => total + file.size, 0), files };
+  }
+
+  function stubDetailFetch(previewStatus: number) {
+    const packages: Record<string, ReturnType<typeof packageWithFiles>> = {
+      "example.detail": packageWithFiles([{ path: "src/main.go", size: 20, kind: "source", viewable: true }]),
+      "example.locked": packageWithFiles([{ path: "credentials.json", size: 12, kind: "configuration", viewable: false }]),
+    };
+    return vi.fn().mockImplementation((input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/file?")) {
+        return Promise.resolve(new Response(JSON.stringify({ data: { path: "src/main.go", size: 20, kind: "source", content: "package main\n" } }), { status: previewStatus }));
+      }
+      const pluginID = url.includes("example.locked") ? "example.locked" : "example.detail";
+      const payload = detailPayload();
+      payload.data.plugin.id = pluginID;
+      payload.data.package = packages[pluginID];
+      return Promise.resolve(new Response(JSON.stringify(payload), { status: 200 }));
+    });
+  }
+
+  it("drops a failed preview when the next plugin has nothing to preview", async () => {
+    vi.stubGlobal("fetch", stubDetailFetch(500));
+
+    const { rerender } = render(
+      <PluginDetailView api={api} data={appData()} pluginID="example.detail" section="files" onBack={vi.fn()} onNavigate={vi.fn()} />,
+    );
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+
+    rerender(
+      <PluginDetailView api={api} data={appData()} pluginID="example.locked" section="files" onBack={vi.fn()} onNavigate={vi.fn()} />,
+    );
+
+    expect(await screen.findByText("选择一个文件查看内容")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.queryByText("正在读取插件文件")).not.toBeInTheDocument();
+  });
+
+  it("does not let a preview started for one plugin land on the next", async () => {
+    let deliverPreview = (_content: string) => undefined as void;
+    const preview = new Promise<Response>((resolve) => {
+      deliverPreview = (content: string) => resolve(new Response(JSON.stringify({ data: { path: "src/main.go", size: 20, kind: "source", content } }), { status: 200 }));
+    });
+    const detailFetch = stubDetailFetch(200);
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((input: string | URL | Request, init?: RequestInit) => {
+      return String(input).includes("/file?") ? preview : detailFetch(input, init);
+    }));
+
+    const { rerender } = render(
+      <PluginDetailView api={api} data={appData()} pluginID="example.detail" section="files" onBack={vi.fn()} onNavigate={vi.fn()} />,
+    );
+    expect(await screen.findByText("正在读取插件文件")).toBeInTheDocument();
+
+    rerender(
+      <PluginDetailView api={api} data={appData()} pluginID="example.locked" section="files" onBack={vi.fn()} onNavigate={vi.fn()} />,
+    );
+    expect(await screen.findByText("选择一个文件查看内容")).toBeInTheDocument();
+
+    await act(async () => {
+      deliverPreview("package main\n");
+      await preview;
+    });
+
+    expect(screen.queryByText("package main")).not.toBeInTheDocument();
+    expect(screen.getByText("选择一个文件查看内容")).toBeInTheDocument();
   });
 });

--- a/frontend/features/admin/views/plugin-detail.tsx
+++ b/frontend/features/admin/views/plugin-detail.tsx
@@ -90,11 +90,15 @@ export function PluginDetailView({
     setDetail(null);
     setSelectedPath("");
     setFileContent(null);
+    setFileError("");
+    setFileLoading(false);
     adminFetch(api, `/api/admin/plugins/${encodeURIComponent(pluginID)}/detail`, { signal: controller.signal })
       .then(async (response) => {
         if (!response.ok) throw new Error(await readAdminError(response, tx("读取插件详情")));
         const payload = await response.json() as { data?: PluginDetailResponse };
         if (!payload.data?.plugin) throw new Error(tx("读取插件详情失败"));
+        // A response that resolves after the plugin changed belongs to the previous one.
+        if (controller.signal.aborted) return;
         setDetail(payload.data);
       })
       .catch((reason) => {
@@ -113,11 +117,16 @@ export function PluginDetailView({
   }, [detail?.package, section, selectedPath]);
 
   useEffect(() => {
-    if (section !== "files" || !detail?.package) return;
     const path = selectedPath;
-    if (!path) return;
-    const selected = detail.package.files.find((file) => file.path === path);
-    if (!selected?.viewable) return;
+    const selected = detail?.package?.files.find((file) => file.path === path);
+    // Every path that previews nothing has to clear the preview too, or the state left
+    // behind by the previous selection is read as belonging to the current one.
+    if (section !== "files" || !detail?.package || !path || !selected?.viewable) {
+      setFileLoading(false);
+      setFileError("");
+      setFileContent(null);
+      return;
+    }
     const controller = new AbortController();
     setFileLoading(true);
     setFileError("");
@@ -127,6 +136,8 @@ export function PluginDetailView({
         if (!response.ok) throw new Error(await readAdminError(response, tx("读取插件文件")));
         const payload = await response.json() as { data?: PackageFileContent };
         if (!payload.data) throw new Error(tx("读取插件文件失败"));
+        // A preview that resolves after the selection changed belongs to the old file.
+        if (controller.signal.aborted) return;
         setFileContent(payload.data);
       })
       .catch((reason) => {

--- a/frontend/features/admin/views/plugin-manager-controls.tsx
+++ b/frontend/features/admin/views/plugin-manager-controls.tsx
@@ -23,6 +23,23 @@ export type PluginRollbackDraft = {
   result: string;
 };
 
+/**
+ * Applies an in-flight lifecycle draft onto a descriptor so the row reflects the state
+ * the admin just asked for. The API reports the status twice — top level and nested
+ * under `lifecycle` — and `pluginManagerLifecycleState` lets the nested copy win, so
+ * overriding only the top-level field leaves the draft invisible.
+ */
+export function pluginWithLifecycleDraft(plugin: PluginDescriptor, draft: PluginStateDraft): PluginDescriptor {
+  if (!draft.status) return plugin;
+  return {
+    ...plugin,
+    status: draft.status,
+    lifecycle: plugin.lifecycle
+      ? { ...plugin.lifecycle, status: draft.status, restart_required: Boolean(draft.restartRequired) }
+      : undefined,
+  };
+}
+
 export function PluginLifecycleControl({
   plugin,
   lifecycle,
@@ -40,7 +57,7 @@ export function PluginLifecycleControl({
   onRollback: (plugin: PluginDescriptor) => void;
   onUpdate: (plugin: PluginDescriptor, status: string) => void;
 }) {
-  const effectiveLifecycle = draft.status ? pluginManagerDisplayState({ plugin: { ...plugin, status: draft.status } }) : lifecycle;
+  const effectiveLifecycle = draft.status ? pluginManagerDisplayState({ plugin: pluginWithLifecycleDraft(plugin, draft) }) : lifecycle;
   const status = effectiveLifecycle.status;
   const nextStatus = status === "disabled" ? "enabled" : "disabled";
   const canUpdate = (allowBuiltInUpdates || plugin.source !== "built_in") && !effectiveLifecycle.mandatory && (status === "enabled" || status === "disabled");

--- a/frontend/features/admin/views/plugin-template-settings.test.tsx
+++ b/frontend/features/admin/views/plugin-template-settings.test.tsx
@@ -54,3 +54,51 @@ describe("PluginTemplateSettings", () => {
     expect(onChange).toHaveBeenLastCalledWith(themeKey, {});
   });
 });
+
+describe("PluginTemplateSettings theme token allowlist", () => {
+  function registryWithTokens(tokens: Record<string, string>) {
+    return simRegistryFromPlugins([{
+      id: "example.sim",
+      name: "Example Template",
+      version: "1.0.0",
+      capabilities: [
+        { kind: "sim", name: "theme_tokens", value: JSON.stringify({ id: "light", title: "Example Light", mode: "light", tokens }) },
+      ],
+    }]);
+  }
+
+  function renderTokens(tokens: Record<string, string>) {
+    return render(
+      <PluginTemplateSettings
+        contributions={[]}
+        overrides={{}}
+        pluginID="example.sim"
+        registry={registryWithTokens(tokens)}
+      />,
+    );
+  }
+
+  it("hides tokens the override normalizer would discard", () => {
+    renderTokens({ "--accent": "#2563eb", "--not-a-real-token": "#000000" });
+
+    expect(screen.getByRole("textbox", { name: "accent 当前值" })).toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: "not-a-real-token 当前值" })).not.toBeInTheDocument();
+    expect(screen.getByText("只能调整模板已经声明的安全主题 Token。")).toBeInTheDocument();
+  });
+
+  it("renders a duplicated token once, showing the default the shell applies", () => {
+    renderTokens({ accent: "#2563eb", "--accent": "#16a34a" });
+
+    expect(screen.getAllByRole("textbox", { name: "accent 当前值" })).toHaveLength(1);
+    expect(screen.getByRole("textbox", { name: "accent 当前值" })).toHaveValue("#16a34a");
+  });
+
+  it("offers no apply action when the template declares no adjustable token", () => {
+    renderTokens({ "--not-a-real-token": "#000000" });
+
+    expect(screen.getByText("只能调整模板已经声明的安全主题 Token。")).toBeInTheDocument();
+    expect(screen.getByText("调整保存在当前浏览器。")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "应用调整" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "恢复默认" })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/features/admin/views/plugin-template-settings.tsx
+++ b/frontend/features/admin/views/plugin-template-settings.tsx
@@ -1,7 +1,7 @@
 import { Braces, CreditCard, LayoutDashboard, Menu, PanelTop, RotateCcw, Save, Search, SlidersHorizontal, SquareDashed, UserRound } from "lucide-react";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { type AdminUIContribution } from "../core/types";
-import { isSafePluginCSSValue } from "../domain/plugin-theme";
+import { isSafePluginCSSValue, pluginThemeTokenEntries } from "../domain/plugin-theme";
 import { type PluginThemeOverrides } from "../domain/plugin-theme-overrides";
 import { localizedCapabilityTitle, localizedContributionTitle } from "../domain/plugin-localization";
 import { type SIMRegistry, type SIMThemeTokens } from "../domain/sim-registry";
@@ -100,10 +100,15 @@ function ThemeTokenEditor({
   const [draft, setDraft] = useState<Record<string, string>>(overrides);
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
+  // Only allowlisted token names survive `normalizePluginThemeOverrides`, so anything
+  // else offered here would be accepted by the editor and then silently dropped. The
+  // shell resolves the same declarations through `pluginThemeTokenEntries`, so the
+  // editor shows the default the shell actually applies.
+  const editableTokens = useMemo(() => pluginThemeTokenEntries(capability.payload.tokens), [capability.payload.tokens]);
 
   function apply() {
-    const values = Object.fromEntries(Object.entries(draft).flatMap(([name, rawValue]) => {
-      const value = rawValue.trim();
+    const values = Object.fromEntries(editableTokens.flatMap(({ name }) => {
+      const value = draft[name]?.trim() ?? "";
       return value ? [[name, value]] : [];
     }));
     if (Object.values(values).some((value) => !isSafePluginCSSValue(value))) {
@@ -129,41 +134,48 @@ function ThemeTokenEditor({
         <div><SlidersHorizontal size={15} aria-hidden="true" /><span><strong>{tx("样式调整")}</strong><small>{localizedCapabilityTitle(capability, languageLocale())}</small></span></div>
         <span>{capability.payload.mode}</span>
       </div>
-      <div className="plugin-theme-token-list">
-        {Object.entries(capability.payload.tokens).map(([rawName, defaultValue]) => {
-          const name = rawName.replace(/^--/, "");
-          const value = draft[name] ?? defaultValue;
-          const pickerValue = colorPickerValue(value);
-          return (
-            <label className="plugin-theme-token-row" key={name}>
-              <span><strong>--{name}</strong><small>{tx("默认值")}: {defaultValue}</small></span>
-              <span className="plugin-theme-token-control">
-                {pickerValue ? (
+      <p className="plugin-theme-token-hint">
+        <span>{tx("只能调整模板已经声明的安全主题 Token。")}</span>
+        <span>{tx("调整保存在当前浏览器。")}</span>
+      </p>
+      {editableTokens.length === 0 ? null : (
+      <>
+        <div className="plugin-theme-token-list">
+          {editableTokens.map(({ name, defaultValue }) => {
+            const value = draft[name] ?? defaultValue;
+            const pickerValue = colorPickerValue(value);
+            return (
+              <label className="plugin-theme-token-row" key={name}>
+                <span><strong>--{name}</strong><small>{tx("默认值")}: {defaultValue}</small></span>
+                <span className="plugin-theme-token-control">
+                  {pickerValue ? (
+                    <input
+                      aria-label={`${name} ${tx("颜色")}`}
+                      className="plugin-theme-color-input"
+                      type="color"
+                      value={pickerValue}
+                      onChange={(event) => setDraft((current) => ({ ...current, [name]: event.target.value }))}
+                    />
+                  ) : null}
                   <input
-                    aria-label={`${name} ${tx("颜色")}`}
-                    className="plugin-theme-color-input"
-                    type="color"
-                    value={pickerValue}
+                    aria-label={`${name} ${tx("当前值")}`}
+                    type="text"
+                    value={value}
                     onChange={(event) => setDraft((current) => ({ ...current, [name]: event.target.value }))}
                   />
-                ) : null}
-                <input
-                  aria-label={`${name} ${tx("当前值")}`}
-                  type="text"
-                  value={value}
-                  onChange={(event) => setDraft((current) => ({ ...current, [name]: event.target.value }))}
-                />
-              </span>
-            </label>
-          );
-        })}
-      </div>
-      {error ? <div className="inline-error" role="alert">{error}</div> : null}
-      {notice ? <p className="plugin-theme-token-notice" role="status">{notice}</p> : null}
-      <div className="plugin-theme-token-actions">
-        <button className="compact-button secondary" type="button" onClick={restore}><RotateCcw size={14} aria-hidden="true" />{tx("恢复默认")}</button>
-        <button className="compact-button" type="button" onClick={apply}><Save size={14} aria-hidden="true" />{tx("应用调整")}</button>
-      </div>
+                </span>
+              </label>
+            );
+          })}
+        </div>
+        {error ? <div className="inline-error" role="alert">{error}</div> : null}
+        {notice ? <p className="plugin-theme-token-notice" role="status">{notice}</p> : null}
+        <div className="plugin-theme-token-actions">
+          <button className="compact-button secondary" type="button" onClick={restore}><RotateCcw size={14} aria-hidden="true" />{tx("恢复默认")}</button>
+          <button className="compact-button" type="button" onClick={apply}><Save size={14} aria-hidden="true" />{tx("应用调整")}</button>
+        </div>
+      </>
+      )}
     </div>
   );
 }

--- a/frontend/features/admin/views/plugins-lifecycle.test.tsx
+++ b/frontend/features/admin/views/plugins-lifecycle.test.tsx
@@ -1,7 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { type PluginDescriptor } from "../core/types";
 import { emptyData } from "../domain/catalog";
 import { PluginsView } from "./plugins";
+
+const api = { baseURL: "http://localhost:8080", adminToken: "admin-token" };
 
 describe("PluginsView lifecycle controls", () => {
   afterEach(() => {
@@ -125,5 +128,173 @@ describe("PluginsView lifecycle controls", () => {
     expect(screen.queryByRole("button", { name: "禁用" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "更新" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "卸载" })).not.toBeInTheDocument();
+  });
+});
+
+describe("PluginsView lifecycle state updates", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // The admin API reports the status twice, and the nested copy is the one
+  // `pluginManagerLifecycleState` reads first, so both are populated here.
+  function enabledPlugin(status = "enabled"): PluginDescriptor {
+    return {
+      id: "tokenhub.local-privacy",
+      name: "Local Privacy",
+      version: "1.0.0",
+      source: "local_file",
+      status,
+      lifecycle: {
+        status,
+        restart_required: false,
+        health: "healthy",
+        mandatory: false,
+        rollback_available: false,
+        loadable: status !== "disabled",
+      },
+      kinds: ["extension"],
+      placements: ["gateway_chain"],
+      capabilities: [],
+    };
+  }
+
+  function dataWith(plugin: PluginDescriptor) {
+    const data = emptyData();
+    data.plugins = [plugin];
+    return data;
+  }
+
+  function statusFilterCount(label: string) {
+    return screen.getByRole("button", { name: label }).querySelector("strong")?.textContent;
+  }
+
+  function stubStateFetch(status: string) {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      data: { plugin_id: "tokenhub.local-privacy", status, restart_required: false },
+    }), { status: 200, headers: { "content-type": "application/json" } }));
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  function deferStateFetch() {
+    let settle: (outcome: { ok: true; status: string } | { ok: false; reason: Error }) => void = () => undefined;
+    const pending = new Promise<Response>((resolve, reject) => {
+      settle = (outcome) => {
+        if (!outcome.ok) {
+          reject(outcome.reason);
+          return;
+        }
+        resolve(new Response(JSON.stringify({
+          data: { plugin_id: "tokenhub.local-privacy", status: outcome.status, restart_required: false },
+        }), { status: 200, headers: { "content-type": "application/json" } }));
+      };
+    });
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(pending));
+    return { pending, settle };
+  }
+
+  it("shows the requested status while the state request is still in flight", async () => {
+    const { settle } = deferStateFetch();
+
+    render(<PluginsView api={api} data={dataWith(enabledPlugin())} />);
+    fireEvent.click(screen.getByRole("button", { name: "禁用" }));
+
+    const pending = await screen.findByRole("button", { name: "更新中" });
+    expect(pending).toBeDisabled();
+    expect(screen.getAllByText("已禁用").some((element) => element.matches(".pill"))).toBe(true);
+    expect(statusFilterCount("已禁用")).toBe("1");
+    expect(statusFilterCount("已启用")).toBe("0");
+
+    await act(async () => {
+      settle({ ok: true, status: "disabled" });
+    });
+
+    expect(screen.getByRole("button", { name: "启用" })).toBeInTheDocument();
+    expect(statusFilterCount("已禁用")).toBe("1");
+  });
+
+  it("rolls the row back to the server status when the state request fails", async () => {
+    const { pending, settle } = deferStateFetch();
+    pending.catch(() => undefined);
+
+    render(<PluginsView api={api} data={dataWith(enabledPlugin())} />);
+    fireEvent.click(screen.getByRole("button", { name: "禁用" }));
+    expect(await screen.findByRole("button", { name: "更新中" })).toBeDisabled();
+
+    await act(async () => {
+      settle({ ok: false, reason: new Error("plugin state update rejected") });
+    });
+
+    expect(screen.getByRole("button", { name: "禁用" })).toBeEnabled();
+    expect(screen.getAllByText("已启用").some((element) => element.matches(".pill"))).toBe(true);
+    expect(statusFilterCount("已启用")).toBe("1");
+    expect(statusFilterCount("已禁用")).toBe("0");
+    expect(screen.getByText("plugin state update rejected")).toBeInTheDocument();
+  });
+
+  it("reflects an accepted disable in the row and in the status filter counts", async () => {
+    const fetchMock = stubStateFetch("disabled");
+
+    render(<PluginsView api={api} data={dataWith(enabledPlugin())} />);
+    expect(statusFilterCount("已启用")).toBe("1");
+    fireEvent.click(screen.getByRole("button", { name: "禁用" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:8080/api/admin/plugins/tokenhub.local-privacy/state");
+    expect(init.method).toBe("PATCH");
+    expect(await screen.findByRole("button", { name: "启用" })).toBeInTheDocument();
+    expect(screen.getAllByText("已禁用").some((element) => element.matches(".pill"))).toBe(true);
+    expect(statusFilterCount("已禁用")).toBe("1");
+    expect(statusFilterCount("已启用")).toBe("0");
+  });
+
+  it("keeps the lifecycle button busy until the reload settles", async () => {
+    stubStateFetch("disabled");
+    let releaseReload = () => undefined as void;
+    const onReload = vi.fn(() => new Promise<void>((resolve) => {
+      releaseReload = () => resolve();
+    }));
+
+    render(<PluginsView api={api} data={dataWith(enabledPlugin())} onReload={onReload} />);
+    fireEvent.click(screen.getByRole("button", { name: "禁用" }));
+
+    await waitFor(() => expect(onReload).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole("button", { name: "更新中" })).toBeDisabled();
+
+    releaseReload();
+    expect(await screen.findByRole("button", { name: "启用" })).toBeEnabled();
+    expect(onReload).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the accepted status when the reloaded list is still stale", async () => {
+    stubStateFetch("disabled");
+    const onReload = vi.fn(() => Promise.resolve());
+
+    const { rerender } = render(<PluginsView api={api} data={dataWith(enabledPlugin())} onReload={onReload} />);
+    fireEvent.click(screen.getByRole("button", { name: "禁用" }));
+    expect(await screen.findByRole("button", { name: "启用" })).toBeInTheDocument();
+
+    rerender(<PluginsView api={api} data={dataWith(enabledPlugin())} onReload={onReload} />);
+
+    expect(screen.getByRole("button", { name: "启用" })).toBeInTheDocument();
+    expect(statusFilterCount("已禁用")).toBe("1");
+  });
+
+  it("hands the row back to the server list once the reload reports the same status", async () => {
+    stubStateFetch("disabled");
+    const onReload = vi.fn(() => Promise.resolve());
+
+    const { rerender } = render(<PluginsView api={api} data={dataWith(enabledPlugin())} onReload={onReload} />);
+    fireEvent.click(screen.getByRole("button", { name: "禁用" }));
+    expect(await screen.findByRole("button", { name: "启用" })).toBeInTheDocument();
+
+    rerender(<PluginsView api={api} data={dataWith(enabledPlugin("disabled"))} onReload={onReload} />);
+    expect(screen.getByRole("button", { name: "启用" })).toBeInTheDocument();
+
+    rerender(<PluginsView api={api} data={dataWith(enabledPlugin("enabled"))} onReload={onReload} />);
+    expect(screen.getByRole("button", { name: "禁用" })).toBeInTheDocument();
+    expect(statusFilterCount("已启用")).toBe("1");
   });
 });

--- a/frontend/features/admin/views/plugins.test.tsx
+++ b/frontend/features/admin/views/plugins.test.tsx
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { type PluginCapabilityDescriptor } from "../core/types";
 import { emptyData } from "../domain/catalog";
@@ -146,7 +146,9 @@ describe("PluginsView", () => {
     render(<PluginsView api={{ baseURL: "http://localhost:8080", adminToken: "admin-token" }} data={data} />);
     fireEvent.click(screen.getByRole("tab", { name: "扩展类型" }));
 
-    expect(screen.getByText("2")).toBeInTheDocument();
+    const capabilityCount = screen.getByText("能力").closest(".plugin-type-capability-count");
+    expect(capabilityCount).not.toBeNull();
+    expect(within(capabilityCount as HTMLElement).getByText("2")).toBeInTheDocument();
     expect(consoleError.mock.calls.some((call) => String(call[0]).includes("Encountered two children with the same key"))).toBe(false);
   });
 
@@ -330,8 +332,9 @@ describe("PluginsView", () => {
     expect(screen.getByText("链路注入插件清单")).toBeInTheDocument();
     expect(screen.getByText("Privacy Chain")).toBeInTheDocument();
     expect(screen.getByText("注入点")).toBeInTheDocument();
-    expect(screen.getByText("2")).toBeInTheDocument();
-    expect(screen.getByText("强制 1 · 可选 1")).toBeInTheDocument();
+    const injectionPoints = screen.getByText("强制 1 · 可选 1").closest(".stacked-cell");
+    expect(injectionPoints).not.toBeNull();
+    expect(within(injectionPoints as HTMLElement).getByText("2")).toBeInTheDocument();
     expect(screen.queryByText("privacy-pre")).not.toBeInTheDocument();
     expect(screen.queryByText("privacy-cache")).not.toBeInTheDocument();
     expect(screen.getByText("适用对象")).toBeInTheDocument();

--- a/frontend/features/admin/views/plugins.tsx
+++ b/frontend/features/admin/views/plugins.tsx
@@ -1,5 +1,5 @@
 import { Boxes, Clock3, Download, ExternalLink, GitBranch, Layers3, PackageOpen, Save, Search, Settings2, ShieldCheck, Upload } from "lucide-react";
-import { type FormEvent, type ReactNode, useMemo, useState } from "react";
+import { type FormEvent, type ReactNode, useEffect, useMemo, useState } from "react";
 import { type ApiContext, type AppData, type GatewayHookDescriptor, type PluginBackgroundJobDescriptor, type PluginDescriptor } from "../core/types";
 import { pluginActionKey, pluginBackgroundJobKey } from "../domain/plugin-actions";
 import {
@@ -11,7 +11,7 @@ import {
   type PluginManagerTabKey,
   type PluginStatusFilterKey,
 } from "../domain/plugin-management";
-import { pluginManagerDisplayState, type PluginManagerDisplayState } from "../domain/plugin-manager";
+import { pluginManagerDisplayState, pluginManagerLifecycleState, type PluginManagerDisplayState } from "../domain/plugin-manager";
 import { localizedCapabilityTitle, localizedContributionTitle, localizedPluginName } from "../domain/plugin-localization";
 import { type PluginDetailSection } from "../domain/plugin-detail-route";
 import { type PluginPermissionDiffPreviewPayload } from "../domain/plugin-permission-diff";
@@ -21,7 +21,7 @@ import { languageLocale, tx } from "../i18n/runtime";
 import { adminFetch, isAuthExpiredError, readAdminError } from "../resources/payloads";
 import { StatusPill } from "../shared/ui";
 import { emptyInstallDraft, PluginInstallFields, pluginInstallRequestBody, type PluginInstallDraft } from "./plugin-install-form";
-import { PluginDeleteControl, PluginLifecycleControl, type PluginDeleteDraft, type PluginRollbackDraft, type PluginStateDraft } from "./plugin-manager-controls";
+import { PluginDeleteControl, PluginLifecycleControl, pluginWithLifecycleDraft, type PluginDeleteDraft, type PluginRollbackDraft, type PluginStateDraft } from "./plugin-manager-controls";
 import { emptyPermissionPreviewDraft, PluginPermissionDiffPreview, type PluginPermissionDiffPreviewDraft } from "./plugin-permission-diff-preview";
 
 type PluginUpdateDraft = {
@@ -35,6 +35,7 @@ export function PluginsView({
   data,
   simSelectionPreference,
   onSIMSelectionPreferenceChange,
+  onReload,
   onSelectPlugin,
   theme = "light",
 }: {
@@ -42,6 +43,7 @@ export function PluginsView({
   data: AppData;
   simSelectionPreference?: unknown;
   onSIMSelectionPreferenceChange?: (preference: SIMSelectionPreference) => void;
+  onReload?: () => Promise<void>;
   onSelectPlugin?: (pluginID: string, section?: PluginDetailSection) => void;
   theme?: "light" | "dark";
 }) {
@@ -82,15 +84,21 @@ export function PluginsView({
   const chainInjectionPlugins = chainPluginList.length;
   const uiTemplatePlugins = plugins.filter((plugin) => plugin.kinds?.includes("sim")).length;
   const backgroundJobPlugins = backgroundJobPluginList.length;
+  // The console never polls the plugin list, so an enable or disable that has been
+  // accepted by the server is only visible through its draft until the reload lands.
+  const effectivePlugins = useMemo(
+    () => plugins.map((plugin) => pluginWithLifecycleDraft(plugin, pluginStateDrafts[plugin.id] ?? {})),
+    [plugins, pluginStateDrafts],
+  );
   const pluginCounts = useMemo(() => ({
-    all: plugins.length,
-    enabled: plugins.filter((plugin) => pluginManagerDisplayState({ plugin }).status !== "disabled").length,
-    disabled: plugins.filter((plugin) => pluginManagerDisplayState({ plugin }).status === "disabled").length,
-    updates: plugins.filter((plugin) => pluginManagerDisplayState({ plugin }).actions.update.available).length,
-  }), [plugins]);
+    all: effectivePlugins.length,
+    enabled: effectivePlugins.filter((plugin) => pluginManagerDisplayState({ plugin }).status !== "disabled").length,
+    disabled: effectivePlugins.filter((plugin) => pluginManagerDisplayState({ plugin }).status === "disabled").length,
+    updates: effectivePlugins.filter((plugin) => pluginManagerDisplayState({ plugin }).actions.update.available).length,
+  }), [effectivePlugins]);
   const filteredPlugins = useMemo(() => {
     const normalizedQuery = pluginQuery.trim().toLocaleLowerCase(locale);
-    return plugins.filter((plugin) => {
+    return effectivePlugins.filter((plugin) => {
       const lifecycle = pluginManagerDisplayState({ plugin });
       const matchesStatus = statusFilter === "all"
         || (statusFilter === "enabled" && lifecycle.status !== "disabled")
@@ -106,7 +114,24 @@ export function PluginsView({
       ].join(" ").toLocaleLowerCase(locale);
       return searchable.includes(normalizedQuery);
     });
-  }, [locale, pluginQuery, plugins, statusFilter]);
+  }, [effectivePlugins, locale, pluginQuery, statusFilter]);
+  // A draft only covers the gap between a state change and the reloaded list. Once the
+  // server reports the status the draft was holding, the descriptor owns both the status
+  // and the restart flag again. A draft that still disagrees is kept, so a failed reload
+  // cannot revert the row.
+  useEffect(() => {
+    setPluginStateDrafts((drafts) => {
+      const settled = Object.keys(drafts).filter((pluginID) => {
+        const status = drafts[pluginID].status;
+        const plugin = plugins.find((item) => item.id === pluginID);
+        return Boolean(status) && plugin !== undefined && pluginManagerLifecycleState(plugin).rawStatus === status;
+      });
+      if (settled.length === 0) return drafts;
+      const next = { ...drafts };
+      for (const pluginID of settled) next[pluginID] = { ...next[pluginID], status: undefined, restartRequired: false };
+      return next;
+    });
+  }, [plugins]);
   const activeSIMPlugin = simPlugins.find((plugin) => plugin.id === simSelection.activeSIMPluginID);
   const pluginStateDraft = (plugin: PluginDescriptor) => pluginStateDrafts[plugin.id] ?? {};
   const pluginUpdateDraft = (plugin: PluginDescriptor) => pluginUpdateDrafts[plugin.id] ?? { busy: false, error: "", result: "" };
@@ -116,9 +141,11 @@ export function PluginsView({
 
   async function updatePluginState(plugin: PluginDescriptor, status: string) {
     const current = pluginStateDraft(plugin);
+    // The row shows the requested status while the request is in flight; the catch below
+    // restores the draft the click started from, so a rejected request rolls it back.
     setPluginStateDrafts((drafts) => ({
       ...drafts,
-      [plugin.id]: { ...current, busy: true, error: "", restartRequired: false },
+      [plugin.id]: { ...current, status, busy: true, error: "", restartRequired: false },
     }));
     try {
       const response = await adminFetch(api, `/api/admin/plugins/${encodeURIComponent(plugin.id)}/state`, {
@@ -129,7 +156,18 @@ export function PluginsView({
       const payload = await response.json() as { data?: { status?: string; restart_required?: boolean } };
       setPluginStateDrafts((drafts) => ({
         ...drafts,
-        [plugin.id]: { status: payload.data?.status ?? status, busy: false, error: "", restartRequired: Boolean(payload.data?.restart_required) },
+        [plugin.id]: { status: payload.data?.status ?? status, busy: true, error: "", restartRequired: Boolean(payload.data?.restart_required) },
+      }));
+      // The row stays busy until the reloaded list arrives, so a second click cannot race
+      // the refetch. A reload that fails leaves the draft in place rather than reverting.
+      try {
+        await onReload?.();
+      } catch {
+        // The console reports its own load failures; the accepted status still stands.
+      }
+      setPluginStateDrafts((drafts) => ({
+        ...drafts,
+        [plugin.id]: { ...(drafts[plugin.id] ?? {}), busy: false },
       }));
     } catch (reason) {
       if (isAuthExpiredError(reason)) return;


### PR DESCRIPTION
## Summary

Running the stack for real (Go backend + Next.js console, a DeepSeek provider, the browser driven by Playwright) on top of `1490100e` surfaced a set of defects in the plugin-management pages and one backend error-message gap. The most visible one: clicking 禁用/启用 in the plugin list sends the PATCH and the backend switches state, but the row, the enable/disable button and the status counters never update until a full page reload. This PR fixes the confirmed findings and adds regression tests for each.

## Related Issue

N/A

## Changes

- **Plugin list state toggle does not refresh** (`plugin-manager-controls.tsx`, `plugins.tsx`, `admin-console.tsx`): `pluginManagerLifecycleState` prefers the API's nested `lifecycle.status`, so a draft that overrode only the top-level `status` was shadowed. The draft now overrides both, is applied optimistically on click, drives the counters and status filter, and the row stays busy until the console re-fetches the plugin list (`onReload`). The draft is dropped only once the reloaded list reports the same status, so a failed reload cannot revert the row.
- **Plugin detail file preview keeps stale state across plugins** (`plugin-detail.tsx`, `admin-console.tsx`): the detail view is keyed by plugin id, every non-fetch path clears content/error/loading, and responses that resolve after an abort are ignored.
- **Template theme-token editor silently dropped non-allowlisted tokens while reporting success** (`plugin-template-settings.tsx`, `plugin-theme.ts`): a shared `pluginThemeTokenEntries` helper produces the allowlisted, de-duplicated token list with the same last-wins precedence as `pluginThemeStyle`; the editor renders and applies only those, shows the (previously unused) hint copy, and hides the apply/restore buttons when nothing is editable.
- **Browser smoke harness pointed `TOKENHUB_PLUGIN_DIR` at the tracked Go fixture tree** (`e2e/start-stack.mjs`): the backend writes `plugin.state.json` next to plugin packages, and the tree also contains hook fixtures that rewrite the model or short-circuit the gateway. The harness now copies only `external-trace-hook` into the run's temporary directory.
- **Plugin management page header badge always read "0 records"** (`navigation-ui.tsx`): `pageRecordCount` now handles the `plugins` view.
- **Empty upstream error body produced `"message": ""`** (`provider_error_classification.go`): observed live with DeepSeek answering `POST /embeddings` for a chat model with a bodiless 404. The message now falls back to `Upstream provider returned HTTP <upstream status>` using the original upstream status, not the mapped gateway status. Classification and failover dispositions are unchanged.
- **Test hygiene**: removed a vacuous click on a disabled button in `plugin-detail.test.tsx` and scoped two ambiguous `getByText("2")` assertions in `plugins.test.tsx`.

Reviewed and intentionally left as is:

- `POST /api/admin/providers` returns the result without the `{"data": ...}` envelope. Other create endpoints (for example routing rules) use the same bare shape and the console reads it directly; changing it is an API-contract change outside this fix.
- Upstream 4xx bodies are forwarded as the bounded, secret-redacted prefix that `checkProviderResponse` already produces; reasoning-effort rejection detection matches markers in that text, so extracting only `error.message` could lose them.
- Plugin ids containing `/` are still rejected by the console route parser: Next.js dynamic segments do not handle an encoded `%2F` reliably, so falling back to the list is the safer behaviour.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `node --test tools/*.test.mjs` (168 pass), `node tools/check-doc-translations.mjs --base 1490100e --head HEAD`, `node tools/check-ui-translations.mjs`, `node tools/check-env-contract.mjs`, `node tools/check-source-lines.mjs`: pass.
- Backend (`backend/`): `gofmt -l` clean, `go vet ./...` pass, `go test ./...` pass (the `internal/server` package run in five `-run` chunks because of local memory limits).
- `golangci-lint run ./...`: 0 issues (branch rebased onto `5a1a289e`, which already carries the lint and PostgreSQL fixture fixes from #305).
- Frontend (`frontend/`): `npm run lint`, `npm run typecheck`, `npm test` (159 node tests + 240 component tests) pass; `npm run build` pass; `npm run test:e2e` 6 passed, and the git checkout stays clean afterwards.
- Manual: the original findings were reproduced against a live stack with a real DeepSeek provider before the fix (plugin toggle stale for 20 s, empty embeddings error message) and re-checked in component tests after.
- `git diff --check`: clean.

## Compatibility, Security, and Operations

- Gateway error responses for empty upstream bodies now carry a non-empty `message`; codes, statuses and failover behaviour are unchanged.
- The `PluginsView` component gains an optional `onReload` prop; no public API, persistence, configuration or deployment changes.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
