### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,5 @@ backend/tokenhub
 data/*
 !data/model-catalog.yaml
 !data/provider-catalog.json
+!data/builtin-plugins
+!data/builtin-plugins/**

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,7 +28,7 @@ FROM golang:1.26-alpine AS backend-builder
 
 WORKDIR /src
 ARG GOPROXY=https://proxy.golang.org,direct
-ARG TOKENHUB_VERSION=0.6.0
+ARG TOKENHUB_VERSION=0.8.0
 ARG TOKENHUB_BUILD_TYPE=source
 ENV GOPROXY=$GOPROXY
 RUN apk add --no-cache gcc musl-dev
@@ -46,7 +46,7 @@ RUN cd backend && \
 
 FROM ${NODE_IMAGE}
 
-ARG TOKENHUB_VERSION=0.6.0
+ARG TOKENHUB_VERSION=0.8.0
 LABEL org.opencontainers.image.version="${TOKENHUB_VERSION}"
 
 COPY --from=backend-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/backend/internal/server/version.go
+++ b/backend/internal/server/version.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	DefaultAppVersion = "0.6.0"
+	DefaultAppVersion = "0.8.0"
 
 	defaultBuildType         = "source"
 	releaseBuildType         = "release"

--- a/deploy/container/tokenhub-build-context_test.sh
+++ b/deploy/container/tokenhub-build-context_test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd "$script_dir/../.." && pwd)"
+test_root="$(mktemp -d)"
+trap 'rm -rf -- "$test_root"' EXIT
+
+# Use the actual build context so .dockerignore cannot silently remove release assets.
+docker build --file - --output "type=local,dest=$test_root" "$repository_root" <<'DOCKERFILE'
+FROM scratch
+COPY data/model-catalog.yaml /catalog/model-catalog.yaml
+COPY data/provider-catalog.json /catalog/provider-catalog.json
+COPY data/builtin-plugins /catalog/builtin-plugins
+DOCKERFILE
+
+cmp "$repository_root/data/model-catalog.yaml" "$test_root/catalog/model-catalog.yaml"
+cmp "$repository_root/data/provider-catalog.json" "$test_root/catalog/provider-catalog.json"
+diff -r "$repository_root/data/builtin-plugins" "$test_root/catalog/builtin-plugins"
+test -f "$test_root/catalog/builtin-plugins/providers/openai/plugin.yaml"
+test -f "$test_root/catalog/builtin-plugins/platform/tokenhub.sim.default/plugin.yaml"
+printf 'container build context tests passed\n'

--- a/deploy/container/tokenhub-entrypoint_test.sh
+++ b/deploy/container/tokenhub-entrypoint_test.sh
@@ -91,8 +91,9 @@ run_entrypoint "$second_image"
   fail_test "new build identity was not persisted"
 
 # CI's deployment job already runs this entrypoint suite with Docker available.
-# Keep fresh-volume coverage in that same job without a separate workflow step.
+# Keep image-context and fresh-volume coverage in that same job.
 if command -v docker >/dev/null 2>&1; then
+  bash "$script_dir/tokenhub-build-context_test.sh"
   bash "$script_dir/tokenhub-plugin-volume_test.sh"
 fi
 

--- a/deploy/docker-compose.migration-e2e.yml
+++ b/deploy/docker-compose.migration-e2e.yml
@@ -48,6 +48,7 @@ services:
     environment:
       TOKENHUB_ADMIN_TOKEN: admin-token
       TOKENHUB_DATABASE_URL: sqlite://data/tokenhub.db
+      TOKENHUB_PROVIDER_UPSTREAM_ACCESS_MODE: auto
     ports:
       - "8080:8080"
     healthcheck:

--- a/deploy/docker-compose.migration-e2e.yml
+++ b/deploy/docker-compose.migration-e2e.yml
@@ -51,7 +51,7 @@ services:
     ports:
       - "8080:8080"
     healthcheck:
-      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:8080/healthz"]
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8080/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
       interval: 5s
       timeout: 5s
       retries: 20

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokenhub-admin",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokenhub-admin",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "lucide-react": "1.17.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenhub-admin",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "license": "Apache-2.0",
   "packageManager": "npm@10.9.8",

--- a/sdk/migration-e2e/fixtures/proxy_config.yaml
+++ b/sdk/migration-e2e/fixtures/proxy_config.yaml
@@ -4,7 +4,7 @@ model_list:
   - model_name: gpt-4o-mini
     litellm_params:
       model: openai/gpt-4o-mini
-      api_base: http://localhost:8081/v1
+      api_base: http://mock-upstream/v1
       api_key: os.environ/OPENAI_API_KEY
     model_info:
       mode: chat

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokenhub-sdk-smoke-tests",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokenhub-sdk-smoke-tests",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "2.0.50",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenhub-sdk-smoke-tests",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Prepare TokenHub v0.8.0 and fix deployment and migration fixtures that would prevent a successful release. The container build previously excluded the new built-in plugin packages, and the migration fixture required `wget` even though the runtime image supplies Node.js instead.

## Related Issue

N/A. Requested v0.8.0 release, covering all changes since v0.7.0.

## Changes

- Set backend source/container defaults and frontend/SDK package metadata to 0.8.0.
- Include tracked built-in plugin packages in the Docker build context.
- Add a real Docker build-context regression check to Deployment CI, comparing shipped catalogs and plugin contents with the repository.
- Probe the migration fixture's TokenHub health endpoint using the bundled Node.js runtime.
- Point the migration fixture at the Compose mock upstream and explicitly enable auto network access only in that test stack; production remains strict by default.
- Prepare GitHub release notes covering the full v0.7.0-to-v0.8.0 range, including every merged PR and commit, upgrade notes, runtime limits, and release artifacts; publish them after validation and merge.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [x] Deployment or configuration

## Verification

- Reproduced the missing `data/builtin-plugins` Docker COPY failure locally on the base configuration. The new build-context check passes after the fix and compares all nested plugin files.
- Confirmed the runtime image contains Node.js and does not contain `wget`. Both main and migration Compose configurations render successfully.
- Backend `go test ./...`, `go vet ./...`, and migration-manifest verification passed locally.
- Plugin DevKit `go test ./...` and `go vet ./...` passed locally.
- With Node 22.23.1, frontend dependency installation, lint, typecheck, domain/component tests, production build, and all 10 browser smoke tests passed locally.
- All 175 repository gate tests, documentation translations against v0.7.0, UI translations, environment contract, source-line checks, release-tag tests, shell syntax, and `git diff --check` passed locally.
- Every remote check passed on final head `3b350a6991f09a025b3f7e901d5e92c805ce9719`: [CI](https://github.com/astaxie/TokenHub/actions/runs/34308034083) and [Migration CI](https://github.com/astaxie/TokenHub/actions/runs/34308034063). This includes pinned golangci-lint v2.12.2, PostgreSQL, N-1 compatibility, frontend/browser validation, deployment scripts and Docker build context, and repository gates.
- The real LiteLLM migration E2E passed all 22 checks, including image build/startup, remote apply, verification, idempotent re-apply, and rollback.
- Credential-dependent live SDK tests were not run; this change updates package metadata only. No UI behavior changed in this PR, so separate UI acceptance captures were not needed.

## Compatibility, Security, and Operations

The OpenAI-compatible API and data schema are unchanged by this release-preparation PR. The Docker context exception includes only tracked built-in packages; runtime data exclusions remain intact. Source builds now report 0.8.0 by default, while release builds still receive the version through build arguments. The test-only migration fixture uses an executable actually present in the image. No new environment variables or user deployment steps are introduced, so no deployment-documentation translation changes are required.

The release notes explicitly distinguish supported built-ins/declarative contributions from external command-bearing packages, which remain quarantined before execution. They also explain schema expansions 4/5, persistent plugin storage, and the limits of shadow pricing and historical billing evidence introduced since v0.7.0.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable (no new variables).
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable (no behavior-documentation change in this PR).
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable (no catalog edits).
- [x] `git diff --check` passes.
