### PR TITLE
chore(db): log pool stats on ping failure

### DIFF
--- a/backend/internal/server/store_helpers.go
+++ b/backend/internal/server/store_helpers.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"io"
+	"log"
 	"net"
 	"os"
 	"sort"
@@ -522,7 +523,13 @@ func (s *GormStore) Ping(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return sqlDB.PingContext(ctx)
+	if err := sqlDB.PingContext(ctx); err != nil {
+		stats := sqlDB.Stats()
+		log.Printf("[tokenhub] database ping failed: in_use=%d idle=%d wait_count=%d wait_duration=%s error=%v",
+			stats.InUse, stats.Idle, stats.WaitCount, stats.WaitDuration, err)
+		return err
+	}
+	return nil
 }
 
 // SetGatewayMetrics attaches the metrics collectors. It is called once during server

--- a/backend/internal/server/store_ping_diagnostics_test.go
+++ b/backend/internal/server/store_ping_diagnostics_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPingLogsPoolStatsWhenConnectionIsUnavailable(t *testing.T) {
+	store := NewMemoryStore()
+	t.Cleanup(func() { _ = store.Close() })
+	sqlDB, err := store.db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	connection, err := sqlDB.Conn(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer connection.Close()
+
+	var logs bytes.Buffer
+	previousOutput := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(previousOutput)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if err := store.Ping(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Ping error = %v, want context deadline exceeded", err)
+	}
+	for _, expected := range []string{"database ping failed", "in_use=1", "idle=0", "wait_count=", "wait_duration=", "error=context deadline exceeded"} {
+		if !strings.Contains(logs.String(), expected) {
+			t.Fatalf("Ping log %q does not contain %q", logs.String(), expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Database readiness failures currently return an unavailable response without enough server-side context to distinguish database reachability problems from connection-pool contention. This change logs the pool state when a database ping fails while preserving the existing health-check response and error behavior.

## Related Issue

N/A.

## Changes

- Log the in-use and idle connection counts plus cumulative wait count and duration when `PingContext` fails.
- Preserve and return the original database ping error without adding retries or changing readiness semantics.
- Add a regression test that occupies the available connection, forces a ping timeout, and verifies the diagnostic fields.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `cd backend && go test ./...`
- `cd backend && go vet ./...`
- `cd backend && golangci-lint run ./...`
- `node --test tools/*.test.mjs` (175 tests passed)
- `node tools/check-doc-translations.mjs`
- `node tools/check-ui-translations.mjs`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- `git diff --check`

## Compatibility, Security, and Operations

No API, schema, configuration, or deployment changes. Failed database pings now emit one additional diagnostic log line; successful pings and readiness responses are unchanged.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
