### PR TITLE
fix(codex): restore gpt-6-astra model discovery

### DIFF
--- a/backend/internal/server/provider_account_codex.go
+++ b/backend/internal/server/provider_account_codex.go
@@ -17,8 +17,8 @@ const (
 	openAICodexBaseURL           = "https://chatgpt.com/backend-api/codex"
 	openAICodexResponsesURL      = openAICodexBaseURL + "/responses"
 	openAICodexModelsURL         = openAICodexBaseURL + "/models"
-	openAICodexVersion           = "0.145.0"
-	openAICodexUserAgent         = "codex_cli_rs/0.145.0 (Mac OS 15.0.0; arm64) xterm-256color"
+	openAICodexVersion           = "0.153.4"
+	openAICodexUserAgent         = "codex_cli_rs/0.153.4 (Mac OS 15.0.0; arm64) xterm-256color"
 	openAICodexDefaultProbeModel = "gpt-5.6-luna"
 	openAICodexMaxRequestRetries = 4
 	openAICodexStreamIdleTimeout = 5 * time.Minute

--- a/backend/internal/server/provider_account_codex_test.go
+++ b/backend/internal/server/provider_account_codex_test.go
@@ -83,6 +83,40 @@ func TestCodexSubscriptionModelsUsesLiveVisibleCatalog(t *testing.T) {
 	}
 }
 
+func TestCodexSubscriptionModelsUsesAstraCapableClientFingerprint(t *testing.T) {
+	client := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.URL.Query().Get("client_version"); got != "0.153.4" {
+			t.Fatalf("client_version = %q, want Astra-capable version 0.153.4", got)
+		}
+		if got := req.Header.Get("Version"); got != "0.153.4" {
+			t.Fatalf("Version header = %q, want 0.153.4", got)
+		}
+		if got := req.Header.Get("User-Agent"); !strings.HasPrefix(got, "codex_cli_rs/0.153.4 ") {
+			t.Fatalf("User-Agent = %q, want Codex CLI 0.153.4", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body: io.NopCloser(strings.NewReader(
+				`{"models":[{"slug":"gpt-6-astra","display_name":"GPT-6 Astra","visibility":"list","supported_in_api":true,"priority":1,"minimal_client_version":"0.153.0"}]}`,
+			)),
+			Request: req,
+		}, nil
+	})}
+	adapter := CodexSubscriptionAdapter{Client: client, ModelsURL: "https://chatgpt.example/backend-api/codex/models"}
+
+	catalog, err := adapter.ModelsWithCredentials(context.Background(), ProviderResourceCredentials{
+		AccessToken: "access_astra",
+		AccountID:   "account_astra",
+	})
+	if err != nil {
+		t.Fatalf("list Astra-capable Codex models: %v", err)
+	}
+	if len(catalog.Models) != 1 || catalog.Models[0].ID != "gpt-6-astra" {
+		t.Fatalf("Astra missing from catalog: %+v", catalog.Models)
+	}
+}
+
 func TestCodexModelCatalogUsesETagAndPersistedSnapshot(t *testing.T) {
 	store := NewMemoryStore()
 	provider := store.AddProvider(Provider{


### PR DESCRIPTION
## Summary

Codex subscription model discovery still identifies itself as Codex CLI 0.145.0. The ChatGPT Codex models endpoint omits GPT-6 Astra for that older client fingerprint, even though TokenHub already contains the static GPT-6 Astra catalog and routing support.

Update the Codex client fingerprint to 0.153.4 so live account discovery can include GPT-6 Astra.

## Related Issue

N/A.

## Changes

- Update the Codex model-discovery `client_version` and `Version` header to 0.153.4.
- Update the matching `codex_cli_rs` User-Agent version.
- Add a regression test covering the discovery query, headers, and GPT-6 Astra catalog inclusion.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Deployment or configuration

## Verification

- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...` (0 issues)
- `node --test tools/*.test.mjs` (175 passed, 0 failed)
- `node tools/check-doc-translations.mjs`
- `node tools/check-ui-translations.mjs`
- `node tools/check-env-contract.mjs`
- `node tools/check-source-lines.mjs`
- `git diff --check`

## Compatibility, Security, and Operations

No public API, database, environment-variable, deployment, or routing changes. The only runtime change is the Codex client fingerprint used for ChatGPT Codex model discovery and matching fallback request headers.

## Checklist

- [x] The PR title and body are written in English.
- [x] Tests were added or updated for behavior changes, or the reason they are unnecessary is documented.
- [x] No credentials, local `.env` files, databases, backups, or runtime logs are included.
- [x] Environment variable changes are synchronized across examples, Compose, `start.sh`, and deployment documentation where applicable.
- [x] Shared user-facing behavior is documented consistently in English, Simplified Chinese, and Japanese where applicable.
- [x] `data/model-catalog.yaml` remains tracked and catalog changes were reviewed where applicable.
- [x] `git diff --check` passes.
